### PR TITLE
fix(auto-optimizer): prevent u32 overflow in set_legacy_clocks_nvapi before unsafe FFI (closes #16)

### DIFF
--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -152,6 +152,22 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                                 .map_err(|_| "Invalid integer for core frequency")?;
                             let mem_mhz = matches.get_one::<String>("memory").unwrap().parse::<u32>()
                                 .map_err(|_| "Invalid integer for memory frequency")?;
+
+                            const MIN_LEGACY_MHZ: u32 = 100;
+                            const MAX_LEGACY_MHZ: u32 = 5_000;
+                            if !(MIN_LEGACY_MHZ..=MAX_LEGACY_MHZ).contains(&core_mhz) {
+                                return Err(format!(
+                                    "--core {} MHz is outside the supported legacy range {}..={}",
+                                    core_mhz, MIN_LEGACY_MHZ, MAX_LEGACY_MHZ
+                                ).into());
+                            }
+                            if !(MIN_LEGACY_MHZ..=MAX_LEGACY_MHZ).contains(&mem_mhz) {
+                                return Err(format!(
+                                    "--memory {} MHz is outside the supported legacy range {}..={}",
+                                    mem_mhz, MIN_LEGACY_MHZ, MAX_LEGACY_MHZ
+                                ).into());
+                            }
+
                             for gpu in &gpus {
                                 match set_legacy_clocks_nvapi(gpu, core_mhz, mem_mhz) {
                                     Ok(_) => println!("Legacy clock applied to GPU: Core = {} MHz, Mem = {} MHz", core_mhz, mem_mhz),

--- a/auto-optimizer/src/oc_get_set_function_nvapi.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvapi.rs
@@ -1502,8 +1502,9 @@ pub fn set_legacy_clocks_nvapi(gpu: &Gpu, core_mhz: u32, mem_mhz: u32) -> Result
     };
 
     // 结合以前的逆向记录进行反向运算，乘以倍率使其满足旧结构格式要求
-    info.clocks[8] = mem_mhz * 1000;
-    info.clocks[30] = core_mhz * 2000;
+    // saturating_mul prevents silent wrap-around overflow before the unsafe FFI call
+    info.clocks[8] = mem_mhz.saturating_mul(1000);
+    info.clocks[30] = core_mhz.saturating_mul(2000);
 
     unsafe {
         // 1. 获取隐藏函数指针


### PR DESCRIPTION
## Summary

Fixes **issue #16** — `set_legacy_clocks_nvapi` could silently wrap (release) or panic (debug) on user-supplied MHz values before passing the corrupted `NvClocksInfo` struct to an undocumented NvAPI legacy interface.

Two-layer fix, both changes are minimal and surgical:

### Layer 1 — Saturating multiply at the FFI call site (`oc_get_set_function_nvapi.rs`)

```rust
// Before (overflows for mem_mhz > 4_294_967 / core_mhz > 2_147_483)
info.clocks[8]  = mem_mhz  * 1000;
info.clocks[30] = core_mhz * 2000;

// After
info.clocks[8]  = mem_mhz.saturating_mul(1000);
info.clocks[30] = core_mhz.saturating_mul(2000);
```

`saturating_mul` clamps to `u32::MAX` instead of wrapping, eliminating the silent corruption path on the hot path immediately before the `unsafe` block. Happy-path behavior is unchanged.

### Layer 2 — Range validation at parse time (`main.rs`, `legacy-clock` arm)

```rust
const MIN_LEGACY_MHZ: u32 = 100;
const MAX_LEGACY_MHZ: u32 = 5_000;
if !(MIN_LEGACY_MHZ..=MAX_LEGACY_MHZ).contains(&core_mhz) {
    return Err(format!("--core {} MHz is outside the supported legacy range {}..={}",
                       core_mhz, MIN_LEGACY_MHZ, MAX_LEGACY_MHZ).into());
}
// same for mem_mhz
```

Out-of-range inputs are rejected with a clear error message before they reach the FFI call site at all. The bounds (100–5000 MHz) are generous and cover any real Maxwell-era GPU clock.

## Root cause

The overflow was inherent in using `*` on `u32` values that the user fully controls. The scale factors (`×1000`, `×2000`) overflow at inputs that look plausibly large (`--core 5000000`) but are still valid `u32` values — exactly the case where a user would expect a clean error and instead gets a wrapped value sent to a fragile undocumented driver interface.

## Test plan

- [ ] `cargo check` passes with no new warnings
- [ ] `cargo build --release` succeeds
- [ ] `nvoc set nvapi legacy-clock --core 2000 --memory 4000` works as before
- [ ] `nvoc set nvapi legacy-clock --core 99` returns error: `--core 99 MHz is outside the supported legacy range 100..=5000`
- [ ] `nvoc set nvapi legacy-clock --core 5001` returns error: `--core 5001 MHz is outside the supported legacy range 100..=5000`
- [ ] `nvoc set nvapi legacy-clock --core 2147484` no longer silently wraps (blocked by range check)

## Out of scope

Per issue #16, a wider audit of the `transmute`d function pointer and guessed struct version in the same `unsafe` block is a separate follow-up.

https://claude.ai/code/session_0171xUTc3XAhuW1x7zBkszSo

---
_Generated by [Claude Code](https://claude.ai/code/session_0171xUTc3XAhuW1x7zBkszSo)_