### PR TITLE
fix(auto-optimizer): saturating_add overflow + remove useless format! wrappers

### DIFF
--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -161,7 +161,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 Some(("nvml-cooler", sub_matches)) => match nvml_ref {
@@ -169,7 +169,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_cooler_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 _ => {

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -149,7 +149,7 @@ pub fn export_single_point(point: VfPoint, matches: &clap::ArgMatches) -> Result
             parts[2] = delta_str.clone();
             let y_value: i32 = parts[2].parse().unwrap_or(0);
             let col3_value: i32 = parts[3].parse().unwrap_or(0);
-            parts[1] = (y_value + col3_value).to_string();
+            parts[1] = y_value.saturating_add(col3_value).to_string();
         }
         record_lines.push(parts.join(","));
     }


### PR DESCRIPTION
## Summary

Two related `auto-optimizer` fixes consolidated from PRs #109 and #110:

- **`oc_profile_function.rs:152`** — replace `y_value + col3_value` with `y_value.saturating_add(col3_value)` to prevent i32 overflow corrupting the CSV (closes #93)
- **`main.rs:164,172`** — replace `format!("NVML backend unavailable")` (no args) with plain `"NVML backend unavailable"` string literal — eliminates `clippy::useless_format` (closes #109)

## Root causes

**Overflow (#93):** `export_single_point` sums new OC delta (`y_value`) and pre-existing column value (`col3_value`). Both are `i32`. With `panic = "abort"` in release builds, unchecked `i32 + i32` overflow wraps to `i32::MIN`, writing a ~−2.1 GHz delta back to the CSV on the next read. `saturating_add` clamps to `i32::MAX`/`i32::MIN` instead, matching the `saturating_mul` pattern from PR #57/#87.

**Clippy lint:** `format!` with a static string and no interpolation args allocates needlessly. `&str` already implements `Into<Box<dyn Error>>` so `.into()` works directly.

## Test plan

- [x] `cargo check -p nvoc-auto-optimizer` — clean
- [x] `cargo clippy -p nvoc-auto-optimizer` — no `useless_format` warnings
- [ ] Normal small deltas (e.g. `--delta 100000`) — output unchanged
- [ ] CSV with `col3_value = 2_000_000_000` + `--delta 200_000_000`: before wraps negative; after clamps to `i32::MAX`

Supersedes #109 and #110.

https://claude.ai/code/session_01K6F2hWLxxwtvae9qv9vPBK

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6F2hWLxxwtvae9qv9vPBK)_