### PR TITLE
ci(gpu-ci): fix runner.temp in job env, restore uv.lock filter and --frozen

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -68,12 +68,10 @@ jobs:
             stressor_cuda:
               - 'cli-stressor-cuda/**'
               - 'pyproject.toml'
-              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
             stressor_opencl:
               - 'cli-stressor-opencl/**'
               - 'pyproject.toml'
-              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
 
   auto-optimizer-gpu:
@@ -105,9 +103,6 @@ jobs:
     if: needs.changes.outputs.stressor_cuda == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, cuda]
     timeout-minutes: 30
-    env:
-      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
-      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\cuda-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-cuda
@@ -116,7 +111,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync --frozen
+      - run: uv sync
       - name: short stress run
         run: uv run python test.py
 
@@ -125,9 +120,6 @@ jobs:
     if: needs.changes.outputs.stressor_opencl == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, opencl]
     timeout-minutes: 30
-    env:
-      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
-      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\opencl-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-opencl
@@ -136,7 +128,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync --frozen
+      - run: uv sync
       - run: uv run python test.py
 
   # opencl-stressor-linux:

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -68,10 +68,12 @@ jobs:
             stressor_cuda:
               - 'cli-stressor-cuda/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
             stressor_opencl:
               - 'cli-stressor-opencl/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
 
   auto-optimizer-gpu:
@@ -111,9 +113,14 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync
+      - run: uv sync --frozen
+        env:
+          UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\cuda-stressor-${{ github.run_id }}
       - name: short stress run
         run: uv run python test.py
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\cuda-stressor-${{ github.run_id }}
 
   opencl-stressor-windows:
     needs: changes
@@ -128,8 +135,13 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync
+      - run: uv sync --frozen
+        env:
+          UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\opencl-stressor-${{ github.run_id }}
       - run: uv run python test.py
+        env:
+          UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\opencl-stressor-${{ github.run_id }}
 
   # opencl-stressor-linux:
   #   needs: changes


### PR DESCRIPTION
## Summary

Follow-up to the revert in #102 (which itself reverts #96). This PR fixes the root cause properly so the improvements from #96 can be kept.

**Root cause of #96 breaking CI:** `runner.*` context expressions are only evaluated inside `step` definitions. In a `job`-level `env:` block GitHub Actions expands them to empty strings, causing `uv` to create/search paths like `\uv-cache` on the root of the drive — which either didn't exist or conflicted with other runs, freezing the job.

## Changes

| What | Before (#102 revert state) | After |
|------|---------------------------|-------|
| `UV_CACHE_DIR` / `UV_PROJECT_ENVIRONMENT` | removed (broken at job level in #96) | moved to **step level** where `runner.temp` is valid |
| `uv sync --frozen` | reverted to `uv sync` | restored — fails fast if environment diverges from `uv.lock` |
| `uv.lock` in path filters | removed by revert | restored — lockfile-only updates (security bumps, dep upgrades) now correctly trigger GPU CI |

The `UV_PROJECT_ENVIRONMENT` env var is also forwarded to the `uv run` step so the test script runs inside the isolated per-run venv rather than a default location.

## Merge order

Merge after #102 (or squash both — the net effect is the same). This PR should be rebased/merged only once #102 lands, since both touch `gpu-ci.yml`.

## Test plan

- [ ] GPU CI triggered on a branch that changes only `uv.lock` → jobs `cuda-stressor` and `opencl-stressor-windows` run
- [ ] `uv sync --frozen` step completes without lockfile-update errors
- [ ] `UV_PROJECT_ENVIRONMENT` path resolves to a subdirectory of `runner.temp` (not root of drive)
- [ ] Two concurrent GPU CI runs use distinct `UV_PROJECT_ENVIRONMENT` paths (different `github.run_id`)

https://claude.ai/code/session_01BKo1QeUzm1J8nN6Cd2gFEY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKo1QeUzm1J8nN6Cd2gFEY)_