### PR TITLE
auto-optimizer: fix 7 correctness/safety/UX bugs (#17/#42/#43/#44/#46/#47/#48/#49)

### DIFF
--- a/auto-optimizer/src/arg_help.rs
+++ b/auto-optimizer/src/arg_help.rs
@@ -6,7 +6,7 @@ use crate::platform::{
 use crate::types::{
     OutputFormat, ResetSettings, VfpResetDomain, POSSIBLE_BOOL, POSSIBLE_BOOL_OFF, POSSIBLE_BOOL_ON,
 };
-use clap::{Arg, ArgAction, Command};
+use clap::{value_parser, Arg, ArgAction, Command};
 use nvapi_hi::PState;
 
 pub fn get_arguments() -> Command {
@@ -199,18 +199,20 @@ pub fn get_arguments() -> Command {
                                   .short('c')
                                   .long("core")
                                   .value_name("CORE_MHZ")
-                                  .help("Target absolute core frequency in MHz")
+                                  .help("Target absolute core frequency in MHz (100–5000)")
                                   .num_args(1)
                                   .required(true)
+                                  .value_parser(value_parser!(u32).range(100..=5000))
                           )
                           .arg(
                               Arg::new("memory")
                                   .short('m')
                                   .long("memory")
                                   .value_name("MEM_MHZ")
-                                  .help("Target absolute memory frequency in MHz")
+                                  .help("Target absolute memory frequency in MHz (100–5000)")
                                   .num_args(1)
                                   .required(true)
+                                  .value_parser(value_parser!(u32).range(100..=5000))
                           )
                   )
                   .subcommand(
@@ -221,10 +223,11 @@ pub fn get_arguments() -> Command {
                             Arg::new("vboost")
                                 .short('V')
                                 .long("voltage-boost")
-                        .value_name("VBOOST")
-                        .num_args(1)
-                        .help("Voltage Boost %"),
-                )
+                                .value_name("VBOOST")
+                                .num_args(1)
+                                .value_parser(value_parser!(u32).range(0..=200))
+                                .help("Voltage Boost % (0–200)"),
+                        )
                 .arg(
                     Arg::new("tlimit")
                         .short('T')
@@ -232,7 +235,8 @@ pub fn get_arguments() -> Command {
                         .value_name("TEMPLIMIT")
                         .num_args(1..)
                         .action(ArgAction::Append)
-                        .help("Thermal limit (C)"),
+                        .value_parser(value_parser!(i32).range(40..=110))
+                        .help("Thermal limit °C (40–110)"),
                 )
                 .arg(
                     Arg::new("plimit")
@@ -241,7 +245,8 @@ pub fn get_arguments() -> Command {
                         .value_name("POWERLIMIT")
                         .num_args(1..)
                         .action(ArgAction::Append)
-                        .help("Power limit %"),
+                        .value_parser(value_parser!(u32).range(0..=200))
+                        .help("Power limit % (0–200)"),
                 )
                 .arg(
                     Arg::new("voltage_delta")
@@ -250,7 +255,8 @@ pub fn get_arguments() -> Command {
                         .value_name("UV")
                         .num_args(1)
                         .allow_hyphen_values(true)
-                        .help("Core voltage delta in μV via SetPstates20 (for Maxwell/900-series and older, e.g. +100000 = +100mV). Target pstate selectable via -z."),
+                        .value_parser(value_parser!(i32).range(-250_000..=250_000))
+                        .help("Core voltage delta in μV via SetPstates20 (−250000..+250000). Target pstate selectable via -z."),
                 )
                 .arg(
                     Arg::new("pstate")
@@ -268,7 +274,8 @@ pub fn get_arguments() -> Command {
                         .value_name("CORE_OFFSET")
                         .num_args(1)
                         .allow_hyphen_values(true)
-                        .help("Core clock offset via NVAPI (kHz)."),
+                        .value_parser(value_parser!(i32).range(-2_000_000..=2_000_000))
+                        .help("Core clock offset via NVAPI (kHz, −2000000..+2000000)."),
                 )
                 .arg(
                     Arg::new("mem_offset")
@@ -276,7 +283,8 @@ pub fn get_arguments() -> Command {
                         .value_name("MEM_OFFSET")
                         .num_args(1)
                         .allow_hyphen_values(true)
-                        .help("Memory clock offset via NVAPI (kHz)."),
+                        .value_parser(value_parser!(i32).range(-2_000_000..=2_000_000))
+                        .help("Memory clock offset via NVAPI (kHz, −2000000..+2000000)."),
                 )
                 .arg(
                     Arg::new("locked_voltage")
@@ -353,7 +361,8 @@ pub fn get_arguments() -> Command {
                         .value_name("CORE_OFFSET")
                         .num_args(1)
                         .allow_hyphen_values(true)
-                        .help("Core clock offset via NVML API (MHz)."),
+                        .value_parser(value_parser!(i32).range(-1500..=1500))
+                        .help("Core clock offset via NVML API (MHz, −1500..+1500)."),
                 )
                 .arg(
                     Arg::new("mem_offset")
@@ -361,7 +370,8 @@ pub fn get_arguments() -> Command {
                         .value_name("MEM_OFFSET")
                         .num_args(1)
                         .allow_hyphen_values(true)
-                        .help("Memory clock offset via NVML API (MHz). Note: target effective offset, handled behind the scene as *2."),
+                        .value_parser(value_parser!(i32).range(-1500..=1500))
+                        .help("Memory clock offset via NVML API (MHz, −1500..+1500). Effective offset applied as ×2 internally."),
                 )
                 // NVML thermal threshold write args are intentionally commented out for now.
                 .arg(
@@ -370,7 +380,8 @@ pub fn get_arguments() -> Command {
                         .long("power-limit")
                         .value_name("POWER_LIMIT")
                         .num_args(1)
-                        .help("Power limit via NVML API (W)."),
+                        .value_parser(value_parser!(u32).range(10..=2000))
+                        .help("Power limit via NVML API (W, 10–2000)."),
                 )
                 .arg(
                     Arg::new("app_clock")
@@ -446,7 +457,8 @@ pub fn get_arguments() -> Command {
                                 .value_name("LEVEL")
                                 .num_args(1)
                                 .required(true)
-                                .help("Cooler level %"),
+                                .value_parser(value_parser!(u32).range(0..=100))
+                                .help("Cooler level % (0–100)"),
                         ),
                 )
                 .subcommand(
@@ -477,7 +489,8 @@ pub fn get_arguments() -> Command {
                                 .value_name("LEVEL")
                                 .num_args(1)
                                 .required(true)
-                                .help("Cooler level %"),
+                                .value_parser(value_parser!(u32).range(0..=100))
+                                .help("Cooler level % (0–100)"),
                         ),
                 )
                 .subcommand(
@@ -576,7 +589,8 @@ pub fn get_arguments() -> Command {
                                         .short('s')
                                         .num_args(1)
                                         .default_value("40")
-                                        .help("Point index to start"),
+                                        .value_parser(value_parser!(u64).range(0..=120))
+                                        .help("Point index to start (0–120)"),
                                 )
                                 .arg(
                                     Arg::new("delta")
@@ -586,7 +600,8 @@ pub fn get_arguments() -> Command {
                                         .allow_hyphen_values(true)
                                         .required(true)
                                         .default_value("150000")
-                                        .help("default initial Clock delta / overclocking offset (kHz)"),
+                                        .value_parser(value_parser!(i32).range(-500_000..=500_000))
+                                        .help("Clock delta / OC offset (kHz, −500000..+500000)"),
                                 ),
                         )
                         .subcommand(
@@ -606,7 +621,8 @@ pub fn get_arguments() -> Command {
                                         .num_args(1)
                                         .required(true)
                                         .allow_hyphen_values(true)
-                                        .help("Clock frequency delta in kHz, e.g. +150000 or -50000"),
+                                        .value_parser(value_parser!(i32).range(-500_000..=500_000))
+                                        .help("Clock frequency delta (kHz, −500000..+500000)"),
                                 ),
                         )
                         .subcommand(
@@ -618,7 +634,8 @@ pub fn get_arguments() -> Command {
                                         .short('d')
                                         .num_args(1)
                                         .default_value("3")
-                                        .help("fix ref f"),
+                                        .value_parser(value_parser!(i32).range(0..=20))
+                                        .help("fix ref f (0–20)"),
                                 )
                                 .arg(
                                     Arg::new("tempcsv")
@@ -665,11 +682,8 @@ pub fn get_arguments() -> Command {
                                         .short('m')
                                         .num_args(1)
                                         .allow_hyphen_values(true)
-                                        .value_parser(|v: &str| {
-                                            v.parse::<i32>()
-                                                .map_err(|_| String::from("Must be an integer"))
-                                        })
-                                        .help("Specify a integer"),
+                                        .value_parser(value_parser!(i32).range(-10..=10))
+                                        .help("Margin bin adjustment (−10..+10)"),
                                 ),
                         )
                         .subcommand(
@@ -681,7 +695,8 @@ pub fn get_arguments() -> Command {
                                         .short('s')
                                         .num_args(1)
                                         .default_value("40")
-                                        .help("Point index to start"),
+                                        .value_parser(value_parser!(u64).range(0..=120))
+                                        .help("Point index to start (0–120)"),
                                 )
                                 .arg(
                                     Arg::new("interval_s")
@@ -689,7 +704,8 @@ pub fn get_arguments() -> Command {
                                         .short('a')
                                         .num_args(1)
                                         .default_value("2")
-                                        .help("small interval"),
+                                        .value_parser(value_parser!(u64).range(1..=100))
+                                        .help("small interval (1–100)"),
                                 )
                                 .arg(
                                     Arg::new("interval_m")
@@ -697,7 +713,8 @@ pub fn get_arguments() -> Command {
                                         .short('b')
                                         .num_args(1)
                                         .default_value("3")
-                                        .help("medium interval"),
+                                        .value_parser(value_parser!(u64).range(1..=100))
+                                        .help("medium interval (1–100)"),
                                 )
                                 .arg(
                                     Arg::new("interval_l")
@@ -705,7 +722,8 @@ pub fn get_arguments() -> Command {
                                         .short('c')
                                         .num_args(1)
                                         .default_value("5")
-                                        .help("large interval"),
+                                        .value_parser(value_parser!(u64).range(1..=100))
+                                        .help("large interval (1–100)"),
                                 )
                                 .arg(
                                     Arg::new("wait_time_sec")
@@ -713,7 +731,8 @@ pub fn get_arguments() -> Command {
                                         .short('w')
                                         .num_args(1)
                                         .default_value("5")
-                                        .help("set volt wait time"),
+                                        .value_parser(value_parser!(u64).range(1..=300))
+                                        .help("voltage settle wait time (s, 1–300)"),
                                 )
                                 .arg(
                                     Arg::new("try_point_start")
@@ -721,7 +740,8 @@ pub fn get_arguments() -> Command {
                                         .short('t')
                                         .num_args(1)
                                         .default_value("60")
-                                        .help("Point index to start"),
+                                        .value_parser(value_parser!(u64).range(0..=120))
+                                        .help("Try-point starting index (0–120)"),
                                 )
                                 .arg(
                                     Arg::new("vfcsv")
@@ -771,9 +791,9 @@ pub fn get_arguments() -> Command {
                                         .short('t')
                                         .value_name("timeout_loops")
                                         .num_args(1)
-                                        .allow_hyphen_values(true)
                                         .default_value("30")
-                                        .help("timeout loops"),
+                                        .value_parser(value_parser!(u32).range(1..=1000))
+                                        .help("stress test timeout loops (1–1000)"),
                                 )
                                 .arg(
                                     Arg::new("output")
@@ -832,9 +852,9 @@ pub fn get_arguments() -> Command {
                                         .short('t')
                                         .value_name("timeout_loops")
                                         .num_args(1)
-                                        .allow_hyphen_values(true)
                                         .default_value("30")
-                                        .help("stress test timeout loops"),
+                                        .value_parser(value_parser!(u32).range(1..=1000))
+                                        .help("stress test timeout loops (1–1000)"),
                                 )
                                 .arg(
                                     Arg::new("bsod_recovery")

--- a/auto-optimizer/src/autoscan_config.rs
+++ b/auto-optimizer/src/autoscan_config.rs
@@ -114,10 +114,8 @@ impl AutoscanConfig {
     /// 从 autoscan（gpuboostv3）子命令的 ArgMatches 解析
     pub fn from_autoscan_matches(matches: &ArgMatches) -> Result<Self, Error> {
         let timeout_loops = matches
-            .get_one::<String>("timeout_loops")
-            .map(|s| s.parse::<u32>())
-            .transpose()
-            .map_err(|e| Error::from(format!("Invalid timeout_loops: {}", e)))?
+            .get_one::<u32>("timeout_loops")
+            .copied()
             .unwrap_or(30);
 
         let recovery_method = matches
@@ -156,10 +154,8 @@ impl AutoscanConfig {
     /// legacy 没有 ultrafast / point_seq / output_csv / initcsv / vmem_scan，填默认值
     pub fn from_legacy_matches(matches: &ArgMatches) -> Result<Self, Error> {
         let timeout_loops = matches
-            .get_one::<String>("timeout_loops")
-            .map(|s| s.parse::<u32>())
-            .transpose()
-            .map_err(|e| Error::from(format!("Invalid timeout_loops: {}", e)))?
+            .get_one::<u32>("timeout_loops")
+            .copied()
             .unwrap_or(30);
 
         let recovery_method = matches

--- a/auto-optimizer/src/basic_func.rs
+++ b/auto-optimizer/src/basic_func.rs
@@ -118,11 +118,9 @@ impl TestResolution {
             TestResolution::R800x600 => Some(TestResolution::R768x576),
             TestResolution::R768x576 => Some(TestResolution::R720x480),
             TestResolution::R720x480 => Some(TestResolution::R640x384),
-            TestResolution::R640x384 => Some(TestResolution::R640x384),
-            // TestResolution::R640x384 => Some(TestResolution::R576x360),
+            TestResolution::R640x384 => Some(TestResolution::R576x360),
             TestResolution::R576x360 => Some(TestResolution::R400x300),
-            TestResolution::R400x300 => Some(TestResolution::R400x300),
-            // Lowest resolution, no downgrade available
+            TestResolution::R400x300 => None,
         }
     }
 
@@ -264,12 +262,18 @@ pub fn select_gpus<'a>(
             for input in inputs {
                 // ① 人类可读序号（强语义，禁止 fallback）
                 if input < 256 {
-                    if let Some(g) = gpus.get(input) {
-                        result.push(g);
-                        continue;
-                    } else {
-                        // index 不存在，直接认为无效
-                        continue;
+                    match gpus.get(input) {
+                        Some(g) => {
+                            result.push(g);
+                            continue;
+                        }
+                        None => {
+                            return Err(Error::Custom(format!(
+                                "no GPU found at index {} (system has {} GPU(s))",
+                                input,
+                                gpus.len()
+                            )));
+                        }
                     }
                 }
 
@@ -285,6 +289,11 @@ pub fn select_gpus<'a>(
                     result.push(g);
                     continue;
                 }
+
+                return Err(Error::Custom(format!(
+                    "no GPU matches --gpu 0x{:x} (tried index, raw ID, and legacy ID)",
+                    input
+                )));
             }
             result
         }
@@ -341,11 +350,18 @@ pub fn select_gpu_ids(
             let mut result = Vec::new();
             for input in inputs {
                 if input < 256 {
-                    if let Some(id) = gpu_ids.get(input) {
-                        result.push(*id);
-                        continue;
-                    } else {
-                        continue;
+                    match gpu_ids.get(input) {
+                        Some(&id) => {
+                            result.push(id);
+                            continue;
+                        }
+                        None => {
+                            return Err(Error::Custom(format!(
+                                "no GPU found at index {} (system has {} GPU(s))",
+                                input,
+                                gpu_ids.len()
+                            )));
+                        }
                     }
                 }
 
@@ -359,6 +375,11 @@ pub fn select_gpu_ids(
                     result.push(id);
                     continue;
                 }
+
+                return Err(Error::Custom(format!(
+                    "no GPU matches --gpu 0x{:x} (tried index, raw ID, and legacy ID)",
+                    input
+                )));
             }
             result
         }
@@ -963,29 +984,19 @@ pub fn handle_set_command(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Err
 }
 
 fn handle_nvapi(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
-    if let Some(vboost) = matches
-        .get_one::<String>("vboost")
-        .map(|s| u32::from_str(s.as_str()))
-        .transpose()?
-    {
+    if let Some(&vboost) = matches.get_one::<u32>("vboost") {
         for gpu in gpus {
             gpu.set_voltage_boost(Percentage(vboost))?;
         }
     }
-    if let Some(plimit) = matches.get_many::<String>("plimit") {
-        let plimit = plimit
-            .map(|s| u32::from_str(s.as_str()))
-            .map(|v| v.map(Percentage))
-            .collect::<Result<Vec<_>, _>>()?;
+    if let Some(plimit) = matches.get_many::<u32>("plimit") {
+        let plimit: Vec<Percentage> = plimit.map(|&v| Percentage(v)).collect();
         for gpu in gpus {
             gpu.set_power_limits(plimit.iter().cloned())?;
         }
     }
-    if let Some(tlimit) = matches.get_many::<String>("tlimit") {
-        let tlimit = tlimit
-            .map(|s| i32::from_str(s.as_str()))
-            .map(|v| v.map(|v| Celsius(v).into()))
-            .collect::<Result<Vec<_>, _>>()?;
+    if let Some(tlimit) = matches.get_many::<i32>("tlimit") {
+        let tlimit: Vec<_> = tlimit.map(|&v| Celsius(v).into()).collect();
         for gpu in gpus {
             gpu.set_sensor_limits(tlimit.iter().cloned())?;
         }
@@ -998,11 +1009,7 @@ fn handle_nvapi(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
         .map_err(|e| Error::from(format!("Invalid --pstate value: {}", e)))?
         .unwrap_or(PState::P0);
 
-    if let Some(delta_uv) = matches
-        .get_one::<String>("voltage_delta")
-        .map(|s| i32::from_str(s.as_str()))
-        .transpose()?
-    {
+    if let Some(&delta_uv) = matches.get_one::<i32>("voltage_delta") {
         for gpu in gpus {
             crate::oc_get_set_function_nvapi::set_pstate_base_voltage(
                 gpu,
@@ -1012,11 +1019,7 @@ fn handle_nvapi(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
         }
     }
 
-    if let Some(core_offset) = matches
-        .get_one::<String>("core_offset")
-        .map(|s| i32::from_str(s.as_str()))
-        .transpose()?
-    {
+    if let Some(&core_offset) = matches.get_one::<i32>("core_offset") {
         for gpu in gpus {
             let gpu_info = gpu.info()?;
             match gpu.inner().set_pstates(
@@ -1040,11 +1043,7 @@ fn handle_nvapi(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Error> {
         }
     }
 
-    if let Some(mem_offset) = matches
-        .get_one::<String>("mem_offset")
-        .map(|s| i32::from_str(s.as_str()))
-        .transpose()?
-    {
+    if let Some(&mem_offset) = matches.get_one::<i32>("mem_offset") {
         for gpu in gpus {
             let gpu_info = gpu.info()?;
             match gpu.inner().set_pstates(
@@ -1173,11 +1172,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
         .unwrap_or("0");
     let target_nvml_pstate = crate::conv::parse_nvml_pstate(nvml_pstate_val);
 
-    if let Some(core_offset) = matches
-        .get_one::<String>("core_offset")
-        .map(|s| i32::from_str(s.as_str()))
-        .transpose()?
-    {
+    if let Some(&core_offset) = matches.get_one::<i32>("core_offset") {
         for &gpu_id in gpu_ids {
             match crate::oc_get_set_function_nvml::set_nvml_core_clock_vf_offset(
                 gpu_id,
@@ -1193,11 +1188,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
         }
     }
 
-    if let Some(mem_offset) = matches
-        .get_one::<String>("mem_offset")
-        .map(|s| i32::from_str(s.as_str()))
-        .transpose()?
-    {
+    if let Some(&mem_offset) = matches.get_one::<i32>("mem_offset") {
         for &gpu_id in gpu_ids {
             match crate::oc_get_set_function_nvml::set_nvml_mem_clock_vf_offset(
                 gpu_id,
@@ -1213,11 +1204,7 @@ pub fn handle_nvml_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Result<(),
         }
     }
 
-    if let Some(power_w) = matches
-        .get_one::<String>("power_limit")
-        .map(|s| u32::from_str(s.as_str()))
-        .transpose()?
-    {
+    if let Some(&power_w) = matches.get_one::<u32>("power_limit") {
         for &gpu_id in gpu_ids {
             match crate::oc_get_set_function_nvml::set_nvml_power_limit(gpu_id, power_w) {
                 Ok(_) => println!(
@@ -1396,9 +1383,8 @@ pub fn handle_nvml_cooler_with_ids(gpu_ids: &[u32], matches: &ArgMatches) -> Res
         .transpose()?
         .ok_or_else(|| Error::from("Missing required argument: --policy <MODE>"))?;
     let level = matches
-        .get_one::<String>("level")
-        .map(|s| u32::from_str(s.as_str()))
-        .transpose()?
+        .get_one::<u32>("level")
+        .copied()
         .ok_or_else(|| Error::from("Missing required argument: --level <LEVEL>"))?;
 
     for &gpu_id in gpu_ids {
@@ -1511,4 +1497,53 @@ pub fn handle_reset_nvml_cooler_single_gpu(gpu: &Gpu, cooler_id: &str) -> Result
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestResolution;
+
+    #[test]
+    fn test_resolution_downgrade_ladder() {
+        let top = TestResolution::R3600x1920;
+        let mut prev = top;
+        let mut current = top.downgrade();
+        while let Some(next) = current {
+            let (pw, ph) = prev.dimensions();
+            let (nw, nh) = next.dimensions();
+            assert!(
+                nw < pw || nh < ph,
+                "downgrade from {:?} ({pw}x{ph}) to {:?} ({nw}x{nh}) is not strictly smaller",
+                prev,
+                next,
+            );
+            prev = next;
+            current = next.downgrade();
+        }
+        assert_eq!(
+            prev,
+            TestResolution::R400x300,
+            "ladder must end at R400x300"
+        );
+    }
+
+    #[test]
+    fn test_resolution_r640x384_not_self_loop() {
+        let next = TestResolution::R640x384.downgrade();
+        assert_ne!(
+            next,
+            Some(TestResolution::R640x384),
+            "R640x384 must not downgrade to itself"
+        );
+        assert_eq!(next, Some(TestResolution::R576x360));
+    }
+
+    #[test]
+    fn test_resolution_r400x300_is_terminal() {
+        assert_eq!(
+            TestResolution::R400x300.downgrade(),
+            None,
+            "R400x300 is the lowest rung and must return None"
+        );
+    }
 }

--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -148,10 +148,8 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                             handle_cooler_command(&gpus, matches)?;
                         }
                         Some(("legacy-clock", matches)) => {
-                            let core_mhz = matches.get_one::<String>("core").unwrap().parse::<u32>()
-                                .map_err(|_| "Invalid integer for core frequency")?;
-                            let mem_mhz = matches.get_one::<String>("memory").unwrap().parse::<u32>()
-                                .map_err(|_| "Invalid integer for memory frequency")?;
+                            let core_mhz = *matches.get_one::<u32>("core").unwrap();
+                            let mem_mhz = *matches.get_one::<u32>("memory").unwrap();
                             for gpu in &gpus {
                                 match set_legacy_clocks_nvapi(gpu, core_mhz, mem_mhz) {
                                     Ok(_) => println!("Legacy clock applied to GPU: Core = {} MHz, Mem = {} MHz", core_mhz, mem_mhz),

--- a/auto-optimizer/src/oc_get_set_function_nvapi.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvapi.rs
@@ -187,9 +187,9 @@ pub fn handle_cooler_command(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), 
         _ => CoolerPolicy::from_str(policy_raw.as_str())?,
     };
     let level = matches
-        .get_one::<String>("level")
-        .map(|s| u32::from_str(s.as_str()))
-        .ok_or_else(|| Error::from("Missing required argument: --level <LEVEL>"))??;
+        .get_one::<u32>("level")
+        .copied()
+        .ok_or_else(|| Error::from("Missing required argument: --level <LEVEL>"))?;
 
     let cooler_id = matches
         .get_one::<String>("id")
@@ -884,11 +884,14 @@ pub fn core_reset_vfp(gpu: &Gpu) -> nvapi_hi::Result<()> {
 
 pub fn single_point_adj(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(), Error> {
     let point_start = matches
-        .get_one::<String>("point_start")
-        .map(|s| usize::from_str(s.as_str()))
-        .unwrap()?;
+        .get_one::<u64>("point_start")
+        .copied()
+        .ok_or_else(|| Error::from("Missing required argument: --point_start"))? as usize;
 
-    let delta_ini: i32 = matches.get_one::<String>("delta").map(|s| i32::from_str(s.as_str())).unwrap()?;
+    let delta_ini: i32 = matches
+        .get_one::<i32>("delta")
+        .copied()
+        .ok_or_else(|| Error::from("Missing required argument: --delta"))?;
 
     for gpu in gpus {
         gpu.set_vfp(
@@ -935,11 +938,9 @@ pub fn handle_pointwiseoc(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Err
     };
 
     let delta: i32 = matches
-        .get_one::<String>("delta")
-        .ok_or_else(|| Error::from("Missing required argument: DELTA"))?
-        .trim_start_matches('+')
-        .parse::<i32>()
-        .map_err(|_| Error::from("DELTA must be an integer (kHz), e.g. +150000 or -50000"))?;
+        .get_one::<i32>("delta")
+        .copied()
+        .ok_or_else(|| Error::from("Missing required argument: DELTA"))?;
 
     println!(
         "pointwiseoc: applying delta {} kHz to VFP points {}..={} (inclusive)",

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -35,6 +35,17 @@ fn is_std(str: &str) -> bool {
     str == "-"
 }
 
+fn parse_col<T>(row: &[String], idx: usize, ctx: &str) -> Result<T, Error>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    row.get(idx)
+        .ok_or_else(|| Error::Custom(format!("CSV row missing column {} ({})", idx, ctx)))?
+        .parse::<T>()
+        .map_err(|e| Error::Custom(format!("CSV column {} ({}) parse error: {}", idx, ctx, e)))
+}
+
 #[cfg(windows)]
 fn spawn_dynamic_load_process() -> Result<Child, Error> {
     let repo_root = env!("CARGO_MANIFEST_DIR");
@@ -191,17 +202,22 @@ fn extract_default_frequencies(file_path: &str, legacy_flag: bool) -> Result<Vec
 
     for result in rdr.records() {
         let record = result?;
-        let default_frequency_load: u32;
-
-        if legacy_flag {
-            default_frequency_load = record[1].parse()?;
-        }
-        // Read only frequency column
-        else {
-            default_frequency_load = record[3].parse()?;
-        }
-        // Read only default_frequency column
-
+        let col_idx = if legacy_flag { 1 } else { 3 };
+        let default_frequency_load: u32 = record
+            .get(col_idx)
+            .ok_or_else(|| {
+                Error::Custom(format!(
+                    "CSV row missing column {} (expected frequency)",
+                    col_idx
+                ))
+            })?
+            .parse()
+            .map_err(|e| {
+                Error::Custom(format!(
+                    "CSV column {} frequency parse error: {}",
+                    col_idx, e
+                ))
+            })?;
         default_frequencies_load.push(default_frequency_load);
     }
     Ok(default_frequencies_load)
@@ -214,12 +230,23 @@ fn update_csv_with_load_and_margin(
     minimum_delta_core_freq_step: i32,
     legacy_flag: bool,
 ) -> Result<(), Error> {
+    let dest = Path::new(file_path);
+    let parent = dest.parent().unwrap_or_else(|| Path::new("."));
+    let tmp_name = format!(
+        ".{}.tmp-{}",
+        dest.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("vfp"),
+        std::process::id()
+    );
+    let tmp_path = parent.join(&tmp_name);
+
     let mut rdr = ReaderBuilder::new()
         .has_headers(true)
         .from_path(file_path)?;
     let mut wtr = WriterBuilder::new()
         .has_headers(true)
-        .from_writer(File::create("./ws/temp.csv")?);
+        .from_writer(File::create(&tmp_path)?);
 
     let mut index = 0;
     let headers = StringRecord::from(vec![
@@ -263,10 +290,11 @@ fn update_csv_with_load_and_margin(
     }
 
     wtr.flush()?;
+    drop(wtr);
 
-    // Replace original file with updated file
-    fs::remove_file(file_path)?;
-    fs::rename("./ws/temp.csv", file_path)?;
+    // Atomic replace: rename temp over the destination.  On Linux/Windows this
+    // is a single syscall so a crash cannot leave the user with neither file.
+    fs::rename(&tmp_path, dest)?;
 
     Ok(())
 }
@@ -493,19 +521,43 @@ pub fn handle_vfp_import(gpu: &Gpu, matches: &clap::ArgMatches) -> Result<(), Er
 
 // oc_profile_function.rs
 
-fn linear_interpolate(v1: u32, d1: i32, v2: u32, d2: i32, current_v: u32, delta_step: i32) -> i32 {
-    let ratio = (current_v - v1) as f64 / (v2 - v1) as f64;
-    let interpolated = (d2 as f64 - d1 as f64) * ratio + d1 as f64;
-
+fn linear_interpolate(
+    v1: u32,
+    d1: i32,
+    v2: u32,
+    d2: i32,
+    current_v: u32,
+    delta_step: i32,
+) -> Result<i32, Error> {
+    if v1 == v2 {
+        // Flat region — no slope; return the average of the two endpoint deltas.
+        return Ok((d1 / 2) + (d2 / 2));
+    }
+    // Normalise so lo_v <= hi_v regardless of argument order.
+    let (lo_v, hi_v, lo_d, hi_d) = if v1 <= v2 {
+        (v1, v2, d1, d2)
+    } else {
+        (v2, v1, d2, d1)
+    };
+    if current_v < lo_v || current_v > hi_v {
+        return Err(Error::Custom(format!(
+            "linear_interpolate: current_v={} outside endpoints [{}, {}]",
+            current_v, lo_v, hi_v
+        )));
+    }
+    let ratio = (current_v - lo_v) as f64 / (hi_v - lo_v) as f64;
+    let interpolated = (hi_d as f64 - lo_d as f64) * ratio + lo_d as f64;
     let rounded = if interpolated >= delta_step as f64 {
         (interpolated / delta_step as f64).floor() * delta_step as f64
     } else {
         0.0
     };
-    rounded as i32
+    Ok(rounded as i32)
 }
 
-fn get_key_points_indices(lines: &[Vec<String>]) -> (usize, usize, usize, usize) {
+fn get_key_points_indices(
+    lines: &[Vec<String>],
+) -> Result<(usize, usize, usize, usize), Error> {
     let mut key_indices = Vec::new();
 
     for (i, columns) in lines.iter().enumerate() {
@@ -525,46 +577,55 @@ fn get_key_points_indices(lines: &[Vec<String>]) -> (usize, usize, usize, usize)
             }
         }
     }
-    assert_eq!(
-        key_indices.len(),
-        4,
-        "Need exactly 4 key points in ultrafast mode"
-    );
-    (
+    if key_indices.len() < 4 {
+        return Err(Error::Custom(format!(
+            "ultrafast mode requires ≥ 4 key points (rows with non-zero freq AND delta), \
+             found {}",
+            key_indices.len()
+        )));
+    }
+    Ok((
         key_indices[0],
         key_indices[1],
         key_indices[2],
         key_indices[3],
-    )
+    ))
 }
 
-fn interpolate_deltas(lines: &mut [Vec<String>], minimum_delta_step: i32, maxq_flag: bool) {
-    let (p1_idx, p2_idx, p3_idx, p4_idx) = get_key_points_indices(lines);
+fn interpolate_deltas(
+    lines: &mut [Vec<String>],
+    minimum_delta_step: i32,
+    maxq_flag: bool,
+) -> Result<(), Error> {
+    let (p1_idx, p2_idx, p3_idx, p4_idx) = get_key_points_indices(lines)?;
 
-    let p1_d;
-    let p2_d;
-    let p3_d;
-    let p4_d;
+    let p1_v: u32 = parse_col(&lines[p1_idx], 0, "voltage")?;
+    let p2_v: u32 = parse_col(&lines[p2_idx], 0, "voltage")?;
+    let p3_v: u32 = parse_col(&lines[p3_idx], 0, "voltage")?;
+    let p4_v: u32 = parse_col(&lines[p4_idx], 0, "voltage")?;
 
-    let p1_v = lines[p1_idx][0].parse::<u32>().unwrap();
-    let p2_v = lines[p2_idx][0].parse::<u32>().unwrap();
-    let p3_v = lines[p3_idx][0].parse::<u32>().unwrap();
-    let p4_v = lines[p4_idx][0].parse::<u32>().unwrap();
-
-    if maxq_flag {
-        p1_d = lines[p1_idx][2].parse::<i32>().unwrap() - minimum_delta_step;
-        p2_d = lines[p2_idx][2].parse::<i32>().unwrap() - minimum_delta_step;
-        p3_d = lines[p3_idx][2].parse::<i32>().unwrap() - 2 * minimum_delta_step;
-        p4_d = lines[p4_idx][2].parse::<i32>().unwrap() - 2 * minimum_delta_step;
+    let (p1_d, p2_d, p3_d, p4_d) = if maxq_flag {
+        let d1: i32 = parse_col(&lines[p1_idx], 2, "delta")?;
+        let d2: i32 = parse_col(&lines[p2_idx], 2, "delta")?;
+        let d3: i32 = parse_col(&lines[p3_idx], 2, "delta")?;
+        let d4: i32 = parse_col(&lines[p4_idx], 2, "delta")?;
+        (
+            d1 - minimum_delta_step,
+            d2 - minimum_delta_step,
+            d3 - 2 * minimum_delta_step,
+            d4 - 2 * minimum_delta_step,
+        )
     } else {
-        p1_d = lines[p1_idx][2].parse::<i32>().unwrap();
-        p2_d = lines[p2_idx][2].parse::<i32>().unwrap();
-        p3_d = lines[p3_idx][2].parse::<i32>().unwrap();
-        p4_d = lines[p4_idx][2].parse::<i32>().unwrap();
-    }
+        (
+            parse_col::<i32>(&lines[p1_idx], 2, "delta")?,
+            parse_col::<i32>(&lines[p2_idx], 2, "delta")?,
+            parse_col::<i32>(&lines[p3_idx], 2, "delta")?,
+            parse_col::<i32>(&lines[p4_idx], 2, "delta")?,
+        )
+    };
 
     for i in 0..lines.len() {
-        let current_v = lines[i][0].parse::<u32>().unwrap();
+        let current_v: u32 = parse_col(&lines[i], 0, "voltage")?;
         let stair_inferred = min(p2_idx - p1_idx, p3_idx - p2_idx);
 
         let new_delta = if i < p1_idx {
@@ -572,19 +633,20 @@ fn interpolate_deltas(lines: &mut [Vec<String>], minimum_delta_step: i32, maxq_f
         } else if i < p2_idx && stair_inferred == p2_idx - p1_idx && maxq_flag {
             min(p1_d, p2_d)
         } else if i < p2_idx {
-            linear_interpolate(p1_v, p1_d, p2_v, p2_d, current_v, minimum_delta_step)
+            linear_interpolate(p1_v, p1_d, p2_v, p2_d, current_v, minimum_delta_step)?
         } else if i < p3_idx && stair_inferred == p3_idx - p2_idx && maxq_flag {
             min(p2_d, p3_d)
         } else if i < p3_idx {
-            linear_interpolate(p2_v, p2_d, p3_v, p3_d, current_v, minimum_delta_step)
+            linear_interpolate(p2_v, p2_d, p3_v, p3_d, current_v, minimum_delta_step)?
         } else if i < p4_idx {
-            linear_interpolate(p3_v, p3_d, p4_v, p4_d, current_v, minimum_delta_step)
+            linear_interpolate(p3_v, p3_d, p4_v, p4_d, current_v, minimum_delta_step)?
         } else {
             p4_d
         };
 
         lines[i][2] = new_delta.to_string();
     }
+    Ok(())
 }
 
 pub fn fix_result(gpu: &Gpu, matches: &clap::ArgMatches) -> Result<(), Error> {
@@ -623,7 +685,7 @@ pub fn fix_result(gpu: &Gpu, matches: &clap::ArgMatches) -> Result<(), Error> {
     }
     // interpolate when ultrafast
     if cfg.is_ultrafast {
-        interpolate_deltas(&mut all_columns, minimum_delta_core_freq_step, maxq_flag);
+        interpolate_deltas(&mut all_columns, minimum_delta_core_freq_step, maxq_flag)?;
     }
 
     for columns in &mut all_columns {
@@ -895,7 +957,14 @@ pub fn export_vfp_from_log(matches: &clap::ArgMatches) -> Result<(), Error> {
                 continue;
             }
             if let Some(point) = extract_value(line, "point: #") {
-                assert_eq!(last_voltage_point.unwrap(), point);
+                let expected = last_voltage_point.unwrap();
+                if expected != point {
+                    eprintln!(
+                        "Warning: log point mismatch (expected #{}, found #{}) — skipping line",
+                        expected, point
+                    );
+                    continue;
+                }
             }
             if let Some(voltage) = extract_value_f64(line, "voltage: #") {
                 last_voltage = Some(voltage);
@@ -965,6 +1034,14 @@ pub fn key_point_extractor(
                 }
             }
             prev_margin_bin = Some(margin_bin);
+        }
+
+        if records.is_empty() {
+            return Err(Error::Custom(
+                "no rows with voltage > 680000 μV found in CSV — \
+                 cannot determine key points for MaxQ profile"
+                    .to_string(),
+            ));
         }
 
         for i in 0..records.len() - 1 {

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -1101,10 +1101,13 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
 
         pre_load_vf_recheck(args.common.matches, args.point);
 
-        println!(
-            "current test progress estimated:{:.2}%",
-            (mem_test_num + mem_test_code - 1) / (args.mem_freq_step_exp + mem_test_code - 1)
-        );
+        let denom = args.mem_freq_step_exp + mem_test_code - 1;
+        let progress_pct = if denom > 0 {
+            (mem_test_num + mem_test_code - 1) as f64 / denom as f64 * 100.0
+        } else {
+            0.0
+        };
+        println!("current test progress estimated:{:.2}%", progress_pct);
         println!("current test num: {}", mem_test_num);
 
         log_point_test_header(


### PR DESCRIPTION
## Summary

Root-cause fixes for 7 open issues across `auto-optimizer`. Each fix targets the upstream source of the bug rather than patching symptoms.

---

### #46 — `TestResolution::downgrade()` infinite loops (critical correctness)

**Root cause**: Two self-referential match arms:
- `R640x384 => Some(R640x384)` — jumps to itself forever
- `R400x300 => Some(R400x300)` — lowest resolution loops instead of terminating

**Fix** (`basic_func.rs`):
```rust
// Before
TestResolution::R640x384 => Some(TestResolution::R640x384),
TestResolution::R400x300 => Some(TestResolution::R400x300),

// After
TestResolution::R640x384 => Some(TestResolution::R576x360),
TestResolution::R400x300 => None,
```

Unit tests added: `test_resolution_downgrade_ladder`, `test_resolution_r640x384_not_self_loop`, `test_resolution_r400x300_is_terminal`.

---

### #43 — `linear_interpolate` NaN and u32 underflow (data corruption)

**Root cause** (`oc_profile_function.rs`):
1. When `v1 == v2` (flat V-F region): `(current_v - v1) as f64 / (v2 - v1) as f64` → `0.0/0.0 = NaN`. All comparisons with NaN return false, so the result silently becomes 0.
2. When `current_v < v1`: `current_v - v1` underflows as `u32`, wrapping to ~4.29 billion → garbage interpolated delta.

**Fix**: Return `Result<i32, Error>`. Special-case the flat region (`d1/2 + d2/2`). Normalise to `(lo_v, hi_v)` and bounds-check `current_v` before subtraction.

---

### #42 — Panics and silent data corruption in ultrafast/MaxQ profile (multiple)

**Root causes** (`oc_profile_function.rs`):

- **A** `get_key_points_indices`: panicked with index-out-of-bounds when fewer than 4 key rows exist → now returns `Result` with a descriptive error.
- **B** `interpolate_deltas`: scattered `.unwrap()` on CSV column parses → replaced with `parse_col::<T>()` helper that propagates `Result`.
- **C** `key_point_extractor`: `records[0..records.len()-1]` panics on empty slice → guarded with an early `is_empty()` check.
- **D** `extract_default_frequencies`: `record[col]` index operator on `StringRecord` panics on short rows → replaced with `.get(col).ok_or_else(...)`.
- **E** `export_vfp_from_log`: `assert_eq!` on log point ordering panics on out-of-order logs → replaced with a `continue` + `eprintln!` warning.

---

### #44 — Non-atomic CSV write in `update_csv_with_load_and_margin` (data loss risk)

**Root cause**: `fs::remove_file(dest)` followed by `fs::rename(tmp, dest)` creates a window where neither file exists; a crash between the two calls loses the CSV permanently.

**Fix**: Write to a sibling temp file (`.filename.tmp-<pid>`), then call a single `fs::rename(tmp, dest)` — on POSIX this is atomic and replaces the destination without a gap.

---

### #47 — `select_gpus`/`select_gpu_ids` silently drops invalid GPU indices (UX)

**Root cause**: When `--gpu N` refers to a non-existent index the code fell through the match without inserting any GPU and without returning an error, causing subsequent operations to run on zero GPUs.

**Fix**: Both functions now return `Err` with a human-readable message when no GPU matches the given index/ID.

---

### #48 / #49 — No input validation on numeric CLI args (overflow / crash)

**Root cause** (`arg_help.rs`): All numeric arguments (`--vboost`, `--tlimit`, `--voltage_delta`, `--core`, `--memory`, `--plimit`, `--level`, `--timeout_loops`, etc.) were declared as raw strings and parsed at call sites with no range checks. Out-of-range values (e.g. `--core 999999`) caused integer overflows or panics deep in the NvAPI/NVML call path.

**Fix**: Added `value_parser!(T).range(lo..=hi)` to every numeric argument, letting clap reject bad values before any code runs. All call sites updated to use typed getters (`get_one::<u32>()`, `get_one::<i32>()`, etc.).

---

### #17 — Memory autoscan progress always shows 0.00% (UX)

**Root cause** (`oc_scanner.rs`): Integer division truncated the result to 0 before the `{:.2}%` format string could display decimals.

**Fix**: Promote to `f64` before dividing, multiply by 100.0, guard against divide-by-zero.

---

## Test plan

- [x] `cargo check` — zero errors, zero warnings
- [x] `cargo test` — 3/3 tests pass (`test_resolution_downgrade_ladder`, `test_resolution_r640x384_not_self_loop`, `test_resolution_r400x300_is_terminal`)
- [ ] Manual smoke-test: `nvoc set vfp autoscan --help` — verify range-bounded args visible in help
- [ ] Manual smoke-test: `nvoc set vfp autoscan --timeout_loops 0` — verify clap rejects out-of-range value
- [ ] Manual smoke-test: `nvoc --gpu 99 get` — verify error message for invalid GPU index

## Issues closed

Closes #17, #42, #43, #44, #46, #47, #48, #49

https://claude.ai/code/session_01UuB2RiU4fsy8TaYEGZP2r4

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuB2RiU4fsy8TaYEGZP2r4)_