### PR TITLE
fix(gpu-ci): move runner.* env vars to step-level, restore --frozen and uv.lock filters

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -68,10 +68,12 @@ jobs:
             stressor_cuda:
               - 'cli-stressor-cuda/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
             stressor_opencl:
               - 'cli-stressor-opencl/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
 
   auto-optimizer-gpu:
@@ -111,7 +113,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync
+      - name: set uv cache dirs
+        shell: pwsh
+        run: |
+          Add-Content $env:GITHUB_ENV "UV_CACHE_DIR=$env:RUNNER_TEMP\uv-cache"
+          Add-Content $env:GITHUB_ENV "UV_PROJECT_ENVIRONMENT=$env:RUNNER_TEMP\uv-envs\cuda-stressor-${{ github.run_id }}"
+      - run: uv sync --frozen
       - name: short stress run
         run: uv run python test.py
 
@@ -128,7 +135,12 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync
+      - name: set uv cache dirs
+        shell: pwsh
+        run: |
+          Add-Content $env:GITHUB_ENV "UV_CACHE_DIR=$env:RUNNER_TEMP\uv-cache"
+          Add-Content $env:GITHUB_ENV "UV_PROJECT_ENVIRONMENT=$env:RUNNER_TEMP\uv-envs\opencl-stressor-${{ github.run_id }}"
+      - run: uv sync --frozen
       - run: uv run python test.py
 
   # opencl-stressor-linux:

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -68,12 +68,10 @@ jobs:
             stressor_cuda:
               - 'cli-stressor-cuda/**'
               - 'pyproject.toml'
-              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
             stressor_opencl:
               - 'cli-stressor-opencl/**'
               - 'pyproject.toml'
-              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
 
   auto-optimizer-gpu:
@@ -105,9 +103,6 @@ jobs:
     if: needs.changes.outputs.stressor_cuda == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, cuda]
     timeout-minutes: 30
-    env:
-      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
-      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\cuda-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-cuda
@@ -116,7 +111,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync --frozen
+      - run: uv sync
       - name: short stress run
         run: uv run python test.py
 
@@ -125,9 +120,6 @@ jobs:
     if: needs.changes.outputs.stressor_opencl == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, opencl]
     timeout-minutes: 30
-    env:
-      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
-      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\opencl-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-opencl
@@ -136,7 +128,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync --frozen
+      - run: uv sync
       - run: uv run python test.py
 
   # opencl-stressor-linux:


### PR DESCRIPTION
## Root cause

PR #96 introduced `UV_CACHE_DIR` and `UV_PROJECT_ENVIRONMENT` at **job-level `env:`**, but the `runner.*` context is only available inside **steps** — not at the job level. GitHub Actions silently substitutes an empty string, so the vars expand to garbage paths instead of `$RUNNER_TEMP\...`.

PR #102 reverted #96 entirely (closing without merge), which also lost the legitimate improvements (`uv sync --frozen`, `uv.lock` in path filters).

## Fix

- **Restore `uv.lock`** in `stressor_cuda` and `stressor_opencl` path filters — CI should re-run when the lockfile changes.
- **Restore `uv sync --frozen`** — ensures CI runs against exactly the locked dependency set.
- **Move UV cache vars to a PowerShell step** that writes to `$GITHUB_ENV`. The `runner.*` context _is_ available inside step `run:` commands, and values written to `$GITHUB_ENV` are visible to all subsequent steps in the job.

```yaml
- name: set uv cache dirs
  shell: pwsh
  run: |
    Add-Content $env:GITHUB_ENV "UV_CACHE_DIR=$env:RUNNER_TEMP\uv-cache"
    Add-Content $env:GITHUB_ENV "UV_PROJECT_ENVIRONMENT=$env:RUNNER_TEMP\uv-envs\cuda-stressor-${{ github.run_id }}"
```

## Test plan

- [ ] Trigger GPU CI manually (`workflow_dispatch`) after merge and confirm both `cuda-stressor` and `opencl-stressor-windows` jobs complete without the env-expansion error
- [ ] Verify `uv sync --frozen` succeeds (lockfile is consistent)
- [ ] Confirm `$RUNNER_TEMP` expands to the actual temp dir path in the job logs

https://claude.ai/code/session_01PJQsfyWanwvh6FVtLrH5DU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJQsfyWanwvh6FVtLrH5DU)_