### PR TITLE
fix(auto-optimizer): enforce DEVMODEW buffer adequacy at compile time (closes #45)

### DIFF
--- a/auto-optimizer/src/basic_func.rs
+++ b/auto-optimizer/src/basic_func.rs
@@ -47,6 +47,11 @@ fn get_primary_screen_size_raw() -> (u32, u32) {
     //   +176  dmPelsHeight      = 4 字节  ← OFFSET_PELS_HEIGHT
     //   …（后续字段省略，总结构体大小 220 字节）
     // 参考：https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-devmodew
+    //
+    // DEVMODEW_SIZE is the documented, stable Win32 ABI value (unchanged since Windows 2000).
+    // We avoid the `windows` crate to keep dependencies minimal, so size_of::<DEVMODEW>() is
+    // unavailable; this constant records the same value. The static assert below enforces that
+    // AlignedBuf always has enough capacity — it will fail to compile if the constant ever drifts.
     const DEVMODEW_SIZE: usize = 220;
     const OFFSET_DM_SIZE: usize = 68;
     const OFFSET_PELS_WIDTH: usize = 172;
@@ -54,6 +59,10 @@ fn get_primary_screen_size_raw() -> (u32, u32) {
     const ENUM_CURRENT_SETTINGS: u32 = 0xFFFF_FFFF;
     #[repr(C, align(4))]
     struct AlignedBuf([u8; 256]);
+    const _: () = assert!(
+        DEVMODEW_SIZE <= std::mem::size_of::<AlignedBuf>(),
+        "AlignedBuf must be at least DEVMODEW_SIZE bytes"
+    );
     unsafe {
         let mut aligned = AlignedBuf([0u8; 256]);
         let buf = &mut aligned.0;


### PR DESCRIPTION
## Summary

Root-cause fix for #45.

---

### Problem

`get_primary_screen_size_raw` in `basic_func.rs` declares:

```rust
const DEVMODEW_SIZE: usize = 220;   // hardcoded
struct AlignedBuf([u8; 256]);       // buffer
```

The two values are related (the buffer must be ≥ the struct size), but nothing in the compiler enforces that relationship. If `DEVMODEW_SIZE` were ever updated — or the buffer shrank — the mismatch would be a silent runtime hazard, not a compile error.

The `windows` crate is intentionally absent to keep dependencies minimal, so `std::mem::size_of::<DEVMODEW>()` is unavailable as a direct substitute.

---

### Fix

Add a compile-time assertion that ties the two values together:

```rust
const _: () = assert!(
    DEVMODEW_SIZE <= std::mem::size_of::<AlignedBuf>(),
    "AlignedBuf must be at least DEVMODEW_SIZE bytes"
);
```

Also add a comment explaining *why* the constant exists instead of `size_of<DEVMODEW>()`, so future readers don't re-raise this as a missing abstraction.

- `DEVMODEW_SIZE = 220` is unchanged — it is the documented stable Win32 ABI value per [MSDN](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-devmodew), unchanged since Windows 2000.
- No runtime behaviour change.
- Zero new dependencies.

---

## Test plan

- [x] `cargo check` — clean (1 pre-existing dead_code warning unrelated to this change)
- [x] Intentionally set `AlignedBuf([u8; 200])` — triggers `"AlignedBuf must be at least DEVMODEW_SIZE bytes"` at compile time ✓

https://claude.ai/code/session_01B4Ty8pW9VGQbcNacewULd4

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4Ty8pW9VGQbcNacewULd4)_