### PR TITLE
fix(auto-optimizer): pre_load_vf_recheck propagates v-f errors instead of panicking (closes #15)

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -507,10 +507,11 @@ fn apply_short_phase_success_step(
     Some(increase)
 }
 
-fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) {
+fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) -> Result<(), Error> {
     println!("Waiting for pre-load volt-freq recheck");
     sleep(Duration::from_secs(1));
-    voltage_frequency_check(matches.clone(), point).expect("Failed to read v-f info");
+    voltage_frequency_check(matches.clone(), point)?;
+    Ok(())
 }
 
 fn apply_long_phase_failure_step(
@@ -844,7 +845,7 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
             Some(*init_core_oc_value - args.common.minimum_delta_core_freq_step),
         )?;
 
-        pre_load_vf_recheck(args.common.matches, point);
+        pre_load_vf_recheck(args.common.matches, point)?;
 
         test_num += 1;
         test_code += 1;
@@ -986,7 +987,7 @@ fn run_gpuboostv3_long_phase<V: std::fmt::Display + Copy>(
     writeln!(l, "Initiating Long Test...")?;
 
     loop {
-        pre_load_vf_recheck(args.common.matches, point);
+        pre_load_vf_recheck(args.common.matches, point)?;
 
         *test_code += 1;
         log_point_test_header(
@@ -1099,7 +1100,7 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
         mem_test_num += 1;
         mem_test_code += 1;
 
-        pre_load_vf_recheck(args.common.matches, args.point);
+        pre_load_vf_recheck(args.common.matches, args.point)?;
 
         println!(
             "current test progress estimated:{:.2}%",


### PR DESCRIPTION
## Root cause

`pre_load_vf_recheck` called `voltage_frequency_check(...).expect("Failed to read v-f info")`, panicking — and killing — the entire autoscan binary on the first transient NvAPI read failure. Every other call site of `voltage_frequency_check` in `oc_scanner.rs` uses a `match` or `?` to handle errors gracefully; this one was an outlier.

Closes #15.

## Change

**`oc_scanner.rs:510-514`** — function signature + body (1 line changed):
```rust
// Before
fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) {
    println!("Waiting for pre-load volt-freq recheck");
    sleep(Duration::from_secs(1));
    voltage_frequency_check(matches.clone(), point).expect("Failed to read v-f info");
}

// After
fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) -> Result<(), Error> {
    println!("Waiting for pre-load volt-freq recheck");
    sleep(Duration::from_secs(1));
    voltage_frequency_check(matches.clone(), point)?;
    Ok(())
}
```

**Three call sites** — add `?` to propagate the error (each a 1-char change):
- `oc_scanner.rs:847` — `run_gpuboostv3_short_phase` inner loop
- `oc_scanner.rs:989` — `run_gpuboostv3_long_phase` inner loop
- `oc_scanner.rs:1102` — `run_mem_oc_phase` inner loop

All three enclosing functions already return `Result<_, Error>` and are themselves called with `?` from `autoscan_gpuboostv3`, so the error propagates cleanly up to the outer autoscan loop without touching the panic path.

## Behavior

| Scenario | Before | After |
|---|---|---|
| `voltage_frequency_check` returns `Ok(true/false)` | continues (same) | continues (same) |
| `voltage_frequency_check` returns `Err(e)` | **panics entire binary**, no checkpoint written | returns `Err(e)`, outer scan loop handles gracefully |

## Test plan
- [ ] `cargo check` passes (verified locally — zero warnings)
- [ ] On a live GPU: autoscan happy path completes normally
- [ ] Monkey-patch / mock `voltage_frequency_check` to return `Err(...)` on second call → autoscan logs the error and exits the current point instead of panicking

https://claude.ai/code/session_015vSN1KXdtFysvdkdP4288F

---
_Generated by [Claude Code](https://claude.ai/code/session_015vSN1KXdtFysvdkdP4288F)_