### PR TITLE
fix(clippy): resolve 25 actionable clippy warnings in auto-optimizer

### DIFF
--- a/auto-optimizer/src/basic_func.rs
+++ b/auto-optimizer/src/basic_func.rs
@@ -503,19 +503,19 @@ pub fn handle_status(
 
                         human::print_status(&status);
                         human::print_settings(gpu, requires_set(gpu, &mut set)?);
-                        if let Ok(info) = gpu.info() {
-                            if let Some(thresholds) = nvml.and_then(|n| {
+                        if let Ok(info) = gpu.info()
+                            && let Some(thresholds) = nvml.and_then(|n| {
                                 crate::oc_get_set_function_nvml::get_nvml_temperature_thresholds(
                                     n,
                                     info.id as u32,
                                 )
-                            }) {
-                                println!("NVML Temperature Thresholds:");
-                                for (name, value) in thresholds {
-                                    match value {
-                                        Some(temp) => println!("  {:<16} : {} C", name, temp),
-                                        None => println!("  {:<16} : N/A", name),
-                                    }
+                            })
+                        {
+                            println!("NVML Temperature Thresholds:");
+                            for (name, value) in thresholds {
+                                match value {
+                                    Some(temp) => println!("  {:<16} : {} C", name, temp),
+                                    None => println!("  {:<16} : N/A", name),
                                 }
                             }
                         }

--- a/auto-optimizer/src/error.rs
+++ b/auto-optimizer/src/error.rs
@@ -61,6 +61,7 @@ impl From<serde_json::Error> for Error {
 }
 
 quick_error! {
+    #[allow(clippy::enum_variant_names)]
     #[derive(Debug)]
     pub enum Error {
         Nvapi(err: nvapi_hi::Error) {from()source(err)display("NVAPI error: {}", err)}

--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -161,7 +161,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 Some(("nvml-cooler", sub_matches)) => match nvml_ref {
@@ -169,7 +169,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_cooler_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 _ => {

--- a/auto-optimizer/src/oc_get_set_function_nvapi.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvapi.rs
@@ -268,12 +268,12 @@ fn parse_lock_frequency(
             None
         };
 
-    if let Some(lower) = lower_mhz {
-        if lower > upper_mhz {
-            return Err(Error::from(
-                "--clock expects upper bound first and lower bound second",
-            ));
-        }
+    if let Some(lower) = lower_mhz
+        && lower > upper_mhz
+    {
+        return Err(Error::from(
+            "--clock expects upper bound first and lower bound second",
+        ));
     }
 
     let domain = match matches
@@ -993,7 +993,7 @@ pub fn handle_pointwiseoc(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Err
     );
 
     for gpu in gpus {
-        set_vfp_range(&gpu, start..=end, delta)?;
+        set_vfp_range(gpu, start..=end, delta)?;
     }
 
     Ok(())
@@ -1025,38 +1025,35 @@ pub fn handle_test_voltage_limits(
             }
         }
 
-        match gpu_type {
-            Ok(ref t) => {
-                let vlp = t.voltage_limit_params();
-                upper_init_point = vlp.upper_init_point;
-                lower_init_point = vlp.lower_init_point;
-                if vlp.vfp_strict_inc_flag {
-                    vfp_strict_inc_flag = 1;
-                }
-                if vlp.margin_threshold_check {
-                    margin_threshold_check = 1;
-                }
-
-                // 9 系及 Volta/Unknown 的特殊打印（无 VFP 支持）
-                match t {
-                    GpuType::Mobile9Series => {
-                        println!("Mobile 9 Series GPU detected.");
-                        drop(Error::VfpUnsupported);
-                    }
-                    GpuType::Desktop9Series => {
-                        println!("Desktop 9 Series GPU detected.");
-                        drop(Error::VfpUnsupported);
-                    }
-                    GpuType::ComputationVolta => {
-                        println!("Computation Volta GPU detected.");
-                    }
-                    GpuType::Unknown => {
-                        println!("Unknown GPU type detected.");
-                    }
-                    _ => {}
-                }
+        if let Ok(ref t) = gpu_type {
+            let vlp = t.voltage_limit_params();
+            upper_init_point = vlp.upper_init_point;
+            lower_init_point = vlp.lower_init_point;
+            if vlp.vfp_strict_inc_flag {
+                vfp_strict_inc_flag = 1;
             }
-            _ => {}
+            if vlp.margin_threshold_check {
+                margin_threshold_check = 1;
+            }
+
+            // 9 系及 Volta/Unknown 的特殊打印（无 VFP 支持）
+            match t {
+                GpuType::Mobile9Series => {
+                    println!("Mobile 9 Series GPU detected.");
+                    drop(Error::VfpUnsupported);
+                }
+                GpuType::Desktop9Series => {
+                    println!("Desktop 9 Series GPU detected.");
+                    drop(Error::VfpUnsupported);
+                }
+                GpuType::ComputationVolta => {
+                    println!("Computation Volta GPU detected.");
+                }
+                GpuType::Unknown => {
+                    println!("Unknown GPU type detected.");
+                }
+                _ => {}
+            }
         }
     }
 

--- a/auto-optimizer/src/oc_get_set_function_nvml.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvml.rs
@@ -10,12 +10,11 @@ fn find_nvml_device<'n>(nvml: &'n Nvml, gpu_id: u32) -> Option<nvml_wrapper::Dev
     let pci_bus = gpu_id / 256;
     let count = nvml.device_count().ok()?;
     for i in 0..count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci) = dev.pci_info() {
-                if pci.bus == pci_bus {
-                    return Some(dev);
-                }
-            }
+        if let Ok(dev) = nvml.device_by_index(i)
+            && let Ok(pci) = dev.pci_info()
+            && pci.bus == pci_bus
+        {
+            return Some(dev);
         }
     }
     None
@@ -75,25 +74,25 @@ pub fn query_nvml_power_watts_by_pci(pci_bus_id_str: &str) -> Option<(f32, f32, 
             let device_count = nvml.device_count()?;
 
             for i in 0..device_count {
-                if let Ok(dev) = nvml.device_by_index(i) {
-                    if let Ok(pci_info) = dev.pci_info() {
-                        // 匹配策略：比较 PCI Bus 编号
-                        if let Some(target_bus) = nvapi_bus_num {
-                            if pci_info.bus == target_bus {
-                                return Ok(dev);
-                            }
-                        }
+                if let Ok(dev) = nvml.device_by_index(i)
+                    && let Ok(pci_info) = dev.pci_info()
+                {
+                    // 匹配策略：比较 PCI Bus 编号
+                    if let Some(target_bus) = nvapi_bus_num
+                        && pci_info.bus == target_bus
+                    {
+                        return Ok(dev);
+                    }
 
-                        // 备用：宽松字符串匹配
-                        let nvml_pci_str = format!(
-                            "{:04x}:{:02x}:{:02x}.0",
-                            pci_info.domain, pci_info.bus, pci_info.device
-                        );
-                        let nvapi_stripped = pci_bus_id_str.trim_start_matches("0000:");
-                        let nvml_stripped = nvml_pci_str.trim_start_matches("0000:");
-                        if nvapi_stripped.eq_ignore_ascii_case(nvml_stripped) {
-                            return Ok(dev);
-                        }
+                    // 备用：宽松字符串匹配
+                    let nvml_pci_str = format!(
+                        "{:04x}:{:02x}:{:02x}.0",
+                        pci_info.domain, pci_info.bus, pci_info.device
+                    );
+                    let nvapi_stripped = pci_bus_id_str.trim_start_matches("0000:");
+                    let nvml_stripped = nvml_pci_str.trim_start_matches("0000:");
+                    if nvapi_stripped.eq_ignore_ascii_case(nvml_stripped) {
+                        return Ok(dev);
                     }
                 }
             }

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -227,22 +227,18 @@ fn extract_default_frequencies(file_path: &str, legacy_flag: bool) -> Result<Vec
 
     for result in rdr.records() {
         let record = result?;
-        let default_frequency_load: u32;
-
-        if legacy_flag {
-            default_frequency_load = record
+        // Read only frequency column / Read only default_frequency column
+        let default_frequency_load: u32 = if legacy_flag {
+            record
                 .get(1)
                 .ok_or_else(|| Error::Custom("row too short: missing column 1".into()))?
-                .parse()?;
-        }
-        // Read only frequency column
-        else {
-            default_frequency_load = record
+                .parse()?
+        } else {
+            record
                 .get(3)
                 .ok_or_else(|| Error::Custom("row too short: missing column 3".into()))?
-                .parse()?;
-        }
-        // Read only default_frequency column
+                .parse()?
+        };
 
         default_frequencies_load.push(default_frequency_load);
     }
@@ -274,7 +270,6 @@ fn update_csv_with_load_and_margin(
         .has_headers(true)
         .from_writer(File::create(&tmp_path)?);
 
-    let mut index = 0;
     let headers = StringRecord::from(vec![
         "voltage",
         "frequency",
@@ -285,21 +280,20 @@ fn update_csv_with_load_and_margin(
         "margin_bin",
     ]);
     wtr.write_record(&headers)?;
-    for result in rdr.records() {
+    for (index, result) in rdr.records().enumerate() {
         let record = result?;
         let voltage = &record[0];
         let frequency = &record[1];
         let delta = &record[2];
         let default_frequency = default_frequencies.get(index).cloned().unwrap_or(0);
-        let margin: i32;
         let default_frequency_load = default_frequencies_load.get(index).cloned().unwrap_or(0);
 
         // Get the corresponding load frequency
-        if legacy_flag {
-            margin = default_frequency_load as i32 - frequency.parse::<i32>()?;
+        let margin: i32 = if legacy_flag {
+            default_frequency_load as i32 - frequency.parse::<i32>()?
         } else {
-            margin = default_frequency_load as i32 - default_frequency as i32;
-        }
+            default_frequency_load as i32 - default_frequency as i32
+        };
 
         let margin_bin = (margin as f32 / minimum_delta_core_freq_step as f32).round() as i32;
         // Write updated row
@@ -312,7 +306,6 @@ fn update_csv_with_load_and_margin(
             &margin.to_string(),
             &margin_bin.to_string(),
         ])?;
-        index += 1;
     }
 
     wtr.flush()?;
@@ -642,8 +635,8 @@ fn interpolate_deltas(
         p4_d = parse_col::<i32>(&lines[p4_idx], 2, "delta")?;
     }
 
-    for i in 0..lines.len() {
-        let current_v = parse_col::<u32>(&lines[i], 0, "voltage")?;
+    for (i, line) in lines.iter_mut().enumerate() {
+        let current_v = parse_col::<u32>(line, 0, "voltage")?;
         let stair_inferred = min(p2_idx - p1_idx, p3_idx - p2_idx);
 
         let new_delta = if i < p1_idx {
@@ -662,7 +655,7 @@ fn interpolate_deltas(
             p4_d
         };
 
-        lines[i][2] = new_delta.to_string();
+        line[2] = new_delta.to_string();
     }
     Ok(())
 }
@@ -901,31 +894,30 @@ pub fn break_point_continue(
             break;
         }
 
-        if last_voltage_point.is_none() {
-            if let Some(point) = extract_value(line, "point: #") {
-                last_voltage_point = Some(point as usize);
+        if last_voltage_point.is_none()
+            && let Some(point) = extract_value(line, "point: #")
+        {
+            last_voltage_point = Some(point as usize);
 
-                if line.contains("Finished") {
-                    last_voltage_point = last_voltage_point.map(|v| v + testing_step);
-                    break;
-                }
+            if line.contains("Finished") {
+                last_voltage_point = last_voltage_point.map(|v| v + testing_step);
+                break;
             }
         }
 
-        if last_code_100_freq.is_none() {
-            if line.contains("Test result is code #0") {
-                if let Some(freq) = extract_value_f64(line, "freq_delta: #") {
-                    last_code_100_freq = Some(freq);
-                }
-            }
+        if last_code_100_freq.is_none()
+            && line.contains("Test result is code #0")
+            && let Some(freq) = extract_value_f64(line, "freq_delta: #")
+        {
+            last_code_100_freq = Some(freq);
         }
 
-        if last_code_0_freq.is_none() {
-            if line.contains("Test") && !line.contains("Test result is code #0") {
-                if let Some(freq) = extract_value_f64(line, "freq_delta: #") {
-                    last_code_0_freq = Some(freq);
-                }
-            }
+        if last_code_0_freq.is_none()
+            && line.contains("Test")
+            && !line.contains("Test result is code #0")
+            && let Some(freq) = extract_value_f64(line, "freq_delta: #")
+        {
+            last_code_0_freq = Some(freq);
         }
 
         if last_voltage_point.is_some()
@@ -966,11 +958,9 @@ pub fn export_vfp_from_log(matches: &clap::ArgMatches) -> Result<(), Error> {
             break;
         }
 
-        if line.contains("Finished") {
-            if let Some(point) = extract_value(line, "point: #") {
-                last_voltage_point = Some(point);
-                last_code_100_freq = None;
-            }
+        if line.contains("Finished") && let Some(point) = extract_value(line, "point: #") {
+            last_voltage_point = Some(point);
+            last_code_100_freq = None;
         }
 
         if last_code_100_freq.is_none() && line.contains("Test result is code #100") {
@@ -978,14 +968,14 @@ pub fn export_vfp_from_log(matches: &clap::ArgMatches) -> Result<(), Error> {
             if last_voltage_point.is_none() {
                 continue;
             }
-            if let Some(point) = extract_value(line, "point: #") {
-                if last_voltage_point != Some(point) {
-                    eprintln!(
-                        "Warning: export_vfp_from_log: expected voltage point {:?}, got {} — skipping",
-                        last_voltage_point, point
-                    );
-                    continue;
-                }
+            if let Some(point) = extract_value(line, "point: #")
+                && last_voltage_point != Some(point)
+            {
+                eprintln!(
+                    "Warning: export_vfp_from_log: expected voltage point {:?}, got {} — skipping",
+                    last_voltage_point, point
+                );
+                continue;
             }
             if let Some(voltage) = extract_value_f64(line, "voltage: #") {
                 last_voltage = Some(voltage);

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -829,8 +829,7 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
             KilohertzDelta(*init_core_oc_value),
         )?;
 
-        let test_flag;
-        test_flag = test_pressure(
+        let test_flag = test_pressure(
             &gpu,
             args.common.matches,
             point,
@@ -1054,8 +1053,7 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
             KilohertzDelta(*init_vmem_oc_value),
         )?;
 
-        let mem_test_flag;
-        mem_test_flag = test_pressure(
+        let mem_test_flag = test_pressure(
             &gpu,
             args.common.matches,
             args.point,
@@ -1268,32 +1266,30 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(),
         let mut last_failed_freq = core_oc_safe_limit_ref;
         let recovery_method_switch: bool = cfg.recovery_method.unwrap_or(is_50_series);
 
-        match break_point_continue(log_filename, testing_step)? {
-            (succeeded_freq, failed_freq, last_voltage_point, ultrafast_flag) => {
-                println!("Extracted Values:");
+        let (succeeded_freq, failed_freq, last_voltage_point, ultrafast_flag) =
+            break_point_continue(log_filename, testing_step)?;
+        println!("Extracted Values:");
 
-                if let Some(freq_s) = succeeded_freq {
-                    println!("  - Last freq_delta succeeded: {} MHz", freq_s);
-                    last_succeeded_freq = (freq_s * 1000.0) as i32; // Update if present
-                }
+        if let Some(freq_s) = succeeded_freq {
+            println!("  - Last freq_delta succeeded: {} MHz", freq_s);
+            last_succeeded_freq = (freq_s * 1000.0) as i32; // Update if present
+        }
 
-                if let Some(freq_f) = failed_freq {
-                    println!("  - Last freq_delta failed: {} MHz", freq_f);
-                    last_failed_freq = (freq_f * 1000.0) as i32; // Update if present
-                }
+        if let Some(freq_f) = failed_freq {
+            println!("  - Last freq_delta failed: {} MHz", freq_f);
+            last_failed_freq = (freq_f * 1000.0) as i32; // Update if present
+        }
 
-                if let Some(voltage_point) = last_voltage_point {
-                    println!("  - Last voltage point: {}", voltage_point);
-                    point = voltage_point; // Update if present
-                    resuming_flag = true;
-                }
+        if let Some(voltage_point) = last_voltage_point {
+            println!("  - Last voltage point: {}", voltage_point);
+            point = voltage_point; // Update if present
+            resuming_flag = true;
+        }
 
-                if let Some(ultrafast_flag) = ultrafast_flag {
-                    println!("Inheriting last scanner flag...");
-                    is_ultrafast = ultrafast_flag; // Update if present
-                    resuming_flag = true;
-                }
-            }
+        if let Some(ultrafast_flag) = ultrafast_flag {
+            println!("Inheriting last scanner flag...");
+            is_ultrafast = ultrafast_flag; // Update if present
+            resuming_flag = true;
         }
 
         if is_ultrafast {
@@ -1682,22 +1678,20 @@ pub fn autoscan_legacy(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(), Err
         let mut last_succeeded_freq = init_core_oc_value;
         let mut last_failed_freq = core_oc_safe_limit_ref;
 
-        match break_point_continue(log_filename, 1 /* single point, step=1 */)? {
-            (succeeded_freq, failed_freq, last_voltage_point, _ultrafast_flag) => {
-                if let Some(freq_s) = succeeded_freq {
-                    println!("  - Last freq_delta succeeded: {} MHz", freq_s);
-                    last_succeeded_freq = (freq_s * 1000.0) as i32;
-                }
-                if let Some(freq_f) = failed_freq {
-                    println!("  - Last freq_delta failed: {} MHz", freq_f);
-                    last_failed_freq = (freq_f * 1000.0) as i32;
-                }
-                if last_voltage_point.is_some() {
-                    // For legacy, any breakpoint means we can resume
-                    resuming_flag = true;
-                    println!("Resuming legacy scan from breakpoint...");
-                }
-            }
+        let (succeeded_freq, failed_freq, last_voltage_point, _ultrafast_flag) =
+            break_point_continue(log_filename, 1 /* single point, step=1 */)?;
+        if let Some(freq_s) = succeeded_freq {
+            println!("  - Last freq_delta succeeded: {} MHz", freq_s);
+            last_succeeded_freq = (freq_s * 1000.0) as i32;
+        }
+        if let Some(freq_f) = failed_freq {
+            println!("  - Last freq_delta failed: {} MHz", freq_f);
+            last_failed_freq = (freq_f * 1000.0) as i32;
+        }
+        if last_voltage_point.is_some() {
+            // For legacy, any breakpoint means we can resume
+            resuming_flag = true;
+            println!("Resuming legacy scan from breakpoint...");
         }
 
         // Apply breakpoint-restored values


### PR DESCRIPTION
## Summary

Addresses 25 clippy warnings across the `auto-optimizer` crate (down from 34 to 10 intentionally-skipped architectural ones). Supersedes #109 — the `useless_format` fix is included here as the first commit.

### Fixes applied

| Lint | Count | Files |
|---|---|---|
| `collapsible_if` | 13 | `basic_func`, `oc_get_set_function_nvapi`, `oc_get_set_function_nvml`, `oc_profile_function`, `oc_scanner` |
| `needless_late_init` | 4 | `oc_profile_function` (×2), `oc_scanner` (×2) |
| `useless_format` | 2 | `main.rs` |
| `explicit_counter_loop` | 1 | `oc_profile_function` — `rdr.records().enumerate()` |
| `needless_range_loop` | 1 | `oc_profile_function` — `iter_mut().enumerate()` |
| `needless_borrow` | 1 | `oc_get_set_function_nvapi` |
| `single_match` | 1 | `oc_get_set_function_nvapi` — `match → if let` |
| `match_single_binding` | 2 | `oc_scanner` — irrefutable tuple match → `let` |
| `enum_variant_names` | 1 | `error.rs` — `#[allow]` inside `quick_error!` |

### Intentionally not fixed

- `type_complexity` (4) — requires introducing type aliases; separate refactor
- `too_many_arguments` (4) — requires structural changes to scanner functions
- `field_reassign_with_default` (2) — FFI structs (`NV_GPU_PERF_PSTATES20_INFO`) with per-field comments that would be lost in struct initializer form

### PR status overview

- **PR #109** — superseded by this PR (useless_format fix is commit 1 here)
- **PR #110** — orthogonal fix (`saturating_add` for issue #93); independent, should merge separately

## Test plan

- [x] `cargo check -p nvoc-auto-optimizer` — clean (1 expected dead_code for public API)
- [x] `cargo clippy -p nvoc-auto-optimizer` — 10 warnings remaining (all intentionally skipped architectural lints)
- [ ] `auto-optimizer (windows)` CI job

https://claude.ai/code/session_017sBpypGRDKycPM32GVGQ9r

---
_Generated by [Claude Code](https://claude.ai/code/session_017sBpypGRDKycPM32GVGQ9r)_