### PR TITLE
fix(auto-optimizer): propagate v-f read errors in pre_load_vf_recheck instead of panicking

### DIFF
--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -507,10 +507,11 @@ fn apply_short_phase_success_step(
     Some(increase)
 }
 
-fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) {
+fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) -> Result<(), Error> {
     println!("Waiting for pre-load volt-freq recheck");
     sleep(Duration::from_secs(1));
-    voltage_frequency_check(matches.clone(), point).expect("Failed to read v-f info");
+    voltage_frequency_check(matches.clone(), point)?;
+    Ok(())
 }
 
 fn apply_long_phase_failure_step(
@@ -844,7 +845,10 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
             Some(*init_core_oc_value - args.common.minimum_delta_core_freq_step),
         )?;
 
-        pre_load_vf_recheck(args.common.matches, point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         test_num += 1;
         test_code += 1;
@@ -986,7 +990,10 @@ fn run_gpuboostv3_long_phase<V: std::fmt::Display + Copy>(
     writeln!(l, "Initiating Long Test...")?;
 
     loop {
-        pre_load_vf_recheck(args.common.matches, point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         *test_code += 1;
         log_point_test_header(
@@ -1099,7 +1106,10 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
         mem_test_num += 1;
         mem_test_code += 1;
 
-        pre_load_vf_recheck(args.common.matches, args.point);
+        if let Err(e) = pre_load_vf_recheck(args.common.matches, args.point) {
+            eprintln!("Warning: Failed to read v-f info: {}", e);
+            break;
+        }
 
         println!(
             "current test progress estimated:{:.2}%",


### PR DESCRIPTION
## Summary

Fixes #15.

`pre_load_vf_recheck` used `.expect()` on `voltage_frequency_check`, crashing the entire autoscan binary on the first transient NvAPI/VFP read failure — even though every other call site in the file already handles this gracefully.

## Root cause

```rust
// Before — panics the whole binary on any transient error
fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) {
    println!("Waiting for pre-load volt-freq recheck");
    sleep(Duration::from_secs(1));
    voltage_frequency_check(matches.clone(), point).expect("Failed to read v-f info");
}
```

The function is called at three places inside the autoscan inner loops (short phase, long phase, mem-OC phase), each time *before* a stress subprocess is spawned. Every surrounding in-test check already follows the correct pattern: log a warning, kill the subprocess if one is alive, and `break`.

## Fix

Changed `pre_load_vf_recheck` to return `Result<(), Error>` and propagate via `?`. Updated all three call sites to match the established error-handling pattern — log + `break`:

```rust
// After — consistent with all other call sites
fn pre_load_vf_recheck(matches: &ArgMatches, point: usize) -> Result<(), Error> {
    println!("Waiting for pre-load volt-freq recheck");
    sleep(Duration::from_secs(1));
    voltage_frequency_check(matches.clone(), point)?;
    Ok(())
}
```

```rust
// At each of the three call sites:
if let Err(e) = pre_load_vf_recheck(args.common.matches, point) {
    eprintln!("Warning: Failed to read v-f info: {}", e);
    break;
}
```

No subprocess is alive at any of the three pre-load points, so no kill is needed. Breaking exits the inner scan loop; the outer loop decides whether to continue or stop — exactly the intended behavior.

## Test plan

- [ ] `cargo check` passes (verified locally)
- [ ] `cargo clippy` produces no new warnings on `oc_scanner.rs`
- [ ] Happy path: autoscan with a healthy GPU proceeds identically — `pre_load_vf_recheck` returns `Ok(())`, no observable behavior change
- [ ] Error path: mock `voltage_frequency_check` to return `Err(...)` on the second call — process logs `Warning: Failed to read v-f info: …` and exits the inner loop cleanly instead of panicking

https://claude.ai/code/session_01Ccr3amoKqFLF2WEStnjs4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ccr3amoKqFLF2WEStnjs4q)_