### PR TITLE
fix(auto-optimizer,stressor): format! cleanup + stressor fail-fast on GPU error

### DIFF
--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -161,7 +161,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 Some(("nvml-cooler", sub_matches)) => match nvml_ref {
@@ -169,7 +169,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_cooler_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 _ => {

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -149,7 +149,7 @@ pub fn export_single_point(point: VfPoint, matches: &clap::ArgMatches) -> Result
             parts[2] = delta_str.clone();
             let y_value: i32 = parts[2].parse().unwrap_or(0);
             let col3_value: i32 = parts[3].parse().unwrap_or(0);
-            parts[1] = (y_value + col3_value).to_string();
+            parts[1] = y_value.saturating_add(col3_value).to_string();
         }
         record_lines.push(parts.join(","));
     }

--- a/cli-stressor-cuda/test.py
+++ b/cli-stressor-cuda/test.py
@@ -569,6 +569,11 @@ def main():
             # 如果是检测到不支持（SKIP）则不视为测试失败，否则视为失败
             if res.supported:
                 overall_passed = False
+                print(f"  累计: {res.iterations} 次 matmul, {res.tflops:.2f} TFLOPS")
+                # GPU may be in a fault/bus-fallen state on Linux (no TDR); do not
+                # attempt further precisions — print partial summary and exit now.
+                print_summary(device_name, total_memory_gb, results)
+                sys.exit(1)
         else:
             print("  结果: completed without detected error")
         print(f"  累计: {res.iterations} 次 matmul, {res.tflops:.2f} TFLOPS")

--- a/cli-stressor-opencl/test.py
+++ b/cli-stressor-opencl/test.py
@@ -1025,6 +1025,12 @@ def main():
 
         if res.first_error:
             print(f"  结果: {res.first_error}")
+            if res.supported:
+                print(f"  累计: {res.iterations} 次 matmul, {res.tflops:.2f} TFLOPS")
+                # GPU may be in a fault/bus-fallen state on Linux (no TDR); do not
+                # attempt further precisions — print partial summary and exit now.
+                print_summary(runtime, results)
+                return 1
         else:
             print("  结果: completed without detected error")
         print(f"  累计: {res.iterations} 次 matmul, {res.tflops:.2f} TFLOPS")


### PR DESCRIPTION
## Summary

Three related fixes consolidated into one PR (supersedes #111):

- **`auto-optimizer/src/oc_profile_function.rs:152`** — `y_value.saturating_add(col3_value)` to prevent i32 overflow corrupting CSV (closes #93)
- **`auto-optimizer/src/main.rs:164,172`** — replace `format!("NVML backend unavailable")` with plain string literal — eliminates `clippy::useless_format` (closes #109)
- **`cli-stressor-cuda/test.py` + `cli-stressor-opencl/test.py`** — fail-fast in the outer precision loop after a real GPU error (closes #35)

## Root causes

**Overflow (#93):** See PR #110/#111 — `saturating_add` clamps instead of wrapping on i32 overflow, matching the `saturating_mul` pattern from PR #57/#87.

**Clippy lint (#109):** `format!` with a static string and no interpolation args allocates needlessly; `&str` already implements `Into<Box<dyn Error>>`.

**Stressor fail-fast (#35):** After `run_stress_for_precision` breaks out with a real error (not a SKIP), the outer `for spec in precisions` loop was continuing to the next precision. On Linux there is no TDR — submitting kernel work to a faulted or bus-fallen GPU produces a stuck process that the autoscan recovery script cannot kill, potentially requiring a reboot. The fix: on a supported-but-failed precision, print the iteration count and partial summary, then exit immediately. SKIP results (unsupported hardware) still fall through and continue as before.

## Test plan

- [x] `cargo check -p nvoc-auto-optimizer` — clean
- [x] `cargo clippy -p nvoc-auto-optimizer` — no `useless_format` warnings
- [ ] Normal small deltas — auto-optimizer output unchanged
- [ ] CSV with `col3_value = 2_000_000_000` + `--delta 200_000_000`: before wraps negative; after clamps to `i32::MAX`
- [ ] Stressor CUDA: inject a forced validation failure on FP16 — process exits after FP16, does not attempt BF16/FP32; partial summary is printed
- [ ] Stressor OpenCL: same validation-failure injection — process exits after first failing precision; partial summary printed
- [ ] Stressor with SKIP precision (unsupported hardware) — continues to next precision normally

Supersedes #111.

https://claude.ai/code/session_01PwFW6CVnkVeDZnWE1HhsQ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwFW6CVnkVeDZnWE1HhsQ2)_