### PR TITLE
fix(auto-optimizer): saturating_add for i32 delta sum in export_single_point

### DIFF
--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -149,7 +149,7 @@ pub fn export_single_point(point: VfPoint, matches: &clap::ArgMatches) -> Result
             parts[2] = delta_str.clone();
             let y_value: i32 = parts[2].parse().unwrap_or(0);
             let col3_value: i32 = parts[3].parse().unwrap_or(0);
-            parts[1] = (y_value + col3_value).to_string();
+            parts[1] = y_value.saturating_add(col3_value).to_string();
         }
         record_lines.push(parts.join(","));
     }


### PR DESCRIPTION
## Summary

- Replace `y_value + col3_value` with `y_value.saturating_add(col3_value)` in `auto-optimizer/src/oc_profile_function.rs:152` — closes #93.

## Root cause

`export_single_point` updates rows in a user-supplied CSV. It sums the new OC delta (`y_value`, parsed from the just-written `parts[2]`) with a pre-existing column value (`col3_value`, from `parts[3]`). Both are `i32`. With `panic = "abort"` in release builds, an unchecked `i32 + i32` overflow wraps to `i32::MIN` and writes the corrupted value back to the CSV — the next read sees it as a ~−2.1 GHz delta when the user intended +200 MHz.

## Fix

```rust
// before
parts[1] = (y_value + col3_value).to_string();

// after
parts[1] = y_value.saturating_add(col3_value).to_string();
```

`saturating_add` clamps to `i32::MAX`/`i32::MIN` instead of wrapping, matching the project's established style from the `saturating_mul` sweep in PR #57 / PR #87 (`oc_get_set_function_nvapi.rs`).

## Test plan

- [ ] `cargo check -p nvoc-auto-optimizer` — clean
- [ ] Normal small deltas (e.g. `--delta 100000`) — output unchanged
- [ ] CSV with `col3_value = 2_000_000_000` + `--delta 200_000_000`: before = wraps to negative; after = clamps to `i32::MAX`

https://claude.ai/code/session_015c8BLtJS3Cb1GDvYzWBRBa