### PR TITLE
ci(gpu-ci): revert invalid runner.* env + restore uv.lock change filters

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -68,10 +68,12 @@ jobs:
             stressor_cuda:
               - 'cli-stressor-cuda/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
             stressor_opencl:
               - 'cli-stressor-opencl/**'
               - 'pyproject.toml'
+              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
 
   auto-optimizer-gpu:

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -68,12 +68,10 @@ jobs:
             stressor_cuda:
               - 'cli-stressor-cuda/**'
               - 'pyproject.toml'
-              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
             stressor_opencl:
               - 'cli-stressor-opencl/**'
               - 'pyproject.toml'
-              - 'uv.lock'
               - '.github/workflows/gpu-ci.yml'
 
   auto-optimizer-gpu:
@@ -105,9 +103,6 @@ jobs:
     if: needs.changes.outputs.stressor_cuda == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, cuda]
     timeout-minutes: 30
-    env:
-      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
-      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\cuda-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-cuda
@@ -116,7 +111,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync --frozen
+      - run: uv sync
       - name: short stress run
         run: uv run python test.py
 
@@ -125,9 +120,6 @@ jobs:
     if: needs.changes.outputs.stressor_opencl == 'true'
     runs-on: [self-hosted, windows, gpu-nvidia, opencl]
     timeout-minutes: 30
-    env:
-      UV_CACHE_DIR: ${{ runner.temp }}\uv-cache
-      UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}\uv-envs\opencl-stressor-${{ github.run_id }}
     defaults:
       run:
         working-directory: cli-stressor-opencl
@@ -136,7 +128,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - uses: astral-sh/setup-uv@v4
-      - run: uv sync --frozen
+      - run: uv sync
       - run: uv run python test.py
 
   # opencl-stressor-linux:


### PR DESCRIPTION
## Summary

Two-commit fix for the broken GPU CI introduced by PR #96.

**Supersedes PR #102** (which contains only the revert; this PR adds the `uv.lock` filter restoration on top).

---

### Commit 1 — Revert PR #96 (same as PR #102)

PR #96 placed `${{ runner.temp }}` inside `jobs.<job>.env:`. GitHub Actions **does not interpolate the `runner` context at the job-level `env` block** — only inside `steps`. The env values were passed as literal strings like `${{ runner.temp }}\uv-cache`, causing `uv` to try to create nonsensical directory paths on the Windows runner.

Fix: remove `UV_CACHE_DIR` / `UV_PROJECT_ENVIRONMENT` overrides and drop `--frozen` (safe for a single dedicated runner).

### Commit 2 — Restore `uv.lock` in stressor change-detection filters

PR #96 added `uv.lock` to the `stressor_cuda` and `stressor_opencl` dorny/paths-filter lists so that a Python dependency bump (lockfile update) would automatically trigger the affected GPU stressor jobs. The revert dropped this as a side-effect.

This commit adds the two `uv.lock` lines back, so dependency updates continue to trigger stressor CI even when `pyproject.toml` itself is unchanged.

---

## Test plan

- [x] `cargo check -p nvoc-auto-optimizer` — clean (1 pre-existing `dead_code` warning)
- [x] `cargo check -p nvoc-srv` — clean (pre-existing Windows-conditional warnings only)
- [ ] CI: stressor jobs must be skipped when only Rust files change (paths-filter working correctly)
- [ ] CI: stressor jobs must fire when `uv.lock` changes (regression check)

https://claude.ai/code/session_01LBVQ1oQxNXCmyvsEnG9WZb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBVQ1oQxNXCmyvsEnG9WZb)_