### PR TITLE
fix(auto-optimizer): memory autoscan progress always shows 0.00% (integer division)

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -1103,7 +1103,9 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
 
         println!(
             "current test progress estimated:{:.2}%",
-            (mem_test_num + mem_test_code - 1) / (args.mem_freq_step_exp + mem_test_code - 1)
+            (mem_test_num + mem_test_code - 1) as f64
+                / (args.mem_freq_step_exp + mem_test_code - 1) as f64
+                * 100.0
         );
         println!("current test num: {}", mem_test_num);
 


### PR DESCRIPTION
## Summary

Fixes #17.

The memory OC phase in `run_mem_oc_phase` computed its progress percentage via integer (`usize`) division, so `{:.2}%` received an already-truncated value of `0` or `1` — printing `0.00%` for the entire scan and `1.00%` at the very last step. The progress indicator was effectively useless and could cause users to abort a healthy, long-running autoscan thinking it had hung.

## Root cause

```rust
// Before — usize / usize truncates before format runs
(mem_test_num + mem_test_code - 1) / (args.mem_freq_step_exp + mem_test_code - 1)
```

## Fix

Cast both operands to `f64` and multiply by 100.0, matching the identical pattern already used correctly in the core-OC short-test phase (L594) and long-test phase (L874):

```rust
// After
(mem_test_num + mem_test_code - 1) as f64
    / (args.mem_freq_step_exp + mem_test_code - 1) as f64
    * 100.0
```

No behaviour change on the happy path; only the formatting is corrected.

## Scope

- Single-line arithmetic fix in `auto-optimizer/src/oc_scanner.rs:1106`
- No struct changes, no API changes, no test infrastructure required
- All three `progress estimated` print sites in the file are now consistent

## Test plan

- [ ] `grep` confirms no remaining `usize / usize` before a `%` format in `oc_scanner.rs` — verified in this PR
- [ ] Manual: run `nvoc set vfp autoscan` with memory phase enabled; observe progress percentage increases smoothly from `0.00%` toward `100.00%` instead of staying at `0.00%`

https://claude.ai/code/session_01Rowi9cN3DZPthBaNdzrCT6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rowi9cN3DZPthBaNdzrCT6)_