### PR TITLE
fix(auto-optimizer): prevent u32 overflow in set_legacy_clocks_nvapi (#16)

### DIFF
--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -152,6 +152,26 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                                 .map_err(|_| "Invalid integer for core frequency")?;
                             let mem_mhz = matches.get_one::<String>("memory").unwrap().parse::<u32>()
                                 .map_err(|_| "Invalid integer for memory frequency")?;
+
+                            // Reject values outside a generous but finite window.
+                            // The internal scale factors are ×2000 (core) and ×1000 (mem);
+                            // anything above 5 000 MHz would produce a u32 overflow even
+                            // with saturating_mul, and no real Fermi/Kepler GPU runs there.
+                            const MIN_LEGACY_MHZ: u32 = 100;
+                            const MAX_LEGACY_MHZ: u32 = 5_000;
+                            if !(MIN_LEGACY_MHZ..=MAX_LEGACY_MHZ).contains(&core_mhz) {
+                                return Err(format!(
+                                    "--core {} MHz is outside the supported legacy range {}–{} MHz",
+                                    core_mhz, MIN_LEGACY_MHZ, MAX_LEGACY_MHZ
+                                ).into());
+                            }
+                            if !(MIN_LEGACY_MHZ..=MAX_LEGACY_MHZ).contains(&mem_mhz) {
+                                return Err(format!(
+                                    "--memory {} MHz is outside the supported legacy range {}–{} MHz",
+                                    mem_mhz, MIN_LEGACY_MHZ, MAX_LEGACY_MHZ
+                                ).into());
+                            }
+
                             for gpu in &gpus {
                                 match set_legacy_clocks_nvapi(gpu, core_mhz, mem_mhz) {
                                     Ok(_) => println!("Legacy clock applied to GPU: Core = {} MHz, Mem = {} MHz", core_mhz, mem_mhz),

--- a/auto-optimizer/src/oc_get_set_function_nvapi.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvapi.rs
@@ -1502,8 +1502,11 @@ pub fn set_legacy_clocks_nvapi(gpu: &Gpu, core_mhz: u32, mem_mhz: u32) -> Result
     };
 
     // 结合以前的逆向记录进行反向运算，乘以倍率使其满足旧结构格式要求
-    info.clocks[8] = mem_mhz * 1000;
-    info.clocks[30] = core_mhz * 2000;
+    // Use saturating_mul so that any out-of-range value saturates to u32::MAX
+    // rather than wrapping silently in release builds. The range check in the
+    // caller (main.rs) is the primary guard; this is the backstop.
+    info.clocks[8]  = mem_mhz.saturating_mul(1000);
+    info.clocks[30] = core_mhz.saturating_mul(2000);
 
     unsafe {
         // 1. 获取隐藏函数指针


### PR DESCRIPTION
## Summary

Fixes #16 — `set_legacy_clocks_nvapi` multiplied user-supplied MHz values by fixed scale factors (`×2000` core, `×1000` mem) using plain `u32` arithmetic, which panics in debug builds and silently wraps in release builds, then writes garbage into the `NvClocksInfo` struct passed to the undocumented `NvAPI_GPU_SetClocks` legacy interface.

## Root cause

```rust
info.clocks[8]  = mem_mhz  * 1000;   // overflows for mem_mhz  > 4 294 967
info.clocks[30] = core_mhz * 2000;   // overflows for core_mhz > 2 147 483
```

No range check existed upstream; `main.rs` accepted any value `u32` could represent.

## Fix — two layers

### 1. Primary: range guard at parse time (`main.rs`)

Rejects `--core` / `--memory` values outside `100–5 000 MHz` before anything reaches unsafe FFI. 5 000 MHz is well above any real Fermi/Kepler clock speed and well below the overflow threshold.

```rust
const MIN_LEGACY_MHZ: u32 = 100;
const MAX_LEGACY_MHZ: u32 = 5_000;
if !(MIN_LEGACY_MHZ..=MAX_LEGACY_MHZ).contains(&core_mhz) {
    return Err(format!("--core {} MHz is outside the supported legacy range {}–{} MHz", ...).into());
}
```

### 2. Backstop: saturating multiply at the assignment site (`oc_get_set_function_nvapi.rs`)

Replaces `*` with `.saturating_mul()` so any value that somehow bypasses the guard saturates to `u32::MAX` instead of wrapping silently.

```rust
info.clocks[8]  = mem_mhz.saturating_mul(1000);
info.clocks[30] = core_mhz.saturating_mul(2000);
```

## Test plan

- [ ] `nvoc set legacy-clock --core 800 --memory 1000` — succeeds (normal Fermi range)
- [ ] `nvoc set legacy-clock --core 50 --memory 1000` — rejected with clear message (`< 100 MHz`)
- [ ] `nvoc set legacy-clock --core 6000 --memory 1000` — rejected with clear message (`> 5 000 MHz`)
- [ ] `nvoc set legacy-clock --core 2147484 --memory 1000` — rejected (previously would silently wrap to 200 in release build)
- [ ] `cargo build` on both debug and release profiles — no new warnings

https://claude.ai/code/session_0172r8asywVHPPSosGB598ho

---
_Generated by [Claude Code](https://claude.ai/code/session_0172r8asywVHPPSosGB598ho)_