### PR TITLE
fix(auto-optimizer): pre_load_vf_recheck panics on recoverable v-f read failure

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -507,10 +507,11 @@ fn apply_short_phase_success_step(
     Some(increase)
 }
 
-fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) {
+fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) -> Result<(), Error> {
     println!("Waiting for pre-load volt-freq recheck");
     sleep(Duration::from_secs(1));
-    voltage_frequency_check(matches.clone(), point).expect("Failed to read v-f info");
+    voltage_frequency_check(matches.clone(), point)?;
+    Ok(())
 }
 
 fn apply_long_phase_failure_step(
@@ -844,7 +845,10 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
             Some(*init_core_oc_value - args.common.minimum_delta_core_freq_step),
         )?;
 
-        pre_load_vf_recheck(args.common.matches, point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         test_num += 1;
         test_code += 1;
@@ -986,7 +990,10 @@ fn run_gpuboostv3_long_phase<V: std::fmt::Display + Copy>(
     writeln!(l, "Initiating Long Test...")?;
 
     loop {
-        pre_load_vf_recheck(args.common.matches, point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         *test_code += 1;
         log_point_test_header(
@@ -1099,7 +1106,10 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
         mem_test_num += 1;
         mem_test_code += 1;
 
-        pre_load_vf_recheck(args.common.matches, args.point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, args.point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         println!(
             "current test progress estimated:{:.2}%",


### PR DESCRIPTION
## Summary

Fixes #15.

`pre_load_vf_recheck` used `.expect()` on the result of `voltage_frequency_check`, panicking the entire autoscan binary on the first transient NvAPI v-f read failure. Every other call site in `oc_scanner.rs` breaks the inner loop and logs a warning on error — this was the sole outlier.

**Root cause:** `pre_load_vf_recheck` returned `()` instead of `Result`, so it had no way to surface errors to callers.

## Changes

- **`pre_load_vf_recheck` signature** (`oc_scanner.rs:510`): `() → Result<(), Error>`. Use `?` to propagate the error from `voltage_frequency_check` instead of `.expect()`.
- **3 call sites** (`oc_scanner.rs:848, 993, 1109`): pattern-match the result and, on `Err`, `eprintln!` a warning and `break` the inner phase loop — exactly the same pattern as the surrounding scanner logic at lines 264–270. No running stress subprocess exists at these sites (they're pre-load rechecks before `test_pressure` is invoked), so no `force_kill_process` call is needed.

No behavior change on the happy path. A transient read failure now logs a warning and exits the current phase loop cleanly, allowing the outer point-by-point scan loop to decide whether to continue.

## Test plan

- [ ] `cargo build` passes (verified locally — clean build).
- [ ] In a test environment, monkey-patch `voltage_frequency_check` to return `Err(...)` on second invocation; confirm autoscan logs `Warning: Failed to read v-f info: ...` and exits the phase loop rather than panicking.
- [ ] Normal autoscan run (happy path) is unaffected.

https://claude.ai/code/session_018wx6XjykmuDjA6mFRDRzEq

---
_Generated by [Claude Code](https://claude.ai/code/session_018wx6XjykmuDjA6mFRDRzEq)_