### PR TITLE
fix(validation): replace global-max or-logic with per-element allclose criterion

### DIFF
--- a/cli-stressor-cuda/test.py
+++ b/cli-stressor-cuda/test.py
@@ -192,14 +192,21 @@ def validate_precision(
         return False, float("inf"), float("inf"), "validation produced NaN/Inf"
 
     diff = (out_f32 - ref).abs()
-    max_abs = float(diff.max().item())
-    ref_abs = float(ref.abs().max().item())
-    max_rel = max_abs / (ref_abs + 1e-12)
     abs_thr, rel_thr = choose_tolerance(spec.name)
 
-    # 只要绝对误差或相对误差其中一个仍在可接受范围内，就不判失败。
-    passed = (max_abs <= abs_thr) or (max_rel <= rel_thr)
-    reason = None if passed else f"error too large: abs={max_abs:.4g}, rel={max_rel:.4g}"
+    # Per-element bound: atol + rtol * |ref|  (same convention as torch.allclose / numpy.allclose).
+    # Using a global max-of-diff vs max-of-ref with an `or` would let a single badly-corrupted
+    # element pass whenever the global reference max is large enough to make max_rel look small.
+    elementwise_bound = abs_thr + rel_thr * ref.abs()
+    violated = diff > elementwise_bound
+    n_violated = int(violated.sum().item())
+    max_abs = float(diff.max().item())
+    ref_abs_max = float(ref.abs().max().item())
+    max_rel = max_abs / (ref_abs_max + 1e-12)
+    passed = n_violated == 0
+    reason = (None if passed else
+              f"{n_violated} elements exceed atol+rtol*|ref|; max_abs={max_abs:.4g}, "
+              f"max_rel={max_rel:.4g}")
     return passed, max_abs, max_rel, reason
 
 

--- a/cli-stressor-opencl/test.py
+++ b/cli-stressor-opencl/test.py
@@ -555,13 +555,21 @@ def validate_precision(
         return False, float("inf"), float("inf"), "validation produced NaN/Inf"
 
     diff = np.abs(out_f32 - ref)
-    max_abs = float(np.max(diff))
-    ref_abs = float(np.max(np.abs(ref)))
-    max_rel = max_abs / (ref_abs + 1e-12)
     abs_thr, rel_thr = choose_tolerance(spec.name)
 
-    passed = (max_abs <= abs_thr) or (max_rel <= rel_thr)
-    reason = None if passed else f"error too large: abs={max_abs:.4g}, rel={max_rel:.4g}"
+    # Per-element bound: atol + rtol * |ref|  (same convention as numpy.allclose).
+    # Using a global max-of-diff vs max-of-ref with an `or` would let a single badly-corrupted
+    # element pass whenever the global reference max is large enough to make max_rel look small.
+    elementwise_bound = abs_thr + rel_thr * np.abs(ref)
+    violated = diff > elementwise_bound
+    n_violated = int(np.sum(violated))
+    max_abs = float(np.max(diff))
+    ref_abs_max = float(np.max(np.abs(ref)))
+    max_rel = max_abs / (ref_abs_max + 1e-12)
+    passed = n_violated == 0
+    reason = (None if passed else
+              f"{n_violated} elements exceed atol+rtol*|ref|; max_abs={max_abs:.4g}, "
+              f"max_rel={max_rel:.4g}")
     return passed, max_abs, max_rel, reason
 
 


### PR DESCRIPTION
## Summary

Fixes #33

Both `cli-stressor-cuda/test.py` and `cli-stressor-opencl/test.py` contained the same broken validation pass criterion:

```python
# BEFORE (buggy)
max_abs = diff.max()
max_rel = max_abs / ref.abs().max()          # global max / global max — different elements!
passed = (max_abs <= atol) or (max_rel <= rtol)  # `or` means either alone can pass
```

This allowed a single badly-corrupted output element to silently pass validation: if the global reference maximum was large (routinely ~110 for N=768 standard-normal matmul), `max_rel` would be small even when `max_abs` was enormous. Concretely, a BF16 element off by 50 units still reported `OK`.

**Root cause**: reducing per-element evidence to global scalars, then combining with `or`, is the exact anti-pattern for detecting localised silent corruption.

## Fix

Both stressors now use the standard `allclose` convention — every element must independently satisfy:

```
|out - ref|  ≤  atol + rtol * |ref|        (per element)
```

```python
# AFTER (fixed)
elementwise_bound = abs_thr + rel_thr * ref.abs()
violated = diff > elementwise_bound
n_violated = int(violated.sum())
passed = n_violated == 0
reason = f"{n_violated} elements exceed atol+rtol*|ref|; max_abs=..., max_rel=..."
```

The `max_abs` / `max_rel` scalars are still computed and printed in the status line for observability, but the pass/fail decision is made element-wise.

## Scope

- `cli-stressor-cuda/test.py` — torch tensor path  
- `cli-stressor-opencl/test.py` — numpy array path (identical bug, same fix pattern)
- `choose_tolerance()` values are **unchanged** — re-calibration against the stricter criterion is a separate follow-up task (noted in #33)

## Test plan

- [ ] Inject deterministic corruption (`out[0, 0] += 50.0` in a BF16 run) — validation must now report `FAIL` instead of `OK`
- [ ] Clean run (no corruption injected) — validation must continue to report `OK` for all supported precisions
- [ ] Verify the error message format includes the violation count: `N elements exceed atol+rtol*|ref|`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADnVSh2oX7c611VoQH2VTZ)_