### PR TITLE
fix(stressor): per-element validation criterion and compute-only TFLOPS (closes #33, #34, #37, #38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .codex
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+*.egg-info/

--- a/cli-stressor-cuda/test.py
+++ b/cli-stressor-cuda/test.py
@@ -22,6 +22,7 @@ class StressResult:
     iterations: int = 0
     total_flops: int = 0
     elapsed_s: float = 0.0
+    compute_s: float = 0.0
     tflops: float = 0.0
     validations: int = 0
     validation_failures: int = 0
@@ -192,14 +193,21 @@ def validate_precision(
         return False, float("inf"), float("inf"), "validation produced NaN/Inf"
 
     diff = (out_f32 - ref).abs()
-    max_abs = float(diff.max().item())
-    ref_abs = float(ref.abs().max().item())
-    max_rel = max_abs / (ref_abs + 1e-12)
     abs_thr, rel_thr = choose_tolerance(spec.name)
 
-    # 只要绝对误差或相对误差其中一个仍在可接受范围内，就不判失败。
-    passed = (max_abs <= abs_thr) or (max_rel <= rel_thr)
-    reason = None if passed else f"error too large: abs={max_abs:.4g}, rel={max_rel:.4g}"
+    # Per-element bound: atol + rtol * |ref|  (same convention as torch.allclose).
+    # A global max-of-diff vs max-of-ref with `or` lets a single badly-corrupted element
+    # pass whenever the global reference max is large enough to make max_rel look small.
+    elementwise_bound = abs_thr + rel_thr * ref.abs()
+    violated = diff > elementwise_bound
+    n_violated = int(violated.sum().item())
+    max_abs = float(diff.max().item())
+    ref_abs_max = float(ref.abs().max().item())
+    max_rel = max_abs / (ref_abs_max + 1e-12)
+    passed = n_violated == 0
+    reason = (None if passed else
+              f"{n_violated} elements exceed atol+rtol*|ref|; max_abs={max_abs:.4g}, "
+              f"max_rel={max_rel:.4g}")
     return passed, max_abs, max_rel, reason
 
 
@@ -289,9 +297,7 @@ def run_stress_for_precision(
 
             result.iterations += burst_iters
             result.total_flops += int(2 * (size**3) * burst_iters)
-            result.elapsed_s = time.monotonic() - start
-            if result.elapsed_s > 0:
-                result.tflops = (result.total_flops / result.elapsed_s) / 1e12
+            result.compute_s += op_elapsed
 
             del a, b
             empty_device_cache(device)
@@ -332,8 +338,8 @@ def run_stress_for_precision(
             time.sleep(0)
 
     result.elapsed_s = time.monotonic() - start
-    if result.elapsed_s > 0:
-        result.tflops = (result.total_flops / result.elapsed_s) / 1e12
+    if result.compute_s > 0:
+        result.tflops = (result.total_flops / result.compute_s) / 1e12
     return result
 
 
@@ -352,11 +358,15 @@ def print_summary(device_name: str, total_memory_gb, results):
             status = "OK" if (r.first_error is None and r.validation_failures == 0) else "FAIL"
         if status != "OK":
             overall_ok = False
+        wallclock_eff = (f"{100 * r.compute_s / r.elapsed_s:.1f}%"
+                         if r.elapsed_s > 0 else "n/a")
         print(
             f"{r.precision:12} {status:4} | "
             f"iters={r.iterations:8d} | "
-            f"time={r.elapsed_s:7.1f}s | "
+            f"wall={r.elapsed_s:7.1f}s | "
+            f"compute={r.compute_s:6.1f}s | "
             f"{r.tflops:8.2f} TFLOPS | "
+            f"eff={wallclock_eff:6} | "
             f"validations={r.validations:3d} | "
             f"val_fail={r.validation_failures:3d} | "
             f"max_abs={r.max_abs_error:.3g} | max_rel={r.max_rel_error:.3g}"

--- a/cli-stressor-opencl/test.py
+++ b/cli-stressor-opencl/test.py
@@ -97,6 +97,7 @@ class StressResult:
     iterations: int = 0
     total_flops: int = 0
     elapsed_s: float = 0.0
+    compute_s: float = 0.0
     tflops: float = 0.0
     validations: int = 0
     validation_failures: int = 0
@@ -555,13 +556,21 @@ def validate_precision(
         return False, float("inf"), float("inf"), "validation produced NaN/Inf"
 
     diff = np.abs(out_f32 - ref)
-    max_abs = float(np.max(diff))
-    ref_abs = float(np.max(np.abs(ref)))
-    max_rel = max_abs / (ref_abs + 1e-12)
     abs_thr, rel_thr = choose_tolerance(spec.name)
 
-    passed = (max_abs <= abs_thr) or (max_rel <= rel_thr)
-    reason = None if passed else f"error too large: abs={max_abs:.4g}, rel={max_rel:.4g}"
+    # Per-element bound: atol + rtol * |ref|  (same convention as numpy.allclose).
+    # A global max-of-diff vs max-of-ref with `or` lets a single badly-corrupted element
+    # pass whenever the global reference max is large enough to make max_rel look small.
+    elementwise_bound = abs_thr + rel_thr * np.abs(ref)
+    violated = diff > elementwise_bound
+    n_violated = int(np.sum(violated))
+    max_abs = float(np.max(diff))
+    ref_abs_max = float(np.max(np.abs(ref)))
+    max_rel = max_abs / (ref_abs_max + 1e-12)
+    passed = n_violated == 0
+    reason = (None if passed else
+              f"{n_violated} elements exceed atol+rtol*|ref|; max_abs={max_abs:.4g}, "
+              f"max_rel={max_rel:.4g}")
     return passed, max_abs, max_rel, reason
 
 
@@ -680,9 +689,7 @@ def run_stress_for_precision(
 
             result.iterations += executed_iters
             result.total_flops += int(2 * (size**3) * executed_iters)
-            result.elapsed_s = time.monotonic() - start
-            if result.elapsed_s > 0:
-                result.tflops = (result.total_flops / result.elapsed_s) / 1e12
+            result.compute_s += op_elapsed
             windows_since_refresh += 1
 
             if time.monotonic() >= next_validate:
@@ -722,8 +729,8 @@ def run_stress_for_precision(
     release_device_buffers(active_buffers)
 
     result.elapsed_s = time.monotonic() - start
-    if result.elapsed_s > 0:
-        result.tflops = (result.total_flops / result.elapsed_s) / 1e12
+    if result.compute_s > 0:
+        result.tflops = (result.total_flops / result.compute_s) / 1e12
     return result
 
 
@@ -751,11 +758,15 @@ def print_summary(runtime: OpenCLRuntime, results):
             overall_ok = False
         if r.supported:
             ran_any_precision = True
+        wallclock_eff = (f"{100 * r.compute_s / r.elapsed_s:.1f}%"
+                         if r.elapsed_s > 0 else "n/a")
         print(
             f"{r.precision:12} {status:4} | "
             f"iters={r.iterations:8d} | "
-            f"time={r.elapsed_s:7.1f}s | "
+            f"wall={r.elapsed_s:7.1f}s | "
+            f"compute={r.compute_s:6.1f}s | "
             f"{r.tflops:8.2f} TFLOPS | "
+            f"eff={wallclock_eff:6} | "
             f"validations={r.validations:3d} | "
             f"val_fail={r.validation_failures:3d} | "
             f"max_abs={r.max_abs_error:.3g} | max_rel={r.max_rel_error:.3g}"


### PR DESCRIPTION
## Summary

Fixes four bugs across `cli-stressor-cuda/test.py` and `cli-stressor-opencl/test.py`.

---

### Fixes #33 and #37 — Broken validation pass criterion

**Root cause**: both stressors reduced per-element diff to a single `max_abs` scalar, divided it by the global `max(|ref|)` scalar (from a potentially *different* element), then combined with `or` so satisfying *either* loose bound was enough to pass. With N=768 standard-normal matmul, `ref.abs().max()` is routinely ~110, making the relative branch trivially pass even for BF16 elements off by 50 units.

**Fix**: replace with the standard `allclose` convention — every element must independently satisfy:

```
|out - ref| ≤ atol + rtol * |ref|        (per element)
```

A failing run now reports the violation count (`N elements exceed atol+rtol*|ref|`), plus `max_abs` and `max_rel` for observability.

**Note**: `choose_tolerance()` values are unchanged — re-calibration against the stricter criterion is a separate follow-up (noted in #33/#37).

---

### Fixes #34 and #38 — TFLOPS measurement bias

**Root cause**: both stressors computed `result.tflops` by dividing burst-only flop counts by total wall time (`elapsed_s`), which includes warmup iterations, sidecar validation, allocator resets (`empty_cache`/buffer reallocation), `print` calls, and host↔device copies. This made the headline TFLOPS systematically low and dependent on `--validate-interval`, `--warmup-iters`, and `--input-refresh-interval` — settings unrelated to GPU throughput — making the `database.md` baseline non-reproducible across operational configurations.

**Fix**: add `compute_s: float` to `StressResult` and accumulate only `op_elapsed` (burst-kernel wall time, after `synchronize`). `result.tflops` is computed from `compute_s` only. `elapsed_s` retains the full wall time for display.

`print_summary` now shows:
```
FP16   OK | iters=... | wall= 90.0s | compute= 12.3s | 245.67 TFLOPS | eff=13.7% | ...
```

The `eff=` column makes validation/warmup overhead immediately visible.

---

## Scope

- `cli-stressor-cuda/test.py` — validation fix + TFLOPS fix
- `cli-stressor-opencl/test.py` — validation fix + TFLOPS fix
- `choose_tolerance()` values — **unchanged**
- `sys.exit(1)` on validation failure — **unchanged** (confirmed intentional: immediate abort prevents driver lock-up on Linux with no TDR)

## Test plan

- [ ] Inject `out[0, 0] += 50.0` in a BF16 CUDA run — validation must now report `FAIL` with `1 elements exceed atol+rtol*|ref|`
- [ ] Clean CUDA run — validation must continue to report `OK` for all precisions
- [ ] Run CUDA stressor with `--validate-interval 1` vs `--validate-interval 999` on the same hardware — reported TFLOPS must now be consistent
- [ ] Same corruption injection and clean run for OpenCL stressor
- [ ] Run OpenCL with `--validate-interval 1 --input-refresh-interval 1` vs `--validate-interval 999 --input-refresh-interval 64` — TFLOPS must now be consistent

https://claude.ai/code/session_01X93XY3NZKnFYepVaQRKrRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01X93XY3NZKnFYepVaQRKrRP)_