### PR TITLE
fix(auto-optimizer): replace SystemTime with Instant for fluctuation pacing

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -24,7 +24,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Child, Command};
 use std::thread::sleep;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 use std::{fs, iter};
 
 
@@ -226,7 +226,7 @@ mod pressure_runner {
                 Ok(mut process) => {
                     let mut exit_code = 1;
                     let test_start_at = Instant::now();
-                    let mut last_fluctuation = SystemTime::now();
+                    let mut last_fluctuation = Instant::now();
                     let mut in_test_check_number = 0;
                     let mut fluctuation_h_l_flag = false;
                     let mut thrm_or_pwr_limit_number = 0;
@@ -243,8 +243,7 @@ mod pressure_runner {
                     sleep(Duration::from_secs(1));
 
                     loop {
-                        if last_fluctuation.elapsed().unwrap_or(Duration::from_secs(6))
-                            >= Duration::from_millis(1500)
+                        if last_fluctuation.elapsed() >= Duration::from_millis(1500)
                         {
                             in_test_check_number += 1;
                             println!("inducing freq fluctuation...");
@@ -295,7 +294,7 @@ mod pressure_runner {
                                 }
                             }
 
-                            last_fluctuation = SystemTime::now();
+                            last_fluctuation = Instant::now();
                         }
 
                         sleep(time::Duration::from_secs(1));


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #18 — `SystemTime` was used to pace the fluctuation timer in `pressure_runner::run` (`oc_scanner.rs`). Because `SystemTime` is a wall-clock it can move backward (NTP correction, manual clock change, VM time drift), making `elapsed()` fallible. The `unwrap_or(Duration::from_secs(6))` fallback was **larger** than the 1.5 s trigger threshold, so any clock slip caused the fluctuation step to fire on every loop iteration instead of once per 1.5 s — artificially inflating `in_test_check_number` and diluting the `thrm_or_pwr_limit_number / in_test_check_number` ratio that decides whether a V-F point is stable.

`Instant` is monotonic and its `elapsed()` is infallible, making it the correct primitive for all pacing/timeout work. The same function already used `Instant` for `test_start_at`; this makes `last_fluctuation` consistent.

## Changes

| File | What changed |
|---|---|
| `auto-optimizer/src/oc_scanner.rs:27` | Removed `SystemTime` from import (no longer used) |
| `auto-optimizer/src/oc_scanner.rs:229` | `SystemTime::now()` → `Instant::now()` |
| `auto-optimizer/src/oc_scanner.rs:246` | Dropped `.unwrap_or(Duration::from_secs(6))` — `Instant::elapsed()` is infallible |
| `auto-optimizer/src/oc_scanner.rs:298` | `SystemTime::now()` → `Instant::now()` |

**Scope confirmed:** the only other `SystemTime` use in the repo is `srv/src/bin/nvoc_service.rs:266` for a wall-clock log timestamp — intentional and left untouched.

## Test plan

- [x] `cargo check` passes clean on `auto-optimizer`
- [ ] Run autoscan through at least one full short+long cycle on a test machine
- [ ] Simulate clock slip (`sudo date -s "$(date -d '-2 seconds')"`) mid-run and confirm fluctuation rate stays at ~0.67 Hz

https://claude.ai/code/session_01DLH4rgJcwoDHTJ6txitHri
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLH4rgJcwoDHTJ6txitHri)_