### PR TITLE
ci: add duplicate-crate version audit (closes #12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,12 +230,42 @@ jobs:
           python -m pip install --quiet pytest
           python -m pytest -q test_non_gpu_ci.py
 
+  rust-crate-versions:
+    name: Rust duplicate-crate audit (advisory)
+    runs-on: ubuntu-latest
+    # Advisory: nvml-wrapper 0.11.0 (srv) vs 0.12.1 (auto-optimizer) is a known skew — see #12.
+    # Remove continue-on-error once both crates agree on the same version.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Cargo.lock for duplicate crate versions
+        run: |
+          python3 << 'PYEOF'
+          import sys, re, collections
+          text = open('Cargo.lock').read()
+          blocks = re.split(r'(?=\[\[package\]\])', text)
+          seen = collections.defaultdict(set)
+          for block in blocks:
+              nm = re.search(r'name = "([^"]+)"', block)
+              vr = re.search(r'version = "([^"]+)"', block)
+              if nm and vr:
+                  seen[nm.group(1)].add(vr.group(1))
+          dupes = {k: sorted(v) for k, v in seen.items() if len(v) > 1}
+          if dupes:
+              print('Duplicate crate versions found (advisory — fix and remove continue-on-error):')
+              for name, vers in sorted(dupes.items()):
+                  print(f'  {name}: {", ".join(vers)}')
+              sys.exit(1)
+          print('No duplicate crate versions found.')
+          PYEOF
+
   ci-summary:
     name: ci summary
     needs:
       - changes
       - rust-auto-optimizer
       - rust-srv
+      - rust-crate-versions
       - python-tui
       - python-gui
       - python-stressor-cuda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,30 +233,49 @@ jobs:
   rust-crate-versions:
     name: Rust duplicate-crate audit (advisory)
     runs-on: ubuntu-latest
-    # Advisory: the workspace currently has several duplicate crate versions:
-    #   - nvml-wrapper 0.11.0 (srv) vs 0.12.1 (auto-optimizer) — see #12 (unintentional skew)
-    #   - bitflags, thiserror, zerocopy, windows-sys, etc. (expected semver-breaking upgrades
-    #     pulled in by different transitive dependencies — normal in Rust projects)
-    # Keep continue-on-error until the Cargo.lock reports zero duplicate package names.
+    # Advisory: nvml-wrapper has an unintentional workspace skew (0.11.0 in srv vs
+    # 0.12.1 in auto-optimizer — see #12). All other known duplicates are expected
+    # semver-breaking transitive deps silenced via ALLOWLIST in the script below.
+    # Remove continue-on-error once the nvml-wrapper skew is resolved.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Check Cargo.lock for duplicate crate versions
         run: |
           python3 << 'PYEOF'
           import sys, tomllib, collections
+
+          # Expected transitive duplicates from semver-breaking upgrades pulled in by
+          # different dependency chains.  Add entries only when unavoidable; remove
+          # them once the workspace converges on a single version.
+          ALLOWLIST = {
+              "bitflags",        # 1.x / 2.x
+              "getrandom",       # 0.2 / 0.3 / 0.4
+              "hashbrown",       # 0.15 / 0.17
+              "r-efi",           # 5.x / 6.x
+              "thiserror",       # 1.x / 2.x
+              "thiserror-impl",  # 1.x / 2.x
+              "windows-sys",     # 0.52 / 0.59 / 0.61
+              "wit-bindgen",     # 0.51 / 0.57
+              "zerocopy",        # 0.6 / 0.8
+              "zerocopy-derive", # 0.6 / 0.8
+          }
+
           with open('Cargo.lock', 'rb') as f:
               data = tomllib.load(f)
           seen = collections.defaultdict(set)
           for pkg in data.get('package', []):
               seen[pkg['name']].add(pkg['version'])
-          dupes = {k: sorted(v) for k, v in seen.items() if len(v) > 1}
+          dupes = {k: sorted(v) for k, v in seen.items() if len(v) > 1 and k not in ALLOWLIST}
           if dupes:
-              print('Duplicate crate versions found (advisory):')
+              print('Unexpected duplicate crate versions found:')
               for name, vers in sorted(dupes.items()):
                   print(f'  {name}: {", ".join(vers)}')
               sys.exit(1)
-          print('No duplicate crate versions found.')
+          print('No unexpected duplicate crate versions found.')
           PYEOF
 
   ci-summary:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,13 +231,11 @@ jobs:
           python -m pytest -q test_non_gpu_ci.py
 
   rust-crate-versions:
-    name: Rust duplicate-crate audit (advisory)
+    name: Rust duplicate-crate audit
     runs-on: ubuntu-latest
-    # Advisory: nvml-wrapper has an unintentional workspace skew (0.11.0 in srv vs
-    # 0.12.1 in auto-optimizer — see #12). All other known duplicates are expected
-    # semver-breaking transitive deps silenced via ALLOWLIST in the script below.
-    # Remove continue-on-error once the nvml-wrapper skew is resolved.
-    continue-on-error: true
+    # Guards against unintentional workspace version skew. The ALLOWLIST below
+    # covers expected semver-breaking transitive duplicates; any crate not on
+    # the list that appears at multiple versions will fail this job.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,11 @@ jobs:
   rust-crate-versions:
     name: Rust duplicate-crate audit (advisory)
     runs-on: ubuntu-latest
-    # Advisory: nvml-wrapper 0.11.0 (srv) vs 0.12.1 (auto-optimizer) is a known skew — see #12.
-    # Remove continue-on-error once both crates agree on the same version.
+    # Advisory: the workspace currently has several duplicate crate versions:
+    #   - nvml-wrapper 0.11.0 (srv) vs 0.12.1 (auto-optimizer) — see #12 (unintentional skew)
+    #   - bitflags, thiserror, zerocopy, windows-sys, etc. (expected semver-breaking upgrades
+    #     pulled in by different transitive dependencies — normal in Rust projects)
+    # Keep continue-on-error until the Cargo.lock reports zero duplicate package names.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -249,7 +252,7 @@ jobs:
               seen[pkg['name']].add(pkg['version'])
           dupes = {k: sorted(v) for k, v in seen.items() if len(v) > 1}
           if dupes:
-              print('Duplicate crate versions found (advisory — fix and remove continue-on-error):')
+              print('Duplicate crate versions found (advisory):')
               for name, vers in sorted(dupes.items()):
                   print(f'  {name}: {", ".join(vers)}')
               sys.exit(1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,15 +241,12 @@ jobs:
       - name: Check Cargo.lock for duplicate crate versions
         run: |
           python3 << 'PYEOF'
-          import sys, re, collections
-          text = open('Cargo.lock').read()
-          blocks = re.split(r'(?=\[\[package\]\])', text)
+          import sys, tomllib, collections
+          with open('Cargo.lock', 'rb') as f:
+              data = tomllib.load(f)
           seen = collections.defaultdict(set)
-          for block in blocks:
-              nm = re.search(r'name = "([^"]+)"', block)
-              vr = re.search(r'version = "([^"]+)"', block)
-              if nm and vr:
-                  seen[nm.group(1)].add(vr.group(1))
+          for pkg in data.get('package', []):
+              seen[pkg['name']].add(pkg['version'])
           dupes = {k: sorted(v) for k, v in seen.items() if len(v) > 1}
           if dupes:
               print('Duplicate crate versions found (advisory — fix and remove continue-on-error):')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -170,8 +214,10 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -179,6 +225,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -802,6 +854,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,20 +1027,6 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
-dependencies = [
- "bitflags 2.11.1",
- "libloading",
- "nvml-wrapper-sys",
- "static_assertions",
- "thiserror 1.0.69",
- "wrapcenum-derive",
-]
-
-[[package]]
-name = "nvml-wrapper"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
@@ -1015,7 +1059,7 @@ dependencies = [
  "nvapi",
  "nvapi-hi",
  "nvapi-sys",
- "nvml-wrapper 0.12.1",
+ "nvml-wrapper",
  "nvml-wrapper-sys",
  "quick-error",
  "serde_json",
@@ -1037,7 +1081,7 @@ dependencies = [
  "log",
  "log2",
  "nvapi-hi",
- "nvml-wrapper 0.11.0",
+ "nvml-wrapper",
  "nvml-wrapper-sys",
  "nvoc-auto-optimizer",
  "serde",
@@ -1052,6 +1096,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "os_pipe"
@@ -1560,6 +1610,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,48 @@
 members = ["auto-optimizer", "srv"]
 resolver = "2"
 
+[workspace.package]
+edition = "2024"
+
 [profile.release]
 incremental = true
 panic = "abort"
 opt-level = 2
 lto = "thin"
 codegen-units = 8
+
+[workspace.dependencies]
+nvoc-auto-optimizer = { path = "./auto-optimizer" }
+
+anyhow = "*"
+async-stream = "0.3"
+chrono = "0.4"
+clap = { version = "4.5.60", features = [
+  "std",
+  "help",
+  "usage",
+  "error-context",
+] }
+compio = { version = "0.15.0", features = ["runtime", "time"] }
+csv = "1.4.0"
+futures-util = "0.3"
+flume = "0.11"
+humantime = "2.2.0"
+log = "0.4"
+log2 = "0.2.2"
+gag = "1.0.0"
+num-traits = "0.2.19"
+nvml-wrapper = "0.12.0"
+nvml-wrapper-sys = "0.9.0"
+nvapi-hi = { version = "0.2.0", features = [
+  "serde",
+], git = "https://github.com/arcnmx/nvapi-rs", branch = "v0.2.x" }
+nvapi-sys = { git = "https://github.com/arcnmx/nvapi-rs", branch = "v0.2.x" }
+nvapi = { git = "https://github.com/arcnmx/nvapi-rs", branch = "v0.2.x" }
+quick-error = "2.0.1"
+time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
+tiny_http = "0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+windows-service = "0.8.0"
+windows-sys = { version = "0.61.2", features = ["Win32"] }

--- a/auto-optimizer/Cargo.toml
+++ b/auto-optimizer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nvoc-auto-optimizer"
 version = "0.1.0"
 authors = ["Skyworks"]
-edition = "2024"
+edition = { workspace = true }
 
 description = "NVIDIA GPU curve optimizer"
 keywords = ["nvidia", "gtx", "gpu", "nvapi", "overclock"]
@@ -22,15 +22,15 @@ codegen-units = 8
 # $env:CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16"  # 在各机器的构建环境中配置
 
 [dependencies]
-nvapi-hi = { version = "0.2.0", features = ["serde", ], git = "https://github.com/arcnmx/nvapi-rs", branch = "v0.2.x" }
-nvapi-sys = { git = "https://github.com/arcnmx/nvapi-rs", branch = "v0.2.x" }
-nvapi = { git = "https://github.com/arcnmx/nvapi-rs", branch = "v0.2.x" }
-nvml-wrapper = "0.12.1"
-nvml-wrapper-sys = "0.9.1"
-clap = { version = "4.5.60", default-features = false, features = ["std", "help", "usage", "error-context"] }
-quick-error = "2.0.1"
-csv = "1.4.0"
-serde_json = "^1.0.0"
-anyhow = "*"
-num-traits = "0.2.19"
-time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
+nvapi-hi = { workspace = true }
+nvapi-sys = { workspace = true }
+nvapi = { workspace = true }
+nvml-wrapper = { workspace = true }
+nvml-wrapper-sys = { workspace = true }
+clap = { workspace = true }
+quick-error = { workspace = true }
+csv = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+num-traits = { workspace = true }
+time = { workspace = true }

--- a/srv/Cargo.toml
+++ b/srv/Cargo.toml
@@ -3,28 +3,29 @@ name = "nvoc-srv"
 version = "0.0.1"
 description = "NVOC Windows service"
 authors = ["Skyworks"]
-edition = "2024"
+edition = { workspace = true }
 
 [profile.dev]
 incremental = true
 
 [dependencies]
-windows-service = "0.8.0"
-windows-sys = { version = "0.61.2", features = ["Win32"]}
-nvml-wrapper = "0.11.0"
-nvml-wrapper-sys = "0.9.0"
-nvapi-hi = { package = "nvapi-hi", version = "0.2.0", features = ["serde", ], git = "https://github.com/arcnmx/nvapi-rs", branch = "v0.2.x" }
-nvoc-auto-optimizer = { path = "../auto-optimizer" }
-clap = { version = "4.5.60", default-features = false }
-log = "0.4"
-log2 = "0.2.2"
-chrono = "0.4"  
-gag = "1.0.0"
-tiny_http = "0.12"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-futures-util = "0.3"
-compio = { version = "0.15.0", features = ["runtime", "time"] }
-flume = "0.11"
-humantime = "2.2.0"
-async-stream = "0.3"
+nvoc-auto-optimizer = { workspace = true }
+
+async-stream = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+compio = { workspace = true }
+futures-util = { workspace = true }
+flume = { workspace = true }
+humantime = { workspace = true }
+nvml-wrapper = { workspace = true }
+nvml-wrapper-sys = { workspace = true }
+nvapi-hi = { workspace = true }
+log = { workspace = true }
+log2 = { workspace = true }
+gag = { workspace = true }
+tiny_http = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+windows-service = { workspace = true }
+windows-sys = { workspace = true }


### PR DESCRIPTION
## Summary

Adds the last missing piece from #12: a `rust-crate-versions` job that scans `Cargo.lock` for crates appearing at more than one version across the workspace.

The check is pure Python (no cargo needed, works on ubuntu-latest) — it uses stdlib `tomllib` (Python 3.11+) to parse `Cargo.lock` as TOML, collects `{name → {version…}}`, and exits 1 if any name maps to multiple versions that are **not** in the ALLOWLIST of known expected transitive duplicates (bitflags 1.x/2.x, thiserror 1.x/2.x, zerocopy 0.6/0.8, windows-sys 0.52/0.59/0.61, etc.).

An `actions/setup-python@v5` step pins Python 3.11 so the job is deterministic regardless of what ships on `ubuntu-latest`.

## Changes

- **CI**: New `rust-crate-versions` job using `tomllib` + ALLOWLIST; wired into `ci-summary` as a **required** check (no `continue-on-error`).
- **Workspace**: Consolidated all shared dependencies into `[workspace.dependencies]` in root `Cargo.toml`; both `auto-optimizer` and `srv` now use `{ workspace = true }` references.
- **Cargo.lock**: Removed the duplicate `nvml-wrapper 0.11.0` entry — both crates now use `0.12.1`.

## Relationship to issue #12

Issue #12 was opened when there was no CI at all. The `ci.yml` workflow already added:
- ✅ `cargo build` + `cargo test` for `auto-optimizer` (Windows)
- ✅ `cargo build` for `srv` (Windows)
- ✅ `pytest` for `tui` (Ubuntu + Windows, Python 3.11 + 3.12)
- ✅ GUI import smoke test
- ✅ Stressor byte-compile + non-GPU unit tests + ruff
- ✅ `cargo fmt` / `cargo clippy` (advisory)

This PR adds:
- ✅ Version-skew audit via `Cargo.lock` inspection (required)

## Test plan

- [x] Python script tested locally — correctly identifies all ALLOWLIST-filtered duplicates and exits 0 on the current lockfile
- [x] CI `rust-crate-versions` job passes (✅) with the resolved `Cargo.lock`
- [x] All other CI jobs pass (srv, tui, gui, stressor)

https://claude.ai/code/session_01HAKybYtxH4qoZ9PkLzQGrb