### PR TITLE
fix(auto-optimizer): saturating_mul + voltage range guard in parse_lock_voltage (closes #82)

### DIFF
--- a/auto-optimizer/src/oc_get_set_function_nvapi.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvapi.rs
@@ -375,11 +375,24 @@ fn parse_lock_voltage(
         .is_ok_and(|v| v.copied().unwrap_or(false))
     {
         let input_voltage = raw_target.parse::<u32>()?;
+        // Values ≥ 10 000 are already in µV; smaller values are in mV and need ×1000.
+        // Use saturating_mul for consistency with every other MHz/mV→kHz/µV conversion
+        // in this file (even though the < 10 000 guard prevents overflow in practice).
         let voltage_uv = if input_voltage >= 10_000 {
             input_voltage
         } else {
-            input_voltage * 1000
+            input_voltage.saturating_mul(1000)
         };
+        // Reject values outside any plausible consumer/professional GPU voltage window
+        // before handing an arbitrary number to the undocumented NVAPI voltage-lock path.
+        const MIN_LOCK_UV: u32 = 500_000; // 0.5 V
+        const MAX_LOCK_UV: u32 = 2_000_000; // 2.0 V — generous upper bound
+        if !(MIN_LOCK_UV..=MAX_LOCK_UV).contains(&voltage_uv) {
+            return Err(Error::from(format!(
+                "--voltage {} µV is outside the supported range {}–{} µV (0.5–2.0 V)",
+                voltage_uv, MIN_LOCK_UV, MAX_LOCK_UV
+            )));
+        }
         Ok(Microvolts(voltage_uv))
     } else {
         let point = raw_target.parse::<usize>().unwrap_or(default_point);


### PR DESCRIPTION
## Summary

Follow-up to #16 (closed) and its "follow-up sweep" note. `parse_lock_voltage` was the **only** remaining multiplication in `oc_get_set_function_nvapi.rs` that still used bare `*` instead of `.saturating_mul()`.

- Fixes #82

---

### Root cause

`parse_lock_voltage` (line 381) contained:
```rust
input_voltage * 1000   // bare multiply
```
while every other mV→µV / MHz→kHz conversion in the same file uses `.saturating_mul()` — a pattern established by PR #57 (issue #16). The `< 10 000` guard prevents a runtime overflow today, but the inconsistency is a latent hazard for future refactors and an audit gap in the voltage-lock path.

Additionally, no upper-bound sanity check existed before the computed µV value was handed to `gpu.set_vfp_lock_voltage()` via the undocumented NVAPI path — so a user entering `--voltage 9999` (mV) would produce 9 999 000 µV ≈ **10 V**, which would be forwarded to the driver without rejection.

---

### Changes — `auto-optimizer/src/oc_get_set_function_nvapi.rs`

1. **`input_voltage * 1000` → `input_voltage.saturating_mul(1000)`** — style and overflow-hardening, consistent with all other conversions in the file.

2. **Range guard (0.5 V – 2.0 V)** — reject computed µV values outside a generous but sane GPU voltage window before reaching the NVAPI driver call:
   ```rust
   const MIN_LOCK_UV: u32 = 500_000;   // 0.5 V
   const MAX_LOCK_UV: u32 = 2_000_000; // 2.0 V
   if !(MIN_LOCK_UV..=MAX_LOCK_UV).contains(&voltage_uv) {
       return Err(Error::from(format!(
           "--voltage {} µV is outside the supported range {}–{} µV (0.5–2.0 V)",
           voltage_uv, MIN_LOCK_UV, MAX_LOCK_UV
       )));
   }
   ```

---

## Test plan

- [x] `cargo check -p nvoc-auto-optimizer` — clean
- [ ] `nvoc set nvapi --voltage 1000` (mV path) — accepted, converted to 1 000 000 µV
- [ ] `nvoc set nvapi --voltage 1000000` (µV path, ≥ 10 000) — accepted as-is
- [ ] `nvoc set nvapi --voltage 9999` — rejected: "9 999 000 µV is outside the supported range"
- [ ] `nvoc set nvapi --voltage 300` (mV → 300 000 µV < MIN) — rejected with clear message
- [ ] `nvoc set nvapi --voltage 2500000` (µV > MAX) — rejected with clear message

https://claude.ai/code/session_01VhH8iCMwvAm11N5ZDkC4Fh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhH8iCMwvAm11N5ZDkC4Fh)_