### PR TITLE
fix(stressors): break precision loop on GPU fault to prevent Linux hang

### DIFF
--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -149,7 +149,7 @@ pub fn export_single_point(point: VfPoint, matches: &clap::ArgMatches) -> Result
             parts[2] = delta_str.clone();
             let y_value: i32 = parts[2].parse().unwrap_or(0);
             let col3_value: i32 = parts[3].parse().unwrap_or(0);
-            parts[1] = (y_value + col3_value).to_string();
+            parts[1] = y_value.saturating_add(col3_value).to_string();
         }
         record_lines.push(parts.join(","));
     }

--- a/cli-stressor-cuda/test.py
+++ b/cli-stressor-cuda/test.py
@@ -554,6 +554,10 @@ def main():
         else:
             print(f"  结果: completed without detected error")
         print(f"  累计: {res.iterations} 次 matmul, {res.tflops:.2f} TFLOPS")
+        # On Linux a faulted GPU won't recover without a reboot; stop further
+        # precision tests immediately rather than issuing more GEMM kernels.
+        if res.first_error and res.supported:
+            break
 
     print_summary(device_name, total_memory_gb, results)
 

--- a/cli-stressor-opencl/test.py
+++ b/cli-stressor-opencl/test.py
@@ -979,6 +979,10 @@ def main():
         else:
             print("  结果: completed without detected error")
         print(f"  累计: {res.iterations} 次 matmul, {res.tflops:.2f} TFLOPS")
+        # On Linux a faulted GPU won't recover without a reboot; stop further
+        # precision tests immediately rather than issuing more kernels.
+        if result_status(res) == "FAIL":
+            break
 
     print_summary(runtime, results)
     return 1 if any(result_status(result) == "FAIL" for result in results) else 0


### PR DESCRIPTION
## Summary

- Both `cli-stressor-cuda` and `cli-stressor-opencl` now break out of the per-precision loop immediately after a real (non-SKIP) failure — closes #35.

## Root cause

The inner stress loop was fixed in PR #59 to use `break` instead of `sys.exit(1)`, which preserved multi-precision summaries. However the outer `for spec in precisions` loop in `main()` had no corresponding guard — after one precision failed, `main()` silently continued dispatching GEMM kernels to the next precision.

On Linux, a GPU in an OC-fault state does not self-recover (no TDR equivalent). Firing another kernel into a fallen-off-bus device risks a permanently stuck process that blocks the autoscan recovery script and may require a reboot. @physicsdolphin flagged this in issue #35.

## Fix

```python
# after printing the per-precision result:
if res.first_error and res.supported:   # CUDA
    break

if result_status(res) == "FAIL":        # OpenCL (uses result_status helper)
    break
```

`print_summary()` is still called with all results collected so far, so partial summaries are preserved. The exit code is still non-zero on failure. SKIP results (unsupported precision) do not trigger the break.

> **Note:** the first commit on this branch (`6162e9d`, `saturating_add`) is also being reviewed in PR #111. That commit's diff will disappear from this PR once #111 merges to `main`.

## Test plan

- [ ] CUDA: run with `--precisions fp16,fp32` against a config where FP16 fails; verify FP32 test is **not** started and partial summary is printed
- [ ] OpenCL: same test with two precision modes
- [ ] Normal run (no failures): all precisions complete as before
- [ ] SKIP precision (unsupported): does not trigger early exit; remaining precisions run

https://claude.ai/code/session_01FRS8ASEedS6moqcCWN1Mmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRS8ASEedS6moqcCWN1Mmj)_