### PR TITLE
refactor(auto-optimizer): GPU context abstraction, NVML dual-path, decouple GPU selection

### DIFF
--- a/auto-optimizer/src/basic_func.rs
+++ b/auto-optimizer/src/basic_func.rs
@@ -4,6 +4,7 @@ use nvapi_hi::{
     allowable_result, Celsius, Gpu, GpuSettings, KilohertzDelta, MicrovoltsDelta, PState,
     Percentage,
 };
+use nvml_wrapper::Nvml;
 use std::io;
 
 use crate::conv::ConvertEnum;
@@ -74,7 +75,6 @@ fn get_primary_screen_size_raw() -> (u32, u32) {
         }
     }
 }
-use nvml_wrapper::Nvml;
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
@@ -251,11 +251,12 @@ fn parse_gpu_id(s: &str) -> anyhow::Result<usize> {
 
 pub fn select_gpus<'a>(
     gpus: &'a [Gpu],
-    gpu: Option<clap::parser::ValuesRef<'_, String>>,
+    selections: Option<&[String]>,
 ) -> anyhow::Result<Vec<&'a Gpu>, Error> {
-    let selected = match gpu {
+    let selected = match selections {
         Some(values) => {
             let inputs = values
+                .iter()
                 .map(|s| parse_gpu_id(s.as_str()))
                 .collect::<anyhow::Result<Vec<_>, _>>()
                 .map_err(|e| Error::Custom(e.to_string()))?;
@@ -329,11 +330,12 @@ pub fn get_sorted_gpu_ids_nvml(nvml: &Nvml) -> Result<Vec<u32>, Error> {
 
 pub fn select_gpu_ids(
     gpu_ids: &[u32],
-    gpu: Option<clap::parser::ValuesRef<'_, String>>,
+    selections: Option<&[String]>,
 ) -> anyhow::Result<Vec<u32>, Error> {
-    let selected = match gpu {
+    let selected = match selections {
         Some(values) => {
             let inputs = values
+                .iter()
                 .map(|s| parse_gpu_id(s.as_str()))
                 .collect::<anyhow::Result<Vec<_>, _>>()
                 .map_err(|e| Error::Custom(e.to_string()))?;
@@ -420,22 +422,17 @@ pub fn handle_list(nvml: &Nvml) -> Result<(), Error> {
     Ok(())
 }
 
-// Define the handle_info function to handle the "info" subcommand
+/// Display detailed NVAPI GPU info for pre-selected GPUs.
 pub fn handle_info(
-    gpu: Option<clap::parser::ValuesRef<'_, String>>,
+    nvml: Option<&Nvml>,
+    gpus: &[&Gpu],
     oformat: OutputFormat,
     output_file: Option<&str>,
 ) -> Result<(), Error> {
-    // Get the list of GPUs
-
-    let gpu_list = get_sorted_gpus()?;
-    let gpus = select_gpus(&gpu_list, gpu)?;
-
     for (i, gpu) in gpus.iter().enumerate() {
-        println!("GPU {}: ID:0x{:04X}", i, gpu.id()); // ← Print something human-readable
+        println!("GPU {}: ID:0x{:04X}", i, gpu.id());
     }
 
-    // Handle the output format
     match oformat {
         OutputFormat::Human => {
             let mut success = 0usize;
@@ -451,7 +448,7 @@ pub fn handle_info(
                         continue;
                     }
                 };
-                human::print_info(&gpu, &info);
+                human::print_info(gpu, &info, nvml);
                 let gpu_type = fetch_gpu_type(&info)?;
                 human::print_scan_separator();
                 println!(
@@ -500,7 +497,6 @@ pub fn handle_info(
                     ));
                 }
             } else {
-                // Write to stdout
                 let mut gpu_info = Vec::new();
                 for gpu in gpus {
                     match gpu.info() {
@@ -525,15 +521,107 @@ pub fn handle_info(
     Ok(())
 }
 
+/// Display basic GPU info using NVML only — used when NVAPI is unavailable.
+pub fn handle_info_nvml_only(
+    nvml: &Nvml,
+    gpu_ids: &[u32],
+    oformat: OutputFormat,
+) -> Result<(), Error> {
+    use nvml_wrapper::enum_wrappers::device::Clock;
+
+    if gpu_ids.is_empty() {
+        return Err(Error::DeviceNotFound);
+    }
+
+    match oformat {
+        OutputFormat::Human => {
+            for &gpu_id in gpu_ids {
+                let pci_bus = gpu_id / 256;
+                let count = nvml
+                    .device_count()
+                    .map_err(|e| Error::Custom(format!("NVML device_count: {:?}", e)))?;
+                for i in 0..count {
+                    if let Ok(dev) = nvml.device_by_index(i) {
+                        if let Ok(pci) = dev.pci_info() {
+                            if pci.bus != pci_bus {
+                                continue;
+                            }
+                            let name = dev.name().unwrap_or_else(|_| "Unknown".into());
+                            let uuid = dev.uuid().unwrap_or_else(|_| "Unknown".into());
+                            println!("GPU {} (NVML):", gpu_id);
+                            println!("  Name          : {}", name);
+                            println!("  UUID          : {}", uuid);
+                            println!(
+                                "  PCI           : {:04x}:{:02x}:{:02x}",
+                                pci.domain, pci.bus, pci.device
+                            );
+                            if let Ok(mem) = dev.memory_info() {
+                                println!(
+                                    "  Total VRAM    : {} MiB",
+                                    mem.total / (1024 * 1024)
+                                );
+                            }
+                            if let Ok(cap) = dev.cuda_compute_capability() {
+                                println!("  Compute Cap.  : {}.{}", cap.major, cap.minor);
+                            }
+                            if let Ok(c) = dev.power_management_limit_constraints() {
+                                println!(
+                                    "  Power Limits  : {} W – {} W",
+                                    c.min_limit / 1000,
+                                    c.max_limit / 1000
+                                );
+                            }
+                            if let Ok(clk) = dev.clock(Clock::Graphics, nvml_wrapper::enum_wrappers::device::ClockId::Current) {
+                                println!("  Core Clock    : {} MHz", clk);
+                            }
+                            if let Ok(clk) = dev.clock(Clock::Memory, nvml_wrapper::enum_wrappers::device::ClockId::Current) {
+                                println!("  Mem Clock     : {} MHz", clk);
+                            }
+                            println!();
+                        }
+                    }
+                }
+            }
+        }
+        OutputFormat::Json => {
+            use serde_json::{json, Value};
+            let mut entries: Vec<Value> = Vec::new();
+            let count = nvml
+                .device_count()
+                .map_err(|e| Error::Custom(format!("NVML device_count: {:?}", e)))?;
+            for &gpu_id in gpu_ids {
+                let pci_bus = gpu_id / 256;
+                for i in 0..count {
+                    if let Ok(dev) = nvml.device_by_index(i) {
+                        if let Ok(pci) = dev.pci_info() {
+                            if pci.bus != pci_bus {
+                                continue;
+                            }
+                            let entry = json!({
+                                "gpu_id": gpu_id,
+                                "name": dev.name().ok(),
+                                "uuid": dev.uuid().ok(),
+                                "pci_bus": pci.bus,
+                                "total_vram_mib": dev.memory_info().ok().map(|m| m.total / (1024*1024)),
+                            });
+                            entries.push(entry);
+                        }
+                    }
+                }
+            }
+            serde_json::to_writer_pretty(io::stdout(), &entries)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn handle_status(
-    gpus: &[Gpu],
-    gpu: Option<clap::parser::ValuesRef<'_, String>>,
+    nvml: Option<&Nvml>,
+    gpus: &[&Gpu],
     matches: &ArgMatches,
     oformat: OutputFormat,
 ) -> Result<(), Error> {
     const NANOS_IN_SECOND: f64 = 1e9;
-
-    let gpus = select_gpus(gpus, gpu)?;
 
     let monitor = matches
         .get_one::<String>("monitor")
@@ -545,7 +633,7 @@ pub fn handle_status(
         match oformat {
             OutputFormat::Human => {
                 let mut shown = false;
-                for &gpu in &gpus {
+                for gpu in gpus.iter() {
                     let mut set = None;
 
                     fn requires_set<'a>(
@@ -572,9 +660,10 @@ pub fn handle_status(
 
                     human::print_status(&status);
                     human::print_settings(gpu, requires_set(gpu, &mut set)?);
-                    if let Ok(info) = gpu.info() {
+                    if let (Ok(info), Some(n)) = (gpu.info(), nvml) {
                         if let Some(thresholds) =
                             crate::oc_get_set_function_nvml::get_nvml_temperature_thresholds(
+                                n,
                                 info.id as u32,
                             )
                         {
@@ -603,7 +692,7 @@ pub fn handle_status(
             }
             OutputFormat::Json => {
                 let mut status = Vec::new();
-                for &gpu in &gpus {
+                for gpu in gpus.iter() {
                     match gpu.status() {
                         Ok(s) => status.push(s),
                         Err(e) => eprintln!(
@@ -637,14 +726,122 @@ pub fn handle_status(
     Ok(())
 }
 
-// In commands.rs
-pub fn handle_get(
-    gpus: &[Gpu],
-    gpu: Option<clap::parser::ValuesRef<'_, String>>,
+/// Display GPU status using NVML only — used when NVAPI is unavailable.
+pub fn handle_status_nvml_only(
+    nvml: &Nvml,
+    gpu_ids: &[u32],
+    matches: &ArgMatches,
     oformat: OutputFormat,
 ) -> Result<(), Error> {
-    let gpus = select_gpus(gpus, gpu)?;
+    use nvml_wrapper::enum_wrappers::device::{Clock, ClockId, TemperatureSensor};
 
+    const NANOS_IN_SECOND: f64 = 1e9;
+
+    let monitor = matches
+        .get_one::<String>("monitor")
+        .map(|s| f64::from_str(s.as_str()))
+        .transpose()?
+        .map(|v| Duration::new(v as u64, (v.fract() * NANOS_IN_SECOND) as u32));
+
+    if gpu_ids.is_empty() {
+        return Err(Error::DeviceNotFound);
+    }
+
+    loop {
+        let count = nvml
+            .device_count()
+            .map_err(|e| Error::Custom(format!("NVML device_count: {:?}", e)))?;
+
+        match oformat {
+            OutputFormat::Human => {
+                for &gpu_id in gpu_ids {
+                    let pci_bus = gpu_id / 256;
+                    for i in 0..count {
+                        if let Ok(dev) = nvml.device_by_index(i) {
+                            if let Ok(pci) = dev.pci_info() {
+                                if pci.bus != pci_bus {
+                                    continue;
+                                }
+                                let name = dev.name().unwrap_or_else(|_| "Unknown".into());
+                                println!("GPU {} ({}):", gpu_id, name);
+                                if let Ok(t) = dev.temperature(TemperatureSensor::Gpu) {
+                                    println!("  Temperature   : {} C", t);
+                                }
+                                if let Ok(pw) = dev.power_usage() {
+                                    println!("  Power Usage   : {:.1} W", pw as f32 / 1000.0);
+                                }
+                                if let Ok(util) = dev.utilization_rates() {
+                                    println!("  GPU Util      : {}%", util.gpu);
+                                    println!("  Mem Util      : {}%", util.memory);
+                                }
+                                if let Ok(clk) = dev.clock(Clock::Graphics, ClockId::Current) {
+                                    println!("  Core Clock    : {} MHz", clk);
+                                }
+                                if let Ok(clk) = dev.clock(Clock::Memory, ClockId::Current) {
+                                    println!("  Mem Clock     : {} MHz", clk);
+                                }
+                                if let Ok(fan) = dev.fan_speed(0) {
+                                    println!("  Fan Speed     : {}%", fan);
+                                }
+                                if let Ok(ps) = dev.performance_state() {
+                                    println!("  P-State       : {:?}", ps);
+                                }
+                                println!();
+                            }
+                        }
+                    }
+                }
+            }
+            OutputFormat::Json => {
+                use serde_json::{json, Value};
+                let mut entries: Vec<Value> = Vec::new();
+                for &gpu_id in gpu_ids {
+                    let pci_bus = gpu_id / 256;
+                    for i in 0..count {
+                        if let Ok(dev) = nvml.device_by_index(i) {
+                            if let Ok(pci) = dev.pci_info() {
+                                if pci.bus != pci_bus {
+                                    continue;
+                                }
+                                let entry = json!({
+                                    "gpu_id": gpu_id,
+                                    "name": dev.name().ok(),
+                                    "temperature_c": dev.temperature(TemperatureSensor::Gpu).ok(),
+                                    "power_usage_w": dev.power_usage().ok().map(|p| p as f32 / 1000.0),
+                                    "core_clock_mhz": dev.clock(Clock::Graphics, ClockId::Current).ok(),
+                                    "mem_clock_mhz": dev.clock(Clock::Memory, ClockId::Current).ok(),
+                                    "fan_speed_pct": dev.fan_speed(0).ok(),
+                                });
+                                entries.push(entry);
+                            }
+                        }
+                    }
+                }
+                if monitor.is_some() {
+                    let _ = serde_json::to_writer(io::stdout(), &entries);
+                    println!();
+                } else {
+                    let _ = serde_json::to_writer_pretty(io::stdout(), &entries);
+                }
+            }
+        }
+
+        if let Some(d) = monitor {
+            sleep(d);
+        } else {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+// In commands.rs
+pub fn handle_get(
+    nvml: Option<&Nvml>,
+    gpus: &[&Gpu],
+    oformat: OutputFormat,
+) -> Result<(), Error> {
     match oformat {
         OutputFormat::Human => {
             for gpu in gpus.iter() {
@@ -656,19 +853,19 @@ pub fn handle_get(
                 if let Ok(set) = gpu.settings() {
                     human::print_settings(gpu, &set);
                 }
-                if let Ok(info) = gpu.info() {
+                if let (Ok(info), Some(n)) = (gpu.info(), nvml) {
                     let gpu_id = info.id as u32;
                     let power_limit =
-                        crate::oc_get_set_function_nvml::query_nvml_power_watts(gpu_id);
+                        crate::oc_get_set_function_nvml::query_nvml_power_watts(n, gpu_id);
                     let temp_thresholds =
-                        crate::oc_get_set_function_nvml::get_nvml_temperature_thresholds(gpu_id);
-                    let pstate_info = crate::oc_get_set_function_nvml::get_nvml_pstate_info(gpu_id);
+                        crate::oc_get_set_function_nvml::get_nvml_temperature_thresholds(n, gpu_id);
+                    let pstate_info = crate::oc_get_set_function_nvml::get_nvml_pstate_info(n, gpu_id);
                     let app_clocks =
                         crate::oc_get_set_function_nvml::get_nvml_supported_applications_clocks(
-                            gpu_id,
+                            n, gpu_id,
                         );
                     let min_max_fan_speed =
-                        crate::oc_get_set_function_nvml::get_nvml_min_max_fan_speed(gpu_id);
+                        crate::oc_get_set_function_nvml::get_nvml_min_max_fan_speed(n, gpu_id);
                     if power_limit.is_some()
                         || temp_thresholds.is_some()
                         || pstate_info.is_some()
@@ -707,14 +904,13 @@ pub fn handle_get(
                                     "      Mem Clock Range    : {} MHz - {} MHz",
                                     min_mem, max_mem
                                 );
-
                                 let core_offset =
                                     crate::oc_get_set_function_nvml::get_nvml_core_clock_vf_offset(
-                                        gpu_id, pstate,
+                                        n, gpu_id, pstate,
                                     );
                                 let mem_offset =
                                     crate::oc_get_set_function_nvml::get_nvml_mem_clock_vf_offset(
-                                        gpu_id, pstate,
+                                        n, gpu_id, pstate,
                                     );
                                 if let Some(c) = core_offset {
                                     println!("      Core Clock Offset  : {} MHz", c);
@@ -724,14 +920,15 @@ pub fn handle_get(
                                 }
                             }
                         } else {
-                            // Fallback if pstate info is unsupported
                             let core_offset =
                                 crate::oc_get_set_function_nvml::get_nvml_core_clock_vf_offset(
+                                    n,
                                     gpu_id,
                                     nvml_wrapper::enum_wrappers::device::PerformanceState::Zero,
                                 );
                             let mem_offset =
                                 crate::oc_get_set_function_nvml::get_nvml_mem_clock_vf_offset(
+                                    n,
                                     gpu_id,
                                     nvml_wrapper::enum_wrappers::device::PerformanceState::Zero,
                                 );
@@ -772,7 +969,6 @@ pub fn handle_get(
                                     }
                                 }
                             } else {
-                                // 简洁模式：只列出支持的显存频率，不显示具体的 GPU 时钟频率
                                 let mem_clocks: Vec<_> =
                                     clocks.iter().map(|(mem_clk, _)| *mem_clk).collect();
                                 if !mem_clocks.is_empty() {
@@ -818,12 +1014,9 @@ pub fn handle_get(
 // In commands.rs
 
 pub fn handle_reset(
-    gpus: &[Gpu],
-    gpu: Option<clap::parser::ValuesRef<'_, String>>,
+    gpus: &[&Gpu],
     matches: &ArgMatches,
 ) -> Result<(), Error> {
-    let gpus = select_gpus(gpus, gpu)?;
-
     let parse_settings = |key: &str| -> Result<Vec<ResetSettings>, Error> {
         matches
             .get_many::<String>(key)
@@ -952,17 +1145,17 @@ pub fn handle_reset(
     Ok(())
 }
 
-pub fn handle_set_command(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
+pub fn handle_set_command(nvml: &Nvml, gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
     match matches.subcommand() {
-        Some(("nvapi", sub)) => handle_nvapi(gpus, sub)?,
-        Some(("nvml", sub)) => handle_nvml(gpus, sub)?,
-        Some(("nvml-cooler", sub)) => handle_nvml_cooler(gpus, sub)?,
+        Some(("nvapi", sub)) => handle_nvapi(nvml, gpus, sub)?,
+        Some(("nvml", sub)) => handle_nvml(nvml, gpus, sub)?,
+        Some(("nvml-cooler", sub)) => handle_nvml_cooler(nvml, gpus, sub)?,
         _ => {}
     }
     Ok(())
 }
 
-fn handle_nvapi(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
+fn handle_nvapi(nvml: &Nvml, gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
     if let Some(vboost) = matches
         .get_one::<String>("vboost")
         .map(|s| u32::from_str(s.as_str()))
@@ -1082,6 +1275,7 @@ fn handle_nvapi(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
         for gpu in gpus {
             let gpu_info = gpu.info()?;
             match crate::oc_get_set_function_nvapi::set_nvapi_pstate_lock(
+                nvml,
                 gpu,
                 gpu_info.id as u32,
                 first_pstate,
@@ -1166,7 +1360,7 @@ fn handle_nvapi(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(), Error> {
+pub fn handle_nvml_with_ids(nvml: &Nvml, gpu_ids: &[u32], matches: &ArgMatches) -> Result<(), Error> {
     let nvml_pstate_val = matches
         .get_one::<String>("pstate")
         .map(|s| s.as_str())
@@ -1180,6 +1374,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
     {
         for &gpu_id in gpu_ids {
             match crate::oc_get_set_function_nvml::set_nvml_core_clock_vf_offset(
+                nvml,
                 gpu_id,
                 core_offset,
                 target_nvml_pstate,
@@ -1200,6 +1395,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
     {
         for &gpu_id in gpu_ids {
             match crate::oc_get_set_function_nvml::set_nvml_mem_clock_vf_offset(
+                nvml,
                 gpu_id,
                 mem_offset,
                 target_nvml_pstate,
@@ -1219,7 +1415,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
         .transpose()?
     {
         for &gpu_id in gpu_ids {
-            match crate::oc_get_set_function_nvml::set_nvml_power_limit(gpu_id, power_w) {
+            match crate::oc_get_set_function_nvml::set_nvml_power_limit(nvml, gpu_id, power_w) {
                 Ok(_) => println!(
                     "Successfully applied NVML power limit {} W to GPU {}",
                     power_w, gpu_id
@@ -1238,7 +1434,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
             let core_clock = clocks[1];
             for &gpu_id in gpu_ids {
                 match crate::oc_get_set_function_nvml::set_nvml_applications_clocks(
-                    gpu_id, mem_clock, core_clock,
+                    nvml, gpu_id, mem_clock, core_clock,
                 ) {
                     Ok(_) => println!(
                         "Successfully applied NVML app clocks (Mem: {}, Core: {}) to GPU {}",
@@ -1265,7 +1461,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
             let max_clock = clocks[1];
             for &gpu_id in gpu_ids {
                 match crate::oc_get_set_function_nvml::set_nvml_core_locked_clocks(
-                    gpu_id, min_clock, max_clock,
+                    nvml, gpu_id, min_clock, max_clock,
                 ) {
                     Ok(_) => println!(
                         "Successfully locked NVML core clocks (Min: {}, Max: {}) to GPU {}",
@@ -1286,7 +1482,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
 
     if matches.get_flag("reset_core_clocks") {
         for &gpu_id in gpu_ids {
-            match crate::oc_get_set_function_nvml::reset_nvml_core_locked_clocks(gpu_id) {
+            match crate::oc_get_set_function_nvml::reset_nvml_core_locked_clocks(nvml, gpu_id) {
                 Ok(_) => println!(
                     "Successfully reset NVML core locked clocks to GPU {}",
                     gpu_id
@@ -1308,7 +1504,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
             let max_clock = clocks[1];
             for &gpu_id in gpu_ids {
                 match crate::oc_get_set_function_nvml::set_nvml_mem_locked_clocks(
-                    gpu_id, min_clock, max_clock,
+                    nvml, gpu_id, min_clock, max_clock,
                 ) {
                     Ok(_) => println!(
                         "Successfully locked NVML Memory clocks (Min: {}, Max: {}) to GPU {}",
@@ -1340,6 +1536,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
 
         for &gpu_id in gpu_ids {
             match crate::oc_get_set_function_nvml::set_nvml_pstate_lock(
+                nvml,
                 gpu_id,
                 first_pstate,
                 second_pstate,
@@ -1360,7 +1557,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
 
     if matches.get_flag("reset_mem_clocks") {
         for &gpu_id in gpu_ids {
-            match crate::oc_get_set_function_nvml::reset_nvml_mem_locked_clocks(gpu_id) {
+            match crate::oc_get_set_function_nvml::reset_nvml_mem_locked_clocks(nvml, gpu_id) {
                 Ok(_) => println!(
                     "Successfully reset NVML Memory locked clocks to GPU {}",
                     gpu_id
@@ -1376,15 +1573,15 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
     Ok(())
 }
 
-fn handle_nvml(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
+fn handle_nvml(nvml: &Nvml, gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
     let mut gpu_ids = Vec::with_capacity(gpus.len());
     for gpu in gpus {
         gpu_ids.push(gpu.info()?.id as u32);
     }
-    handle_nvml_with_ids(&gpu_ids, matches)
+    handle_nvml_with_ids(nvml, &gpu_ids, matches)
 }
 
-pub fn handle_nvml_cooler_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(), Error> {
+pub fn handle_nvml_cooler_with_ids(nvml: &Nvml, gpu_ids: &[u32], matches: &ArgMatches) -> Result<(), Error> {
     let cooler_id = matches
         .get_one::<String>("id")
         .map(|s| s.as_str())
@@ -1403,7 +1600,7 @@ pub fn handle_nvml_cooler_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Res
 
     for &gpu_id in gpu_ids {
         let fan_count =
-            crate::oc_get_set_function_nvml::get_nvml_num_fans(gpu_id).ok_or_else(|| {
+            crate::oc_get_set_function_nvml::get_nvml_num_fans(nvml, gpu_id).ok_or_else(|| {
                 Error::Custom(format!("Failed to query NVML fan count for GPU {}", gpu_id))
             })?;
 
@@ -1422,7 +1619,7 @@ pub fn handle_nvml_cooler_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Res
         };
 
         for fan_idx in fan_indices {
-            match crate::oc_get_set_function_nvml::set_fan_speed(gpu_id, fan_idx, policy, level) {
+            match crate::oc_get_set_function_nvml::set_fan_speed(nvml, gpu_id, fan_idx, policy, level) {
                 Ok(_) => println!(
                     "Successfully applied NVML cooler policy {:?}, level {}% to GPU {} fan {}",
                     policy,
@@ -1443,37 +1640,36 @@ pub fn handle_nvml_cooler_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Res
     Ok(())
 }
 
-pub fn handle_nvml_cooler(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
+pub fn handle_nvml_cooler(nvml: &Nvml, gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
     let mut gpu_ids = Vec::with_capacity(gpus.len());
     for gpu in gpus {
         gpu_ids.push(gpu.info()?.id as u32);
     }
-    handle_nvml_cooler_with_ids(&gpu_ids, matches)
+    handle_nvml_cooler_with_ids(nvml, &gpu_ids, matches)
 }
 
 pub fn handle_reset_nvml_cooler(
-    gpus: &[Gpu],
-    gpu: Option<clap::parser::ValuesRef<'_, String>>,
+    nvml: &Nvml,
+    gpus: &[&Gpu],
     matches: &ArgMatches,
 ) -> Result<(), Error> {
-    let gpus = select_gpus(gpus, gpu)?;
     let cooler_id = matches
         .get_one::<String>("id")
         .map(|s| s.as_str())
         .unwrap_or("all");
 
     for gpu in gpus {
-        handle_reset_nvml_cooler_single_gpu(gpu, cooler_id)?;
+        handle_reset_nvml_cooler_single_gpu(nvml, gpu, cooler_id)?;
     }
 
     Ok(())
 }
 
-pub fn handle_reset_nvml_cooler_single_gpu(gpu: &Gpu, cooler_id: &str) -> Result<(), Error> {
+pub fn handle_reset_nvml_cooler_single_gpu(nvml: &Nvml, gpu: &Gpu, cooler_id: &str) -> Result<(), Error> {
     let gpu_info = gpu.info()?;
     let gpu_id = gpu_info.id as u32;
     let fan_count =
-        crate::oc_get_set_function_nvml::get_nvml_num_fans(gpu_id).ok_or_else(|| {
+        crate::oc_get_set_function_nvml::get_nvml_num_fans(nvml, gpu_id).ok_or_else(|| {
             Error::Custom(format!(
                 "Failed to query NVML fan count for GPU {}",
                 gpu_info.id
@@ -1495,7 +1691,7 @@ pub fn handle_reset_nvml_cooler_single_gpu(gpu: &Gpu, cooler_id: &str) -> Result
     };
 
     for fan_idx in fan_indices {
-        match crate::oc_get_set_function_nvml::set_default_fan_speed(gpu_id, fan_idx) {
+        match crate::oc_get_set_function_nvml::set_default_fan_speed(nvml, gpu_id, fan_idx) {
             Ok(_) => println!(
                 "Successfully restored NVML default fan speed on GPU {} fan {}",
                 gpu_info.id,

--- a/auto-optimizer/src/human.rs
+++ b/auto-optimizer/src/human.rs
@@ -1,5 +1,6 @@
 use crate::oc_get_set_function_nvml::query_nvml_power_watts;
 use nvapi_hi::{ClockDomain, CoolerControl, Gpu, GpuInfo, GpuSettings, GpuStatus, MicrovoltsDelta};
+use nvml_wrapper::Nvml;
 use std::iter;
 
 const HEADER_LEN: usize = 20;
@@ -233,7 +234,7 @@ pub fn print_status(status: &GpuStatus) {
     }
 }
 
-pub fn print_info(gpu: &Gpu, info: &GpuInfo) {
+pub fn print_info(gpu: &Gpu, info: &GpuInfo, nvml: Option<&Nvml>) {
     pline!(
         format!("GPU {}", info.id),
         "{} ({})",
@@ -318,7 +319,7 @@ pub fn print_info(gpu: &Gpu, info: &GpuInfo) {
 
     for limit in info.power_limits.iter() {
         // 使用 NVAPI GPU ID 直接查询（公式：GPU_ID = PCI_Bus × 256）
-        match query_nvml_power_watts(info.id as u32) {
+        match nvml.and_then(|n| query_nvml_power_watts(n, info.id as u32)) {
             Some((min_w, current_w, max_w)) => {
                 pline!(
                     "Power Limit",

--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -56,79 +56,130 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
         return Err("Both NVML and NvAPI initialization failed".into());
     }
 
+    // GPU filter extracted once from CLI — no longer passed as clap ValuesRef
+    let gpu_filter: Option<Vec<String>> = matches
+        .get_many::<String>("gpu")
+        .map(|v| v.cloned().collect());
 
-    let gpu = matches.get_many::<String>("gpu");
     let oformat = matches
         .get_one::<String>("oformat")
         .map(|s| OutputFormat::from_str(s.as_str()))
         .unwrap()?;
 
+    let nvml = nvml_init_result.as_ref().ok();
+
     match matches.subcommand() {
-        Some(("info", _matches)) => {
-            let output_file = _matches.get_one::<String>("output").map(|s| s.as_str());
-            if let Err(e) = handle_info(gpu, oformat, output_file) {
-                eprintln!("Error: {:?}", e);
+        Some(("info", sub_matches)) => {
+            let output_file = sub_matches.get_one::<String>("output").map(|s| s.as_str());
+
+            if nvapi_init_result.is_ok() {
+                // NVAPI path (full info)
+                let gpu_list = get_sorted_gpus()?;
+                let selected = select_gpus(&gpu_list, gpu_filter.as_deref())?;
+                if let Err(e) = handle_info(nvml, &selected, oformat, output_file) {
+                    eprintln!("Error: {:?}", e);
+                }
+            } else if let Some(n) = nvml {
+                // NVML-only fallback
+                eprintln!("Note: NvAPI unavailable, using NVML-only info (limited detail).");
+                let gpu_ids = get_sorted_gpu_ids_nvml(n)?;
+                let selected_ids = select_gpu_ids(&gpu_ids, gpu_filter.as_deref())?;
+                if let Err(e) = handle_info_nvml_only(n, &selected_ids, oformat) {
+                    eprintln!("Error: {:?}", e);
+                }
             }
         }
         Some(("list", _matches)) => {
-            match &nvml_init_result {
-                Ok(nvml) => {
-                    if let Err(e) = handle_list(nvml) {
+            match nvml {
+                Some(n) => {
+                    if let Err(e) = handle_list(n) {
                         eprintln!("Error: {:?}", e);
                     }
                 }
-                Err(e) => {
-                    eprintln!("Error: list requires NVML, but NVML init failed: {}", e);
+                None => {
+                    eprintln!("Error: list requires NVML, but NVML init failed");
                 }
             }
         }
-        Some(("status", matches)) => {
-            if let Err(e) = handle_status(&get_sorted_gpus()?, gpu, matches, oformat) {
-                eprintln!("Error: {:?}", e);
+        Some(("status", sub_matches)) => {
+            if nvapi_init_result.is_ok() {
+                let gpu_list = get_sorted_gpus()?;
+                let selected = select_gpus(&gpu_list, gpu_filter.as_deref())?;
+                if let Err(e) = handle_status(nvml, &selected, sub_matches, oformat) {
+                    eprintln!("Error: {:?}", e);
+                }
+            } else if let Some(n) = nvml {
+                eprintln!("Note: NvAPI unavailable, using NVML-only status.");
+                let gpu_ids = get_sorted_gpu_ids_nvml(n)?;
+                let selected_ids = select_gpu_ids(&gpu_ids, gpu_filter.as_deref())?;
+                if let Err(e) = handle_status_nvml_only(n, &selected_ids, sub_matches, oformat) {
+                    eprintln!("Error: {:?}", e);
+                }
+            } else {
+                eprintln!("Error: status requires NvAPI or NVML, neither is available.");
             }
         }
         Some(("get", _matches)) => {
-            if let Err(e) = handle_get(&get_sorted_gpus()?, gpu, oformat) {
-                eprintln!("Error getting info: {:?}", e);
+            if nvapi_init_result.is_ok() {
+                let gpu_list = get_sorted_gpus()?;
+                let selected = select_gpus(&gpu_list, gpu_filter.as_deref())?;
+                if let Err(e) = handle_get(nvml, &selected, oformat) {
+                    eprintln!("Error getting info: {:?}", e);
+                }
+            } else {
+                eprintln!("Error: get requires NvAPI (for GPU settings), but NvAPI initialization failed.");
             }
         }
-        Some(("reset", matches)) => {
-            match matches.subcommand() {
-                Some(("nvml-cooler", sub_matches)) => {
-                    if let Err(e) = handle_reset_nvml_cooler(&get_sorted_gpus()?, gpu, sub_matches) {
-                        eprintln!("Error: {:?}", e);
+        Some(("reset", sub_matches)) => {
+            if nvapi_init_result.is_err() {
+                return Err("reset requires NvAPI, but NvAPI initialization failed".into());
+            }
+            let gpu_list = get_sorted_gpus()?;
+            match sub_matches.subcommand() {
+                Some(("nvml-cooler", cooler_matches)) => {
+                    let selected = select_gpus(&gpu_list, gpu_filter.as_deref())?;
+                    match nvml {
+                        Some(n) => {
+                            if let Err(e) = handle_reset_nvml_cooler(n, &selected, cooler_matches) {
+                                eprintln!("Error: {:?}", e);
+                            }
+                        }
+                        None => {
+                            eprintln!("Error: nvml-cooler reset requires NVML, but NVML init failed");
+                        }
                     }
                 }
                 _ => {
-                    if let Err(e) = handle_reset(&get_sorted_gpus()?, gpu, matches) {
+                    let selected = select_gpus(&gpu_list, gpu_filter.as_deref())?;
+                    if let Err(e) = handle_reset(&selected, sub_matches) {
                         eprintln!("Error: {:?}", e);
                     }
                 }
             }
         }
-        Some(("set", matches)) => {
-            match matches.subcommand() {
-                Some(("nvml", sub_matches)) => {
-                    match &nvml_init_result {
-                        Ok(nvml) => {
-                            let gpu_ids = get_sorted_gpu_ids_nvml(nvml)?;
-                            let selected_ids = select_gpu_ids(&gpu_ids, gpu)?;
-                            handle_nvml_with_ids(&selected_ids, sub_matches)?;
+        Some(("set", sub_matches)) => {
+            match sub_matches.subcommand() {
+                Some(("nvml", nvml_matches)) => {
+                    match nvml {
+                        Some(n) => {
+                            let gpu_ids = get_sorted_gpu_ids_nvml(n)?;
+                            let selected_ids = select_gpu_ids(&gpu_ids, gpu_filter.as_deref())?;
+                            handle_nvml_with_ids(n, &selected_ids, nvml_matches)?;
                         }
-                        Err(e) => {
-                            return Err(format!("NVML backend unavailable: {}", e).into());
+                        None => {
+                            return Err("NVML backend unavailable".into());
                         }
                     }
                 }
-                Some(("nvml-cooler", sub_matches)) => {
-                    match &nvml_init_result {
-                        Ok(nvml) => {
-                            let gpu_ids = get_sorted_gpu_ids_nvml(nvml)?;
-                            let selected_ids = select_gpu_ids(&gpu_ids, gpu)?;
-                            handle_nvml_cooler_with_ids(&selected_ids, sub_matches)?;
+                Some(("nvml-cooler", nvml_matches)) => {
+                    match nvml {
+                        Some(n) => {
+                            let gpu_ids = get_sorted_gpu_ids_nvml(n)?;
+                            let selected_ids = select_gpu_ids(&gpu_ids, gpu_filter.as_deref())?;
+                            handle_nvml_cooler_with_ids(n, &selected_ids, nvml_matches)?;
                         }
-                        Err(e) => {
-                            return Err(format!("NVML backend unavailable: {}", e).into());
+                        None => {
+                            return Err("NVML backend unavailable".into());
                         }
                     }
                 }
@@ -136,13 +187,16 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                     if nvapi_init_result.is_err() {
                         return Err("This subcommand requires NvAPI, but NvAPI initialization failed".into());
                     }
+                    let Some(n) = nvml else {
+                        return Err("This subcommand requires NVML for P-State info, but NVML initialization failed".into());
+                    };
 
                     let gpus = get_sorted_gpus()?;
-                    let gpus = select_gpus(&gpus, gpu)?;
+                    let gpus = select_gpus(&gpus, gpu_filter.as_deref())?;
 
-                    handle_set_command(&gpus, matches)?;
+                    handle_set_command(n, &gpus, sub_matches)?;
 
-                    match matches.subcommand() {
+                    match sub_matches.subcommand() {
                         Some(("nvapi", _)) => (), // Handled by handle_set_command
                         Some(("nvapi-cooler", matches)) => {
                             handle_cooler_command(&gpus, matches)?;
@@ -163,24 +217,24 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         match matches.subcommand() {
                             Some(("export", matches)) => {
                                 let gpu = single_gpu(&gpus)?;
-                                handle_vfp_export(gpu, matches)?; // Call the export function
+                                handle_vfp_export(gpu, matches)?;
                             }
                             Some(("export_log", matches)) => {
-                                export_vfp_from_log(matches)?; // Call the export function
+                                export_vfp_from_log(matches)?;
                             }
                             Some(("import", matches)) => {
                                 let gpu = single_gpu(&gpus)?;
-                                handle_vfp_import(gpu, matches)?; // Call the import function
+                                handle_vfp_import(gpu, matches)?;
                             }
                             Some(("single_point_adj", matches)) => {
-                                single_point_adj(&gpus, matches)? // Call the adjustment function
+                                single_point_adj(&gpus, matches)?
                             }
                             Some(("pointwiseoc", matches)) => {
                                 handle_pointwiseoc(&gpus, matches)?
                             }
                             Some(("fix_result", matches)) => {
                                 let gpu = single_gpu(&gpus)?;
-                                fix_result(gpu, matches)? // Call the polishment function
+                                fix_result(gpu, matches)?
                             }
                             Some(("autoscan", matches)) => {
                                 if let Err(e) = autoscan_gpuboostv3(&gpus, matches) {

--- a/auto-optimizer/src/oc_get_set_function_nvapi.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvapi.rs
@@ -1,4 +1,5 @@
 use crate::basic_func::{select_gpus, TestResolution};
+use nvml_wrapper::Nvml;
 use crate::conv::ConvertEnum;
 use crate::error::Error;
 use crate::human::print_scan_separator;
@@ -439,12 +440,13 @@ fn nvapi_ranges_overlap(a_min: u32, a_max: u32, b_min: u32, b_max: u32) -> bool 
 }
 
 pub fn set_nvapi_pstate_lock(
+    nvml: &Nvml,
     gpu: &Gpu,
     gpu_id: u32,
     first_pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
     second_pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
 ) -> Result<(String, u32, u32), Error> {
-    let pstates = crate::oc_get_set_function_nvml::get_nvml_pstate_info(gpu_id).ok_or_else(|| {
+    let pstates = crate::oc_get_set_function_nvml::get_nvml_pstate_info(nvml, gpu_id).ok_or_else(|| {
         Error::Custom(format!(
             "Failed to query NVML P-State information for GPU {}",
             gpu_id
@@ -1131,6 +1133,7 @@ pub fn handle_test_voltage_limits(
 
 pub fn get_gpu_tdp_temp_limit(
     arg_matches: ArgMatches,
+    nvml: Option<&Nvml>,
 ) -> Result<
     (
         Percentage,
@@ -1175,15 +1178,14 @@ pub fn get_gpu_tdp_temp_limit(
         points: pff_current_point,
     };
 
-    let gpu = arg_matches.get_many::<String>("gpu");
+    let gpu_filter: Option<Vec<String>> = arg_matches.get_many::<String>("gpu").map(|v| v.cloned().collect());
     let gpu_list = crate::basic_func::get_sorted_gpus()?;
-    let gpus = select_gpus(&gpu_list, gpu)?;
+    let gpus = select_gpus(&gpu_list, gpu_filter.as_deref())?;
 
     for gpu in gpus.iter() {
         let info = gpu.info()?;
 
-        // 使用 NVAPI GPU ID 直接查询（公式：GPU_ID = PCI_Bus × 256）
-        if let Some((min_w, current_w, max_w)) = crate::oc_get_set_function_nvml::query_nvml_power_watts(info.id as u32) {
+        if let Some((min_w, current_w, max_w)) = nvml.and_then(|n| crate::oc_get_set_function_nvml::query_nvml_power_watts(n, info.id as u32)) {
             min_tdp = min_w;
             default_tdp = current_w;
             max_tdp = max_w;
@@ -1254,9 +1256,9 @@ pub fn find_matching_vfp_point(
 }
 
 pub fn voltage_frequency_check(arg_matches: ArgMatches, point: usize) -> Result<bool, Error> {
-    let gpu = arg_matches.get_many::<String>("gpu");
+    let gpu_filter: Option<Vec<String>> = arg_matches.get_many::<String>("gpu").map(|v| v.cloned().collect());
     let gpu_list = crate::basic_func::get_sorted_gpus()?;
-    let gpus = select_gpus(&gpu_list, gpu)?;
+    let gpus = select_gpus(&gpu_list, gpu_filter.as_deref())?;
     let mut precise_flag = false;
 
     for gpu in gpus {

--- a/auto-optimizer/src/oc_get_set_function_nvml.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvml.rs
@@ -3,157 +3,17 @@ use nvml_wrapper::Nvml;
 use nvml_wrapper::enums::device::FanControlPolicy;
 
 // ---------------------------------------------------------------------------
-// NVML 功率查询辅助函数（供 human.rs 和 get_gpu_tdp_temp_limit 复用）
+// Private helper: find an NVML device by NVAPI-style GPU ID (PCI bus * 256)
 // ---------------------------------------------------------------------------
 
-/// 通过 NVML 查询指定 GPU 的功率限制（单位：瓦）。
-///
-/// **注意：** 优先使用 `query_nvml_power_watts(gpu_id)` —— 它更简洁且直接。
-/// 此函数保留作为备用实现（适用于需要从字符串解析 PCI Bus ID 的场景）。
-///
-/// # 参数
-/// - `pci_bus_id_str`: PCI Bus ID 字符串（格式如 "0000:01:00.0" 或 NVAPI 的 "PCIe x16 (1:0...)"）
-///
-/// # 返回
-/// - `Some((min_W, current_W, max_W))`: 成功时返回三个瓦数值
-/// - `None`: NVML 初始化失败或设备不可用时返回
-#[allow(dead_code)]
-pub fn query_nvml_power_watts_by_pci(pci_bus_id_str: &str) -> Option<(f32, f32, f32)> {
-    let nvml = Nvml::init().ok()?;
-
-    // 从 NVAPI 格式提取 PCI Bus 编号
-    // 例如 "PCIe x16 (1:0 routed to IRQ 0)" -> Bus = 1
-    let nvapi_bus_num = if let Some(start) = pci_bus_id_str.find('(') {
-        if let Some(end) = pci_bus_id_str[start..].find(':') {
-            pci_bus_id_str[start+1..start+end].trim().parse::<u32>().ok()
-        } else {
-            None
-        }
-    } else {
-        // 尝试解析标准格式 "0000:01:00.0"
-        pci_bus_id_str.split(':').nth(1).and_then(|s| s.parse::<u32>().ok())
-    };
-
-    // 尝试直接通过 PCI Bus ID 获取设备（可能失败）
-    let device = nvml.device_by_pci_bus_id(pci_bus_id_str).or_else(|_| {
-        // 降级方案：枚举所有 NVML 设备，匹配 PCI Bus 编号
-        let device_count = nvml.device_count()?;
-
-        for i in 0..device_count {
-            if let Ok(dev) = nvml.device_by_index(i) {
-                if let Ok(pci_info) = dev.pci_info() {
-                    // 匹配策略：比较 PCI Bus 编号
-                    if let Some(target_bus) = nvapi_bus_num {
-                        if pci_info.bus == target_bus {
-                            return Ok(dev);
-                        }
-                    }
-
-                    // 备用：宽松字符串匹配
-                    let nvml_pci_str = format!(
-                        "{:04x}:{:02x}:{:02x}.0",
-                        pci_info.domain, pci_info.bus, pci_info.device
-                    );
-                    let nvapi_stripped = pci_bus_id_str.trim_start_matches("0000:");
-                    let nvml_stripped = nvml_pci_str.trim_start_matches("0000:");
-                    if nvapi_stripped.eq_ignore_ascii_case(nvml_stripped) {
-                        return Ok(dev);
-                    }
-                }
-            }
-        }
-
-        Err(nvml_wrapper::error::NvmlError::NotFound)
-    }).ok()?;
-
-    let current_mw = device.power_management_limit().ok()?;
-    let constraints = device.power_management_limit_constraints();
-
-    let (min_mw, max_mw) = match constraints {
-        Ok(c) => (c.min_limit, c.max_limit),
-        Err(_) => (0, 0),
-    };
-
-    let min_w = min_mw as f32 / 1000.0;
-    let max_w = max_mw as f32 / 1000.0;
-    let current_w = current_mw as f32 / 1000.0;
-
-    Some((min_w, current_w, max_w))
-}
-
-/// 通过 NVAPI GPU ID 查询功率限制（直接计算 PCI Bus 号）。
-///
-/// # NVAPI GPU ID 编码规则
-///
-/// NVAPI 使用以下公式编码 GPU ID：
-/// ```text
-/// GPU_ID = PCI_Bus_Number × 256
-/// ```
-///
-/// **示例：**
-/// - GPU ID `256` (0x0100) → PCI Bus `0x01` (Bus 1)
-/// - GPU ID `35072` (0x8900) → PCI Bus `0x89` (Bus 137)
-///
-/// **逆向公式：**
-/// ```text
-/// PCI_Bus_Number = GPU_ID ÷ 256
-/// ```
-///
-/// 这个函数通过上述公式从 GPU ID 提取 PCI Bus 号，然后枚举 NVML 设备进行匹配。
-///
-/// # 参数
-/// - `gpu_id`: NVAPI GPU ID（从 `GpuInfo.id` 获取）
-///
-/// # 返回
-/// - `Some((min_W, current_W, max_W))`: 成功时返回三个瓦数值
-/// - `None`: NVML 初始化失败或设备不可用时返回
-pub fn query_nvml_power_watts(gpu_id: u32) -> Option<(f32, f32, f32)> {
-    let nvml = Nvml::init().ok()?;
-
-    // NVAPI GPU ID 编码规则：GPU_ID = PCI_Bus × 256
-    let pci_bus_num = gpu_id / 256;
-
-    // 枚举所有 NVML 设备，匹配 PCI Bus 编号
-    let device_count = nvml.device_count().ok()?;
-    let mut device = None;
-
-    for i in 0..device_count {
+fn find_nvml_device<'n>(nvml: &'n Nvml, gpu_id: u32) -> Option<nvml_wrapper::Device<'n>> {
+    let pci_bus = gpu_id / 256;
+    let count = nvml.device_count().ok()?;
+    for i in 0..count {
         if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    device = Some(dev);
-                    break;
-                }
-            }
-        }
-    }
-
-    let device = device?;
-
-    let current_mw = device.power_management_limit().ok()?;
-    let constraints = device.power_management_limit_constraints();
-
-    let (min_mw, max_mw) = match constraints {
-        Ok(c) => (c.min_limit, c.max_limit),
-        Err(_) => (0, 0),
-    };
-
-    let min_w = min_mw as f32 / 1000.0;
-    let max_w = max_mw as f32 / 1000.0;
-    let current_w = current_mw as f32 / 1000.0;
-
-    Some((min_w, current_w, max_w))
-}
-
-pub fn get_nvml_core_clock_vf_offset(gpu_id: u32, pstate: nvml_wrapper::enum_wrappers::device::PerformanceState) -> Option<i32> {
-    let nvml = Nvml::init().ok()?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().ok()?;
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.clock_offset(nvml_wrapper::enum_wrappers::device::Clock::Graphics, pstate).ok().map(|o| o.clock_offset_mhz);
+            if let Ok(pci) = dev.pci_info() {
+                if pci.bus == pci_bus {
+                    return Some(dev);
                 }
             }
         }
@@ -161,276 +21,241 @@ pub fn get_nvml_core_clock_vf_offset(gpu_id: u32, pstate: nvml_wrapper::enum_wra
     None
 }
 
-pub fn set_nvml_core_clock_vf_offset(gpu_id: u32, offset: i32, pstate: nvml_wrapper::enum_wrappers::device::PerformanceState) -> Result<(), Error> {
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.set_clock_offset(nvml_wrapper::enum_wrappers::device::Clock::Graphics, pstate, offset)
-                        .map_err(|e| Error::Custom(format!("NVML Set Core Clock VF Offset Error: {:?}", e)));
-                }
-            }
-        }
-    }
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+fn find_nvml_device_err<'n>(nvml: &'n Nvml, gpu_id: u32) -> Result<nvml_wrapper::Device<'n>, Error> {
+    find_nvml_device(nvml, gpu_id)
+        .ok_or_else(|| Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
 }
 
-pub fn get_nvml_mem_clock_vf_offset(gpu_id: u32, pstate: nvml_wrapper::enum_wrappers::device::PerformanceState) -> Option<i32> {
-    let nvml = Nvml::init().ok()?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().ok()?;
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    // Note: NVML reports memory clock offset as double the actual frequency (GDDR historical reason).
-                    // We divide by 2 here so the getter returns the actual effective memory offset.
-                    return dev.clock_offset(nvml_wrapper::enum_wrappers::device::Clock::Memory, pstate).ok().map(|o| o.clock_offset_mhz / 2);
-                }
-            }
-        }
-    }
-    None
+// ---------------------------------------------------------------------------
+// Power queries
+// ---------------------------------------------------------------------------
+
+/// Query power limits for a GPU via NVML.
+///
+/// `gpu_id` uses the NVAPI encoding: `PCI_Bus_Number × 256`.
+pub fn query_nvml_power_watts(nvml: &Nvml, gpu_id: u32) -> Option<(f32, f32, f32)> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    let current_mw = device.power_management_limit().ok()?;
+    let constraints = device.power_management_limit_constraints();
+    let (min_mw, max_mw) = match constraints {
+        Ok(c) => (c.min_limit, c.max_limit),
+        Err(_) => (0, 0),
+    };
+    Some((
+        min_mw as f32 / 1000.0,
+        current_mw as f32 / 1000.0,
+        max_mw as f32 / 1000.0,
+    ))
 }
 
-pub fn set_nvml_mem_clock_vf_offset(gpu_id: u32, offset: i32, pstate: nvml_wrapper::enum_wrappers::device::PerformanceState) -> Result<(), Error> {
-    let nvml = match Nvml::init() {
-        Ok(n) => n,
-        Err(e) => return Err(Error::Custom(format!("NVML Init Error: {:?}", e))),
-    };
-    let pci_bus_num = gpu_id / 256;
-    let device_count = match nvml.device_count() {
-        Ok(c) => c,
-        Err(e) => return Err(Error::Custom(format!("NVML Device Count Error: {:?}", e))),
-    };
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    // NVML expects memory clock offset as double the actual target (GDDR historical reason).
-                    match dev.set_clock_offset(nvml_wrapper::enum_wrappers::device::Clock::Memory, pstate, (offset * 2) as i32) {
-                        Ok(_) => return Ok(()),
-                        Err(e) => return Err(Error::Custom(format!("NVML Set Mem Clock Offset Error: {:?}", e))),
-                    }
-                }
-            }
-        }
-    }
-    Err(Error::Custom("NVML Device not found".to_string()))
+pub fn set_nvml_power_limit(nvml: &Nvml, gpu_id: u32, limit_w: u32) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_power_management_limit(limit_w * 1000)
+        .map_err(|e| Error::Custom(format!("NVML Set Power Limit Error: {:?}", e)))
 }
 
+// ---------------------------------------------------------------------------
+// Clock offset get/set
+// ---------------------------------------------------------------------------
 
-pub fn set_nvml_power_limit(gpu_id: u32, limit_w: u32) -> Result<(), Error> {
-    let nvml = match Nvml::init() {
-        Ok(n) => n,
-        Err(e) => return Err(Error::Custom(format!("NVML Init Error: {:?}", e))),
-    };
-    let pci_bus_num = gpu_id / 256;
-    let device_count = match nvml.device_count() {
-        Ok(c) => c,
-        Err(e) => return Err(Error::Custom(format!("NVML Device Count Error: {:?}", e))),
-    };
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    let limit_mw = limit_w * 1000;
-                    match dev.set_power_management_limit(limit_mw) {
-                        Ok(_) => return Ok(()),
-                        Err(e) => return Err(Error::Custom(format!("NVML Set Power Limit Error: {:?}", e))),
-                    }
-                }
-            }
-        }
-    }
-    Err(Error::Custom("NVML Device not found".to_string()))
+pub fn get_nvml_core_clock_vf_offset(
+    nvml: &Nvml,
+    gpu_id: u32,
+    pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
+) -> Option<i32> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    device
+        .clock_offset(nvml_wrapper::enum_wrappers::device::Clock::Graphics, pstate)
+        .ok()
+        .map(|o| o.clock_offset_mhz)
 }
+
+pub fn set_nvml_core_clock_vf_offset(
+    nvml: &Nvml,
+    gpu_id: u32,
+    offset: i32,
+    pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
+) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_clock_offset(nvml_wrapper::enum_wrappers::device::Clock::Graphics, pstate, offset)
+        .map_err(|e| Error::Custom(format!("NVML Set Core Clock VF Offset Error: {:?}", e)))
+}
+
+pub fn get_nvml_mem_clock_vf_offset(
+    nvml: &Nvml,
+    gpu_id: u32,
+    pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
+) -> Option<i32> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    // NVML reports memory clock offset as double the actual frequency (GDDR historical reason).
+    device
+        .clock_offset(nvml_wrapper::enum_wrappers::device::Clock::Memory, pstate)
+        .ok()
+        .map(|o| o.clock_offset_mhz / 2)
+}
+
+pub fn set_nvml_mem_clock_vf_offset(
+    nvml: &Nvml,
+    gpu_id: u32,
+    offset: i32,
+    pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
+) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    // NVML expects memory clock offset as double the actual target (GDDR historical reason).
+    device
+        .set_clock_offset(
+            nvml_wrapper::enum_wrappers::device::Clock::Memory,
+            pstate,
+            offset * 2,
+        )
+        .map_err(|e| Error::Custom(format!("NVML Set Mem Clock Offset Error: {:?}", e)))
+}
+
+// ---------------------------------------------------------------------------
+// Temperature thresholds
+// ---------------------------------------------------------------------------
 
 #[allow(dead_code)]
 pub fn set_nvml_temperature_threshold(
+    nvml: &Nvml,
     gpu_id: u32,
     threshold: nvml_wrapper::enum_wrappers::device::TemperatureThreshold,
     limit_c: i32,
 ) -> Result<(), Error> {
-    let nvml = match Nvml::init() {
-        Ok(n) => n,
-        Err(e) => return Err(Error::Custom(format!("NVML Init Error: {:?}", e))),
-    };
-    let pci_bus_num = gpu_id / 256;
-    let device_count = match nvml.device_count() {
-        Ok(c) => c,
-        Err(e) => return Err(Error::Custom(format!("NVML Device Count Error: {:?}", e))),
-    };
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev
-                        .set_temperature_threshold(threshold, limit_c)
-                        .map_err(|e| Error::Custom(format!("NVML Set Temperature Threshold Error: {:?}", e)));
-                }
-            }
-        }
-    }
-    Err(Error::Custom("NVML Device not found".to_string()))
+    let device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_temperature_threshold(threshold, limit_c)
+        .map_err(|e| Error::Custom(format!("NVML Set Temperature Threshold Error: {:?}", e)))
 }
 
 #[allow(dead_code)]
-pub fn set_nvml_temperature_limit(gpu_id: u32, limit_c: i32) -> Result<(), Error> {
+pub fn set_nvml_temperature_limit(nvml: &Nvml, gpu_id: u32, limit_c: i32) -> Result<(), Error> {
     set_nvml_temperature_threshold(
+        nvml,
         gpu_id,
         nvml_wrapper::enum_wrappers::device::TemperatureThreshold::GpuMax,
         limit_c,
     )
 }
 
-pub fn get_nvml_temperature_thresholds(gpu_id: u32) -> Option<Vec<(&'static str, Option<u32>)>> {
-    let nvml = Nvml::init().ok()?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().ok()?;
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    let thresholds = [
-                        (
-                            "Shutdown",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::Shutdown,
-                        ),
-                        (
-                            "Slowdown",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::Slowdown,
-                        ),
-                        (
-                            "MemoryMax",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::MemoryMax,
-                        ),
-                        (
-                            "GpuMax",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::GpuMax,
-                        ),
-                        (
-                            "AcousticMin",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::AcousticMin,
-                        ),
-                        (
-                            "AcousticCurr",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::AcousticCurr,
-                        ),
-                        (
-                            "AcousticMax",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::AcousticMax,
-                        ),
-                        (
-                            "GpsCurr",
-                            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::GpsCurr,
-                        ),
-                    ];
-                    return Some(
-                        thresholds
-                            .iter()
-                            .map(|(name, threshold)| (*name, dev.temperature_threshold(*threshold).ok()))
-                            .collect(),
-                    );
-                }
+pub fn get_nvml_temperature_thresholds(
+    nvml: &Nvml,
+    gpu_id: u32,
+) -> Option<Vec<(&'static str, Option<u32>)>> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    let thresholds = [
+        (
+            "Shutdown",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::Shutdown,
+        ),
+        (
+            "Slowdown",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::Slowdown,
+        ),
+        (
+            "MemoryMax",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::MemoryMax,
+        ),
+        (
+            "GpuMax",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::GpuMax,
+        ),
+        (
+            "AcousticMin",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::AcousticMin,
+        ),
+        (
+            "AcousticCurr",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::AcousticCurr,
+        ),
+        (
+            "AcousticMax",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::AcousticMax,
+        ),
+        (
+            "GpsCurr",
+            nvml_wrapper::enum_wrappers::device::TemperatureThreshold::GpsCurr,
+        ),
+    ];
+    Some(
+        thresholds
+            .iter()
+            .map(|(name, threshold)| (*name, device.temperature_threshold(*threshold).ok()))
+            .collect(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// P-State info and clock ranges
+// ---------------------------------------------------------------------------
+
+pub fn get_nvml_pstate_info(
+    nvml: &Nvml,
+    gpu_id: u32,
+) -> Option<
+    Vec<(
+        nvml_wrapper::enum_wrappers::device::PerformanceState,
+        u32,
+        u32,
+        u32,
+        u32,
+    )>,
+> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    let pstates = device.supported_performance_states().ok()?;
+    let mut res = Vec::new();
+    for p in pstates {
+        let core_clock = device
+            .min_max_clock_of_pstate(nvml_wrapper::enum_wrappers::device::Clock::Graphics, p)
+            .unwrap_or((0, 0));
+        let mem_clock = device
+            .min_max_clock_of_pstate(nvml_wrapper::enum_wrappers::device::Clock::Memory, p)
+            .unwrap_or((0, 0));
+        res.push((p, core_clock.0, core_clock.1, mem_clock.0, mem_clock.1));
+    }
+    Some(res)
+}
+
+/// Returns supported memory clocks and, for each, the supported graphics clocks.
+pub fn get_nvml_supported_applications_clocks(
+    nvml: &Nvml,
+    gpu_id: u32,
+) -> Option<Vec<(u32, Vec<u32>)>> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    let mut supported = Vec::new();
+    if let Ok(mem_clocks) = device.supported_memory_clocks() {
+        for mc in mem_clocks {
+            if let Ok(gfx_clocks) = device.supported_graphics_clocks(mc) {
+                supported.push((mc, gfx_clocks));
+            } else {
+                supported.push((mc, vec![]));
             }
         }
     }
-    None
+    Some(supported)
 }
 
-pub fn get_nvml_pstate_info(gpu_id: u32) -> Option<Vec<(nvml_wrapper::enum_wrappers::device::PerformanceState, u32, u32, u32, u32)>> {
-    let nvml = Nvml::init().ok()?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().ok()?;
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    if let Ok(pstates) = dev.supported_performance_states() {
-                        let mut res = Vec::new();
-                        for p in pstates {
-                            let core_clock = dev.min_max_clock_of_pstate(nvml_wrapper::enum_wrappers::device::Clock::Graphics, p).unwrap_or((0, 0));
-                            let mem_clock = dev.min_max_clock_of_pstate(nvml_wrapper::enum_wrappers::device::Clock::Memory, p).unwrap_or((0, 0));
-                            res.push((p, core_clock.0, core_clock.1, mem_clock.0, mem_clock.1));
-                        }
-                        return Some(res);
-                    }
-                }
-            }
-        }
-    }
-    None
+// ---------------------------------------------------------------------------
+// Fan speed queries
+// ---------------------------------------------------------------------------
+
+pub fn get_nvml_min_max_fan_speed(nvml: &Nvml, gpu_id: u32) -> Option<(u32, u32)> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    device.min_max_fan_speed().ok()
 }
 
-/// 获取支持的 memory clocks 以及每个 memory clock 对应的 graphics clocks 列表
-pub fn get_nvml_supported_applications_clocks(gpu_id: u32) -> Option<Vec<(u32, Vec<u32>)>> {
-    let nvml = match Nvml::init() {
-        Ok(n) => n,
-        Err(_) => return None,
-    };
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().ok()?;
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    let mut supported = Vec::new();
-                    if let Ok(mem_clocks) = dev.supported_memory_clocks() {
-                        for mc in mem_clocks {
-                            if let Ok(gfx_clocks) = dev.supported_graphics_clocks(mc) {
-                                supported.push((mc, gfx_clocks));
-                            } else {
-                                supported.push((mc, vec![]));
-                            }
-                        }
-                    }
-                    return Some(supported);
-                }
-            }
-        }
-    }
-    None
+pub fn get_nvml_num_fans(nvml: &Nvml, gpu_id: u32) -> Option<u32> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    device.num_fans().ok()
 }
 
-pub fn get_nvml_min_max_fan_speed(gpu_id: u32) -> Option<(u32, u32)> {
-    let nvml = Nvml::init().ok()?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().ok()?;
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.min_max_fan_speed().ok();
-                }
-            }
-        }
-    }
-    None
-}
+// ---------------------------------------------------------------------------
+// Fan control
+// ---------------------------------------------------------------------------
 
-pub fn get_nvml_num_fans(gpu_id: u32) -> Option<u32> {
-    let nvml = Nvml::init().ok()?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().ok()?;
-    for i in 0..device_count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.num_fans().ok();
-                }
-            }
-        }
-    }
-    None
-}
-
-pub fn parse_nvml_fan_control_policy(
-    policy_raw: &str,
-) -> Result<FanControlPolicy, Error> {
+pub fn parse_nvml_fan_control_policy(policy_raw: &str) -> Result<FanControlPolicy, Error> {
     match policy_raw.to_ascii_lowercase().as_str() {
         "continuous" | "auto" => Ok(FanControlPolicy::TemperatureContinousSw),
         "manual" => Ok(FanControlPolicy::Manual),
@@ -442,6 +267,7 @@ pub fn parse_nvml_fan_control_policy(
 }
 
 pub fn set_fan_speed(
+    nvml: &Nvml,
     gpu_id: u32,
     fan_idx: u32,
     policy: FanControlPolicy,
@@ -453,50 +279,25 @@ pub fn set_fan_speed(
             level
         )));
     }
-
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count =
-        nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    dev.set_fan_control_policy(fan_idx, policy).map_err(|e| {
-                        Error::Custom(format!("NVML Set Fan Control Policy Error: {:?}", e))
-                    })?;
-                    return dev
-                        .set_fan_speed(fan_idx, level)
-                        .map_err(|e| Error::Custom(format!("NVML Set Fan Speed Error: {:?}", e)));
-                }
-            }
-        }
-    }
-
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_fan_control_policy(fan_idx, policy)
+        .map_err(|e| Error::Custom(format!("NVML Set Fan Control Policy Error: {:?}", e)))?;
+    device
+        .set_fan_speed(fan_idx, level)
+        .map_err(|e| Error::Custom(format!("NVML Set Fan Speed Error: {:?}", e)))
 }
 
-pub fn set_default_fan_speed(gpu_id: u32, fan_idx: u32) -> Result<(), Error> {
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count =
-        nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.set_default_fan_speed(fan_idx).map_err(|e| {
-                        Error::Custom(format!("NVML Set Default Fan Speed Error: {:?}", e))
-                    });
-                }
-            }
-        }
-    }
-
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+pub fn set_default_fan_speed(nvml: &Nvml, gpu_id: u32, fan_idx: u32) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_default_fan_speed(fan_idx)
+        .map_err(|e| Error::Custom(format!("NVML Set Default Fan Speed Error: {:?}", e)))
 }
+
+// ---------------------------------------------------------------------------
+// P-State lock (via memory clock window)
+// ---------------------------------------------------------------------------
 
 const NVML_PSTATE_LOCK_MARGIN_MHZ: u32 = 50;
 
@@ -505,11 +306,12 @@ fn nvml_ranges_overlap(a_min: u32, a_max: u32, b_min: u32, b_max: u32) -> bool {
 }
 
 pub fn set_nvml_pstate_lock(
+    nvml: &Nvml,
     gpu_id: u32,
     first_pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
     second_pstate: nvml_wrapper::enum_wrappers::device::PerformanceState,
 ) -> Result<(String, u32, u32), Error> {
-    let pstates = get_nvml_pstate_info(gpu_id).ok_or_else(|| {
+    let pstates = get_nvml_pstate_info(nvml, gpu_id).ok_or_else(|| {
         Error::Custom(format!(
             "Failed to query NVML P-State information for GPU {}",
             gpu_id
@@ -604,96 +406,65 @@ pub fn set_nvml_pstate_lock(
         )));
     }
 
-    set_nvml_mem_locked_clocks(gpu_id, min_lock_mhz, max_lock_mhz)?;
+    set_nvml_mem_locked_clocks(nvml, gpu_id, min_lock_mhz, max_lock_mhz)?;
     Ok((range_label, min_lock_mhz, max_lock_mhz))
 }
 
-/// 设定 GPU 在运行应用程序时锁定在指定的显存与核心频率，避免波动。
-pub fn set_nvml_applications_clocks(gpu_id: u32, mem_clock_mhz: u32, graphics_clock_mhz: u32) -> Result<(), Error> {
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.set_applications_clocks(mem_clock_mhz, graphics_clock_mhz)
-                        .map_err(|e| Error::Custom(format!("NVML Set Applications Clocks Error: {:?}", e)));
-                }
-            }
-        }
-    }
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+// ---------------------------------------------------------------------------
+// Application clocks and locked clocks
+// ---------------------------------------------------------------------------
+
+pub fn set_nvml_applications_clocks(
+    nvml: &Nvml,
+    gpu_id: u32,
+    mem_clock_mhz: u32,
+    graphics_clock_mhz: u32,
+) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_applications_clocks(mem_clock_mhz, graphics_clock_mhz)
+        .map_err(|e| Error::Custom(format!("NVML Set Applications Clocks Error: {:?}", e)))
 }
 
-/// 锁定GPU核心频率在指定的最小值和最大值之间。
-pub fn set_nvml_core_locked_clocks(gpu_id: u32, min_clock_mhz: u32, max_clock_mhz: u32) -> Result<(), Error> {
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.set_gpu_locked_clocks(nvml_wrapper::enums::device::GpuLockedClocksSetting::Numeric { min_clock_mhz, max_clock_mhz })
-                        .map_err(|e| Error::Custom(format!("NVML Set GPU Locked Clocks Error: {:?}", e)));
-                }
-            }
-        }
-    }
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+pub fn set_nvml_core_locked_clocks(
+    nvml: &Nvml,
+    gpu_id: u32,
+    min_clock_mhz: u32,
+    max_clock_mhz: u32,
+) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_gpu_locked_clocks(
+            nvml_wrapper::enums::device::GpuLockedClocksSetting::Numeric {
+                min_clock_mhz,
+                max_clock_mhz,
+            },
+        )
+        .map_err(|e| Error::Custom(format!("NVML Set GPU Locked Clocks Error: {:?}", e)))
 }
 
-/// 解除GPU核心频率锁定。
-pub fn reset_nvml_core_locked_clocks(gpu_id: u32) -> Result<(), Error> {
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.reset_gpu_locked_clocks()
-                        .map_err(|e| Error::Custom(format!("NVML Reset GPU Locked Clocks Error: {:?}", e)));
-                }
-            }
-        }
-    }
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+pub fn reset_nvml_core_locked_clocks(nvml: &Nvml, gpu_id: u32) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .reset_gpu_locked_clocks()
+        .map_err(|e| Error::Custom(format!("NVML Reset GPU Locked Clocks Error: {:?}", e)))
 }
 
-/// 锁定GPU显存频率在指定的最小值和最大值之间。
-pub fn set_nvml_mem_locked_clocks(gpu_id: u32, min_clock_mhz: u32, max_clock_mhz: u32) -> Result<(), Error> {
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.set_mem_locked_clocks(min_clock_mhz, max_clock_mhz)
-                        .map_err(|e| Error::Custom(format!("NVML Set Memory Locked Clocks Error: {:?}", e)));
-                }
-            }
-        }
-    }
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+pub fn set_nvml_mem_locked_clocks(
+    nvml: &Nvml,
+    gpu_id: u32,
+    min_clock_mhz: u32,
+    max_clock_mhz: u32,
+) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .set_mem_locked_clocks(min_clock_mhz, max_clock_mhz)
+        .map_err(|e| Error::Custom(format!("NVML Set Memory Locked Clocks Error: {:?}", e)))
 }
 
-/// 解除GPU显存频率锁定。
-pub fn reset_nvml_mem_locked_clocks(gpu_id: u32) -> Result<(), Error> {
-    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML Init Error: {:?}", e)))?;
-    let pci_bus_num = gpu_id / 256;
-    let device_count = nvml.device_count().map_err(|e| Error::Custom(format!("NVML Device Count Error: {:?}", e)))?;
-    for i in 0..device_count {
-        if let Ok(mut dev) = nvml.device_by_index(i) {
-            if let Ok(pci_info) = dev.pci_info() {
-                if pci_info.bus == pci_bus_num {
-                    return dev.reset_mem_locked_clocks()
-                        .map_err(|e| Error::Custom(format!("NVML Reset Memory Locked Clocks Error: {:?}", e)));
-                }
-            }
-        }
-    }
-    Err(Error::Custom(format!("GPU {} not found in NVML", gpu_id)))
+pub fn reset_nvml_mem_locked_clocks(nvml: &Nvml, gpu_id: u32) -> Result<(), Error> {
+    let mut device = find_nvml_device_err(nvml, gpu_id)?;
+    device
+        .reset_mem_locked_clocks()
+        .map_err(|e| Error::Custom(format!("NVML Reset Memory Locked Clocks Error: {:?}", e)))
 }

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -1071,7 +1071,7 @@ pub fn apply_autoscan_profile(gpu: &Gpu, matches: &clap::ArgMatches, cooler_leve
     gpu.set_cooler_levels(settings)?;
     println!("Successfully set Cooler1 and Cooler2 to {}%.", cooler_level);
 
-    match get_gpu_tdp_temp_limit(matches.clone()) {
+    match get_gpu_tdp_temp_limit(matches.clone(), None) {
         Ok((
             _min_tdp_percent,
             _default_tdp_percent,

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -1,8 +1,8 @@
 use crate::basic_func::TestResolution::{R1680x1050, R640x384};
-use crate::basic_func::{get_second_largest_resolution, local_time_hms, TestResolution};
+use crate::basic_func::{get_second_largest_resolution, handle_reset_nvml_cooler_single_gpu, local_time_hms, TestResolution};
 use crate::error::Error;
-use crate::handle_reset_nvml_cooler_single_gpu;
 use crate::human::print_scan_separator;
+use nvml_wrapper::Nvml;
 use crate::nvidia_gpu_type::{fetch_gpu_type, GpuOcParams};
 use crate::oc_get_set_function_nvapi::{
     core_reset_vfp, get_resolution, get_voltage_by_point, handle_lock_vfp,
@@ -1195,6 +1195,7 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
 
 pub fn autoscan_gpuboostv3(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(), Error> {
     use crate::autoscan_config::AutoscanConfig;
+    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML init failed in autoscan: {:?}", e)))?;
     let cfg = AutoscanConfig::from_autoscan_matches(matches)?;
 
     let mut is_ultrafast = cfg.is_ultrafast;
@@ -1710,7 +1711,7 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(),
             );
         }
         gpu.reset_cooler_levels().unwrap_or_else(|_e| {
-            handle_reset_nvml_cooler_single_gpu(gpu, "all")
+            handle_reset_nvml_cooler_single_gpu(&nvml, gpu, "all")
                 .unwrap_or_else(|e| eprintln!("Failed to reset cooler: {e}"))
         })
     }
@@ -1720,6 +1721,7 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(),
 
 pub fn autoscan_legacy(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(), Error> {
     use crate::autoscan_config::AutoscanConfig;
+    let nvml = Nvml::init().map_err(|e| Error::Custom(format!("NVML init failed in autoscan_legacy: {:?}", e)))?;
     let cfg = AutoscanConfig::from_legacy_matches(matches)?;
 
     let test_exe = cfg.test_exe.as_str();
@@ -1884,7 +1886,7 @@ pub fn autoscan_legacy(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(), Err
                     .cloned(),
             )?;
             gpu.reset_cooler_levels().unwrap_or_else(|_e| {
-                handle_reset_nvml_cooler_single_gpu(gpu, "all")
+                handle_reset_nvml_cooler_single_gpu(&nvml, gpu, "all")
                     .unwrap_or_else(|e| eprintln!("Failed to reset cooler: {e}"))
             })
         }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Addresses **issue #4** — autooptimizer library encapsulation, GPU enumeration, and NVAPI-NVML dual-path architecture. This is a prerequisite for issue #5 (autoscan architecture split).

### 1. GPU selection decoupled from clap (library-ready)

- `select_gpus` / `select_gpu_ids` now accept `Option<&[String]>` instead of `clap::parser::ValuesRef` — removing the CLI framework dependency from library-facing functions
- All handler functions (`handle_info`, `handle_status`, `handle_get`, `handle_reset`, `handle_reset_nvml_cooler`) now accept **pre-selected** `&[&Gpu]` slices; selection happens exactly once in `main.rs`
- Inner functions no longer know about GPU enumeration — they only receive what they need

### 2. NVML re-initialization eliminated

- Added `find_nvml_device` / `find_nvml_device_err` private helpers in `oc_get_set_function_nvml.rs` that locate a device by PCI bus without re-enumerating
- All 20+ public NVML functions now accept `&Nvml` as **first parameter** instead of calling `Nvml::init()` internally on every invocation
- `oc_scanner`: NVML initialized **once** at the top of `autoscan_gpuboostv3` and `autoscan_legacy`, passed to `handle_reset_nvml_cooler_single_gpu`

### 3. NVAPI-NVML dual-path for basic operations

- **`info`**: Full NVAPI path (complete detail) + NVML-only fallback via `handle_info_nvml_only` (name, UUID, PCI, VRAM, compute capability, clocks)
- **`status`**: Full NVAPI path + NVML-only fallback via `handle_status_nvml_only` (temperature, power usage, utilization, clocks, fan speed, P-state)
- **`main.rs`** selects the appropriate path at runtime based on which backends initialized successfully — no hard failure when NVAPI is unavailable

This enables the auto-optimizer to function on **Windows + server/professional GPU environments** where NvAPI cannot initialize, and lays the groundwork for library encapsulation (issue #3).

## Files changed

| File | Change |
|------|--------|
| `oc_get_set_function_nvml.rs` | Full rewrite: `find_nvml_device` helper, all functions accept `&Nvml` |
| `basic_func.rs` | `select_gpus`/`select_gpu_ids` decoupled from clap; handlers accept pre-selected GPUs; NVML fallbacks added |
| `main.rs` | GPU selection moved to outer layer; `nvml` threaded through; NVML fallback paths for info/status |
| `human.rs` | `print_info` accepts `Option<&Nvml>` |
| `oc_get_set_function_nvapi.rs` | `set_nvapi_pstate_lock` and `get_gpu_tdp_temp_limit` accept `&Nvml`/`Option<&Nvml>` |
| `oc_scanner.rs` | NVML initialized once per scan; passed to fan reset helper |
| `oc_profile_function.rs` | Updated `get_gpu_tdp_temp_limit` call site |

## Test plan

- [ ] Build succeeds (`cargo check` passes with zero warnings)
- [ ] `nvoc info` works via NVAPI path on consumer GPU
- [ ] `nvoc status` works via NVAPI path  
- [ ] `nvoc get` works with both NVAPI + NVML data
- [ ] `nvoc set nvml --core-offset 50` routes through NVML path correctly
- [ ] On server GPU (NVAPI unavailable): `nvoc info` falls back to NVML output
- [ ] On server GPU: `nvoc status` falls back to NVML output
- [ ] Autoscan initializes NVML once, not per fan-reset cycle

https://claude.ai/code/session_01YSRSr5tKSC4iSAV4quCRxw
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSRSr5tKSC4iSAV4quCRxw)_