### PR TITLE
fix(auto-optimizer): fix integer division in memory autoscan progress percentage

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -1103,7 +1103,9 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
 
         println!(
             "current test progress estimated:{:.2}%",
-            (mem_test_num + mem_test_code - 1) / (args.mem_freq_step_exp + mem_test_code - 1)
+            (mem_test_num + mem_test_code - 1) as f64
+                / (args.mem_freq_step_exp + mem_test_code - 1).max(1) as f64
+                * 100.0
         );
         println!("current test num: {}", mem_test_num);
 


### PR DESCRIPTION
## Summary

Fixes #17.

The memory OC phase progress print in `oc_scanner.rs:1104-1107` performed `usize / usize` division before passing the result to `{:.2}%` formatting. Because integer division truncates, the displayed value was always `0.00%` until the very end of the run, then briefly `1.00%` — completely defeating the purpose of the indicator during what can be a multi-minute memory autoscan.

**Root cause:** missing `as f64` casts and `* 100.0` multiplier, unlike the two correct implementations already present in the same file (core-OC phase at ~L593, second variant at ~L873).

## Change

`auto-optimizer/src/oc_scanner.rs` line ~1104:

```rust
// Before (integer division → always 0 or 1)
(mem_test_num + mem_test_code - 1) / (args.mem_freq_step_exp + mem_test_code - 1)

// After (matches correct pattern used elsewhere in the file)
(mem_test_num + mem_test_code - 1) as f64
    / (args.mem_freq_step_exp + mem_test_code - 1).max(1) as f64
    * 100.0
```

`.max(1)` guards against division-by-zero on the first iteration when `mem_freq_step_exp` is 0 (denominator underflows to 0 when `mem_test_code == 1`).

## Scope

- Single-line arithmetic fix in one location; no API or behaviour changes.
- The two other progress prints in the file (`~L593`, `~L873`) already use the correct `f64` pattern — confirmed by grep; no further changes needed.
- `oc_profile_function.rs` uses integer `{}` formatting for a similar expression — that is intentional and untouched.

## Test plan

- [ ] `cargo check` passes (verified locally).
- [ ] Run `nvoc set vfp autoscan` with a memory phase enabled; confirm the progress percentage now increments smoothly from `0.00%` toward `100.00%` across the run.

https://claude.ai/code/session_01AQ829YfAzn4Bki77ZYYyNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ829YfAzn4Bki77ZYYyNZ)_