### PR TITLE
fix(auto-optimizer): correct integer division in memory autoscan progress %

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -1101,9 +1101,15 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
 
         pre_load_vf_recheck(args.common.matches, args.point);
 
+        let mem_denom = (args.mem_freq_step_exp + mem_test_code - 1) as f64;
+        let mem_progress_pct = if mem_denom > 0.0 {
+            (mem_test_num + mem_test_code - 1) as f64 / mem_denom * 100.0
+        } else {
+            0.0
+        };
         println!(
             "current test progress estimated:{:.2}%",
-            (mem_test_num + mem_test_code - 1) / (args.mem_freq_step_exp + mem_test_code - 1)
+            mem_progress_pct
         );
         println!("current test num: {}", mem_test_num);
 


### PR DESCRIPTION
## Summary

Fixes #17

The memory autoscan progress line at `oc_scanner.rs:1104–1107` computed:

```rust
(mem_test_num + mem_test_code - 1) / (args.mem_freq_step_exp + mem_test_code - 1)
```

All operands are `usize`, so this is integer division — the result is always `0` or `1` before `{:.2}%` ever runs. The user sees `0.00%` for the entire scan and `1.00%` at the very end.

## Root cause

`usize / usize` truncates. The `{:.2}` format spec applies to an already-truncated integer, so fractional precision is meaningless. The core-OC phase (line ~594) and the second core-OC path (line ~874) both do this correctly by casting to `f64` first.

## Fix

Cast both sides to `f64` and multiply by `100.0`, matching the existing correct pattern. Also added a divide-by-zero guard for the edge case where `mem_freq_step_exp == 0`:

```rust
let mem_denom = (args.mem_freq_step_exp + mem_test_code - 1) as f64;
let mem_progress_pct = if mem_denom > 0.0 {
    (mem_test_num + mem_test_code - 1) as f64 / mem_denom * 100.0
} else {
    0.0
};
println!("current test progress estimated:{:.2}%", mem_progress_pct);
```

## Scope

- Single-site change in `auto-optimizer/src/oc_scanner.rs`
- No logic changes — pure formatting fix
- `oc_profile_function.rs` was audited and has no similar pattern
- `cargo check` passes clean

## Test plan

- [ ] Run `nvoc set vfp autoscan` with a memory phase enabled and confirm the progress percentage now increments from `0.00%` toward `100.00%` across iterations instead of staying at `0.00%`

https://claude.ai/code/session_01BBV8VCYQD5EaoamBM2Wtzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBV8VCYQD5EaoamBM2Wtzh)_