### PR TITLE
fix(srv): replace unwrap() with graceful continues in service timer loop

### DIFF
--- a/srv/src/bin/nvoc_service.rs
+++ b/srv/src/bin/nvoc_service.rs
@@ -260,7 +260,13 @@ mod nvoc_service {
                 }
 
                 _ = timer.next() => {
-                    let cfg = config.lock().unwrap();
+                    let cfg = match config.lock() {
+                        Ok(c) => c,
+                        Err(e) => {
+                            error!("Config mutex poisoned, skipping timer tick: {}", e);
+                            continue;
+                        }
+                    };
                     let vfp_low_lock_point = min(max(cfg.vfp_lock_point, vfp_lowest_lock_point), vfp_highest_lock_point);
                     let temperature_softwall = cfg.temp_limit;
                     let count = nvml.device_count().unwrap_or(0);
@@ -268,7 +274,13 @@ mod nvoc_service {
 
                     // 遍历 GPU
                     for i in 0..count {
-                        let device = nvml.device_by_index(i).unwrap();
+                        let device = match nvml.device_by_index(i) {
+                            Ok(d) => d,
+                            Err(e) => {
+                                error!("GPU {}: NVML device_by_index failed: {:?}", i, e);
+                                continue;
+                            }
+                        };
                         let name = device.name().unwrap_or("Unknown".to_string()); // GPU 名称
                         let uuid = device.uuid().unwrap_or("Non UUID".to_string());                 // GPU UUID
                         let temperature = device.temperature(TemperatureSensor::Gpu).unwrap_or(0); // GPU 温度


### PR DESCRIPTION
## Summary

Two panic-on-error paths remained in `srv/src/bin/nvoc_service.rs` after the safety sweep in PR #98. Both are in the `select!` timer branch (`_ = timer.next() =>`), so a panic there crashes `run_service` and stops the Windows service.

### `config.lock().unwrap()` (line 263)

The HTTP server thread is wrapped in `catch_unwind` and restarted on panic (PR #67). During unwinding, any held `MutexGuard` is dropped, which **poisons** the shared `config` mutex. The next timer tick then panics on `config.lock().unwrap()`, taking the service down.

**Fix:** graceful `continue` with an `error!` log — skips one timer tick instead of crashing.

### `nvml.device_by_index(i).unwrap()` (line 271)

Called inside `for i in 0..count` where `count = nvml.device_count()`. Even for an in-range index, NVML can return an error on GPU hot-unplug or driver crash mid-tick.

**Fix:** graceful `continue` with an `error!` log — skips that GPU's iteration and lets the service survive until the next tick.

## Root cause relation to prior work

- PR #98 / commit `c38f64d` swept the `srv` crate for panic paths (closes #7, #66, #67, #68, #73, #82, #90, #91, #92, #93) but these two in the `timer.next()` arm were missed.
- Follows the same pattern already used in `websrv.rs` for `config.lock()` (lines 133–136) and `nvapi_hi` error returns throughout the timer loop.

## Test plan

- [ ] `cargo check -p nvoc-srv` (Windows CI) — clean
- [ ] Service stays alive when `nvml.device_by_index` returns an error (simulated by driver reset) — logs error, continues to next tick
- [ ] Mutex-poison path: inject a panic in HTTP thread while holding config lock — service timer loop logs error and continues rather than crashing

https://claude.ai/code/session_015FSVeoZQQstg9whADbGwuL

---
_Generated by [Claude Code](https://claude.ai/code/session_015FSVeoZQQstg9whADbGwuL)_