### PR TITLE
ci(gpu-ci): portable runner paths, frozen lockfile, uv.lock filters (closes review comments on #96)

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -68,10 +68,12 @@ jobs:
             stressor_cuda:
               - 'cli-stressor-cuda/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
             stressor_opencl:
               - 'cli-stressor-opencl/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
 
   auto-optimizer-gpu:
@@ -103,6 +105,12 @@ jobs:
     if: needs.changes.outputs.stressor_cuda == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, cuda]
     timeout-minutes: 30
+    env:
+      # Use runner.temp for portability across self-hosted Windows runners.
+      # UV_CACHE_DIR is shared across runs (safe); UV_PROJECT_ENVIRONMENT is
+      # run-scoped via run_id to prevent concurrent-job venv corruption.
+      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
+      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\cuda-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-cuda
@@ -111,7 +119,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync
+      - run: uv sync --frozen
       - name: short stress run
         run: uv run python test.py
 
@@ -120,6 +128,9 @@ jobs:
     if: needs.changes.outputs.stressor_opencl == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, opencl]
     timeout-minutes: 30
+    env:
+      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
+      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\opencl-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-opencl
@@ -128,7 +139,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync
+      - run: uv sync --frozen
       - run: uv run python test.py
 
   # opencl-stressor-linux:


### PR DESCRIPTION
## Summary

Addresses the three unresolved Copilot review comments on PR #96 (`gpu-ci-frozen`). Rather than push to a contributor's branch, the fixes are here as a clean commit on top of `main`.

> **Supersedes** the `env:` block introduced in #96 for the `cuda-stressor` job, and extends the same treatment to `opencl-stressor-windows`.

---

### Fix 1 — Hard-coded `E:` drive paths (Copilot comment #1)

**Root cause:** `UV_CACHE_DIR` and `UV_PROJECT_ENVIRONMENT` were hard-coded to `E:\actions-runner\...`. Any self-hosted Windows runner whose runner data lives on `C:`, `D:`, or any other drive would fail with a path-not-found error before the first `uv` invocation.

**Fix:** Replace with `${{ runner.temp }}\uv-cache` and `${{ runner.temp }}\uv-envs\...`. `runner.temp` is a GitHub Actions built-in context variable that resolves to a writable temporary directory on the current runner regardless of drive letter or directory layout.

---

### Fix 2 — Shared venv path causes concurrent-job corruption (Copilot comment #2)

**Root cause:** A single fixed `UV_PROJECT_ENVIRONMENT` path means two workflow runs that happen to execute on the same self-hosted machine simultaneously (e.g. multiple runner registrations, or two PRs with the `ci:gpu` label triggered at the same time) would write into the same venv, producing non-deterministic failures.

**Fix:** Append `${{ github.run_id }}` to the venv path, making it unique per workflow run. The uv cache (`UV_CACHE_DIR`) is intentionally kept shared — the cache is safe to share across runs.

---

### Fix 3 — `uv.lock` missing from path filters (Copilot comment #3)

**Root cause:** The `stressor_cuda` and `stressor_opencl` path filter groups did not include `uv.lock`. With `uv sync --frozen`, a lockfile change is the primary way dependencies change; without `uv.lock` in the filter the GPU stressor jobs would be silently skipped after a dependency bump.

**Fix:** Add `uv.lock` to both filter groups.

---

### Bonus — `uv sync --frozen` for `opencl-stressor-windows`

PR #96 added `--frozen` to the CUDA stressor but not the OpenCL one. This PR applies it consistently to both.

---

## Test plan

- [ ] CI: `stressor_cuda` and `stressor_opencl` jobs trigger when only `uv.lock` changes
- [ ] CI: both jobs use `runner.temp`-derived paths (inspect job log env dump)
- [ ] CI: two concurrent runs on the same runner do not share a venv directory
- [ ] CI: `uv sync --frozen` exits non-zero if lockfile is stale (lockfile-drift guard)

https://claude.ai/code/session_012KLXYYkxmrAh6F5Gdrpymv

---
_Generated by [Claude Code](https://claude.ai/code/session_012KLXYYkxmrAh6F5Gdrpymv)_