### PR TITLE
fix(auto-optimizer): pre_load_vf_recheck panics on recoverable v-f read failure

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -507,10 +507,11 @@ fn apply_short_phase_success_step(
     Some(increase)
 }
 
-fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) {
+fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) -> Result<(), Error> {
     println!("Waiting for pre-load volt-freq recheck");
     sleep(Duration::from_secs(1));
-    voltage_frequency_check(matches.clone(), point).expect("Failed to read v-f info");
+    voltage_frequency_check(matches.clone(), point)?;
+    Ok(())
 }
 
 fn apply_long_phase_failure_step(
@@ -844,7 +845,10 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
             Some(*init_core_oc_value - args.common.minimum_delta_core_freq_step),
         )?;
 
-        pre_load_vf_recheck(args.common.matches, point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         test_num += 1;
         test_code += 1;
@@ -986,7 +990,10 @@ fn run_gpuboostv3_long_phase<V: std::fmt::Display + Copy>(
     writeln!(l, "Initiating Long Test...")?;
 
     loop {
-        pre_load_vf_recheck(args.common.matches, point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         *test_code += 1;
         log_point_test_header(
@@ -1099,7 +1106,10 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
         mem_test_num += 1;
         mem_test_code += 1;
 
-        pre_load_vf_recheck(args.common.matches, args.point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, args.point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         println!(
             "current test progress estimated:{:.2}%",


### PR DESCRIPTION
## Summary

Fixes #15.

`pre_load_vf_recheck` was calling `voltage_frequency_check(...).expect(...)`, which panics the entire autoscan binary on the first transient NvAPI v-f read failure. Every other call site in `oc_scanner.rs` handles the error gracefully; this was the one outlier.

### Changes

**`auto-optimizer/src/oc_scanner.rs`**

- Changed `pre_load_vf_recheck` signature from `fn(...) -> ()` to `fn(...) -> Result<(), Error>`, replacing `.expect()` with the `?` operator.
- At all three call sites (short phase loop, long phase loop, memory OC phase loop), replaced the bare call with an `if let Err(e)` block that logs a warning and `break`s out of the inner loop — matching the established pattern at line 258.

No behavior change on the happy path. On a transient v-f read failure the scan now breaks out of the current point's inner loop and lets the outer loop decide whether to continue, rather than crashing the process.

## Test plan

- [ ] `cargo check` passes (verified locally — clean compile)
- [ ] `cargo build --release` passes
- [ ] Manual: in a test env, inject a `Err(...)` return from `voltage_frequency_check` during pre-load; confirm the scan exits the inner loop with a warning instead of panicking

https://claude.ai/code/session_01K5CiArGdSHjh6bvBXnW9qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5CiArGdSHjh6bvBXnW9qA)_