### PR TITLE
fix(auto-optimizer): replace SystemTime with Instant for fluctuation pacing

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -24,7 +24,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Child, Command};
 use std::thread::sleep;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 use std::{fs, iter};
 
 
@@ -226,7 +226,7 @@ mod pressure_runner {
                 Ok(mut process) => {
                     let mut exit_code = 1;
                     let test_start_at = Instant::now();
-                    let mut last_fluctuation = SystemTime::now();
+                    let mut last_fluctuation = Instant::now();
                     let mut in_test_check_number = 0;
                     let mut fluctuation_h_l_flag = false;
                     let mut thrm_or_pwr_limit_number = 0;
@@ -243,8 +243,7 @@ mod pressure_runner {
                     sleep(Duration::from_secs(1));
 
                     loop {
-                        if last_fluctuation.elapsed().unwrap_or(Duration::from_secs(6))
-                            >= Duration::from_millis(1500)
+                        if last_fluctuation.elapsed() >= Duration::from_millis(1500)
                         {
                             in_test_check_number += 1;
                             println!("inducing freq fluctuation...");
@@ -295,7 +294,7 @@ mod pressure_runner {
                                 }
                             }
 
-                            last_fluctuation = SystemTime::now();
+                            last_fluctuation = Instant::now();
                         }
 
                         sleep(time::Duration::from_secs(1));


### PR DESCRIPTION
## Summary

Fixes #18.

The autoscan inner loop (`pressure_runner::run`) paced its "freq fluctuation" trigger using `SystemTime`, a wall-clock that can move backward. When `elapsed()` returned `Err` after a clock slip, the `unwrap_or(Duration::from_secs(6))` substituted 6 s — larger than the 1.5 s trigger threshold — so the fluctuation step fired on every 1-second loop tick until the clock recovered. This silently inflated `in_test_check_number` and diluted the throttling-detection ratio computed at line 333-335, potentially masking real thermal/power-cap events and declaring an unstable OC point as stable.

`Instant` is monotonic and infallible; its `elapsed()` returns `Duration` directly so the `unwrap_or` chain disappears entirely.

## Changes

- `auto-optimizer/src/oc_scanner.rs`
  - `last_fluctuation` declaration: `SystemTime::now()` → `Instant::now()` (line 229)
  - Elapsed guard: `.elapsed().unwrap_or(Duration::from_secs(6))` → `.elapsed()` (line 246)
  - Reset after firing: `SystemTime::now()` → `Instant::now()` (line 298)
  - Removes now-unused `SystemTime` from the `use std::time` import

No logic changes outside these four lines; all callers are unaffected.

## Test plan

- [ ] `cargo check` passes (verified locally — clean, zero warnings)
- [ ] `cargo clippy` passes
- [ ] Manual: run autoscan, then `sudo date -s "$(date -d '-2 seconds')"` mid-run and confirm `inducing freq fluctuation...` still fires at ~1.5 s intervals rather than every second

https://claude.ai/code/session_01MiHWtF4zRxZhsMEfjTSB86

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiHWtF4zRxZhsMEfjTSB86)_