### PR TITLE
fix(clippy): remove useless format! wrappers around static strings

### DIFF
--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -161,7 +161,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 Some(("nvml-cooler", sub_matches)) => match nvml_ref {
@@ -169,7 +169,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_cooler_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 _ => {


### PR DESCRIPTION
## Summary

- Replace two `format!("NVML backend unavailable")` calls (no format args) in `auto-optimizer/src/main.rs` with plain string literals — fixes `clippy::useless_format` at lines 164 and 172.

## Root cause

`format!` with a static string and no interpolation args is a no-op allocation; clippy flags it as `useless_format`. Since the error type is `Box<dyn std::error::Error>`, `.into()` works directly on `&str` via `impl From<&str> for Box<dyn Error>`.

## Fix

```rust
// before
return Err(format!("NVML backend unavailable").into());

// after
return Err("NVML backend unavailable".into());
```

## Test plan

- [ ] `cargo clippy -p nvoc-auto-optimizer` — no `useless_format` warnings on these lines
- [ ] `cargo check -p nvoc-auto-optimizer` — clean

https://claude.ai/code/session_015c8BLtJS3Cb1GDvYzWBRBa