### PR TITLE
Update gpu-ci.yml

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -86,8 +86,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      # - uses: dtolnay/rust-toolchain@stable
+      # - uses: Swatinem/rust-cache@v2
         with:
           workspaces: auto-optimizer -> target
       - name: build


### PR DESCRIPTION
现在跑GPU-CI，在auto-optimizer会遇到：
N/ec\ WSL \O:N,g0W�|�~ЏL�0 ���Nx: Bash/WSL_E_LOCAL_SYSTEM_NOT_SUPPORTED

dtolnay/rust-toolchain action 在 Windows 上会尝试调用 bash/WSL。

这是原生windows，已经预装rust了，不用加工具链，救命。。。