### PR TITLE
fix(tui): persist config next to exe in PyInstaller one-file builds

### DIFF
--- a/tui/nvoc_tui/models.py
+++ b/tui/nvoc_tui/models.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -126,4 +127,7 @@ class OutputLine:
 
 
 def repo_root() -> Path:
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        # PyInstaller one-file: write config next to the executable, not the temp extraction dir
+        return Path(sys.executable).resolve().parent
     return Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Superseded by commit `d095a01` on PR #77

The same `repo_root()` frozen-path fix was applied directly to the `tui-pyinstaller-spec-update` branch in commit `d095a01`, along with a unit test (`test_repo_root_uses_executable_dir_when_frozen`) that passes in CI. This PR is now dirty/conflicted and redundant — closing in favour of the fix already in PR #77.