### PR TITLE
fix(auto-optimizer): saturating_add overflow + remove useless format! wrappers

### DIFF
--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -161,7 +161,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 Some(("nvml-cooler", sub_matches)) => match nvml_ref {
@@ -169,7 +169,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_cooler_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 _ => {

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -149,7 +149,7 @@ pub fn export_single_point(point: VfPoint, matches: &clap::ArgMatches) -> Result
             parts[2] = delta_str.clone();
             let y_value: i32 = parts[2].parse().unwrap_or(0);
             let col3_value: i32 = parts[3].parse().unwrap_or(0);
-            parts[1] = (y_value + col3_value).to_string();
+            parts[1] = y_value.saturating_add(col3_value).to_string();
         }
         record_lines.push(parts.join(","));
     }


### PR DESCRIPTION
## Summary

Two related fixes in `nvoc-auto-optimizer`, clustered together:

1. **`oc_profile_function.rs:152`** — replace unchecked `y_value + col3_value` with `y_value.saturating_add(col3_value)` — closes #93.
2. **`main.rs:164,172`** — remove `format!("NVML backend unavailable")` wrappers (no interpolation args) — fixes `clippy::useless_format`.

## Root causes

### 1 — i32 overflow in `export_single_point`

`export_single_point` sums the new OC delta (`y_value`, just written to `parts[2]`) with a pre-existing CSV column value (`col3_value`, from `parts[3]`). Both are `i32`. With `panic = "abort"` in release builds an unchecked `+` silently wraps to `i32::MIN` and writes the corrupted value back to the CSV — the next read sees it as a ~−2.1 GHz delta when the user intended +200 MHz.

`saturating_add` clamps to `i32::MAX`/`i32::MIN`, matching the `saturating_mul` style already in `oc_get_set_function_nvapi.rs` (PR #57 / PR #87).

### 2 — Useless `format!` around static strings

`format!` with a static string and no interpolation args is a no-op allocation; clippy flags it as `clippy::useless_format`. Since the error type is `Box<dyn Error>`, `.into()` works directly on `&str` via `impl From<&str> for Box<dyn Error>`.

## Changes

```rust
// oc_profile_function.rs — before
parts[1] = (y_value + col3_value).to_string();

// oc_profile_function.rs — after
parts[1] = y_value.saturating_add(col3_value).to_string();
```

```rust
// main.rs — before
return Err(format!("NVML backend unavailable").into());

// main.rs — after
return Err("NVML backend unavailable".into());
```

## Test plan

- [x] `cargo check -p nvoc-auto-optimizer` — clean (1 pre-existing dead_code warning, unrelated)
- [x] `cargo clippy -p nvoc-auto-optimizer` — no `useless_format` warnings
- [ ] Normal small deltas (e.g. `--delta 100000`) — output unchanged
- [ ] CSV with `col3_value = 2_000_000_000` + `--delta 200_000_000`: before = wraps to negative; after = clamps to `i32::MAX`

https://claude.ai/code/session_01Q11aVLtRg9h81z1KE2q4Vt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q11aVLtRg9h81z1KE2q4Vt)_