### PR TITLE
fix(auto-optimizer): replace SystemTime with Instant for fluctuation pacing

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -24,7 +24,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Child, Command};
 use std::thread::sleep;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 use std::{fs, iter};
 
 
@@ -226,7 +226,7 @@ mod pressure_runner {
                 Ok(mut process) => {
                     let mut exit_code = 1;
                     let test_start_at = Instant::now();
-                    let mut last_fluctuation = SystemTime::now();
+                    let mut last_fluctuation = Instant::now();
                     let mut in_test_check_number = 0;
                     let mut fluctuation_h_l_flag = false;
                     let mut thrm_or_pwr_limit_number = 0;
@@ -243,8 +243,7 @@ mod pressure_runner {
                     sleep(Duration::from_secs(1));
 
                     loop {
-                        if last_fluctuation.elapsed().unwrap_or(Duration::from_secs(6))
-                            >= Duration::from_millis(1500)
+                        if last_fluctuation.elapsed() >= Duration::from_millis(1500)
                         {
                             in_test_check_number += 1;
                             println!("inducing freq fluctuation...");
@@ -295,7 +294,7 @@ mod pressure_runner {
                                 }
                             }
 
-                            last_fluctuation = SystemTime::now();
+                            last_fluctuation = Instant::now();
                         }
 
                         sleep(time::Duration::from_secs(1));


### PR DESCRIPTION
## Summary

Fixes #18

Replaces the three `SystemTime` usages in `pressure_runner::run` with `Instant`:

- `let mut last_fluctuation = Instant::now()` (was `SystemTime::now()`)
- `if last_fluctuation.elapsed() >= Duration::from_millis(1500)` — `Instant::elapsed()` is infallible, so the `.unwrap_or(Duration::from_secs(6))` fallback is dropped entirely
- `last_fluctuation = Instant::now()` (was `SystemTime::now()`)

The import `SystemTime` is removed as it is now unused.

## Root cause

`SystemTime` is a wall-clock that can move backward (NTP correction at boot/resume, VM time drift, manual clock change). When `elapsed()` returns `Err`, the old code substituted `Duration::from_secs(6)`, which is **larger** than the 1.5 s trigger threshold — so the fluctuation step fired on every 1-second tick rather than every 1.5 seconds for the duration of the slip. This silently inflated `in_test_check_number` and diluted the `thrm_or_pwr_limit_number / in_test_check_number` throttle-detection ratio, causing the scanner to report a point as stable when the GPU was actually capping.

`Instant` is monotonic and infallible — it cannot go backward, and `elapsed()` returns `Duration` directly with no `Result` wrapper.

## Files changed

- `auto-optimizer/src/oc_scanner.rs` — 4 lines changed (3 substitutions + 1 import cleanup)

## Test plan

- [ ] Build `auto-optimizer` crate (`cargo build -p auto-optimizer`) — should compile without warnings on the changed file
- [ ] Run autoscan on a supported GPU; confirm `inducing freq fluctuation...` appears at ~1.5 s intervals, not every second
- [ ] Simulate clock skew (`sudo date -s "$(date -d '-2 seconds')"`) mid-run and verify fluctuation rate does **not** spike

https://claude.ai/code/session_012ezBNMtT2ssfLgWcUTLRbN

---
_Generated by [Claude Code](https://claude.ai/code/session_012ezBNMtT2ssfLgWcUTLRbN)_