### PR TITLE
fix(srv,auto-optimizer,ci): eliminate 15 clippy warnings + clean ruff commands

### DIFF
--- a/.github/workflows/enforce-fmt-lint.yml
+++ b/.github/workflows/enforce-fmt-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install ruff
-      - run: ruff format . --check --output-format=github .
+      - run: ruff format --check --output-format=github .
 
   ruff-lint:
     name: "ruff check ."
@@ -34,7 +34,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install ruff
-      - run: ruff check . --output-format=github .
+      - run: ruff check --output-format=github .
 
   fmt:
     name: Rustfmt

--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -161,7 +161,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".to_string().into());
                     }
                 },
                 Some(("nvml-cooler", sub_matches)) => match nvml_ref {
@@ -169,7 +169,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_cooler_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".to_string().into());
                     }
                 },
                 _ => {

--- a/srv/src/bin/nvoc_service.rs
+++ b/srv/src/bin/nvoc_service.rs
@@ -8,6 +8,7 @@
 // extern crate nvml_wrapper;
 // extern crate nvml_wrapper_sys;
 
+#[cfg(windows)]
 #[path = "../websrv.rs"]
 mod websrv;
 


### PR DESCRIPTION
## Summary

Three targeted fixes that eliminate 15 clippy warnings (50 → 35) and clean up the new `enforce-fmt-lint.yml` workflow.

### `srv`: `#[cfg(windows)]` on `mod websrv` (−13 dead-code warnings)

`websrv.rs` was always compiled via `#[path = "../websrv.rs"] mod websrv;` outside any cfg-gate, but every caller lives inside `#[cfg(windows)]`. On Linux CI this produced 13 spurious `dead_code` warnings:
- `NVOCServiceConfig`, `NVOCServiceCmd` structs
- `start_http_server`, `respond`, `percent_decode`, `parse_query`, `json_content_type`, `is_mutation_request` functions
- `TEMP_LIMIT_MIN/MAX`, `OC_DELTA_MIN/MAX`, `GPU_INDEX_MAX` constants

Fix: add `#[cfg(windows)]` to the `mod websrv;` declaration.

### `auto-optimizer/src/main.rs`: `format!` → `.to_string()` (−2 `useless_format` warnings)

Lines 164 and 172 had `format!("NVML backend unavailable")` which allocates needlessly — a static string literal with `.to_string()` (or the existing `.into()`) is equivalent and avoids the lint.

### `enforce-fmt-lint.yml`: remove duplicate `.` positional arg

Both ruff commands had the current directory passed twice:
```
ruff format . --check --output-format=github .  # duplicate '.'
ruff check . --output-format=github .            # duplicate '.'
```
Removed the redundant first `.`.

## Remaining warnings (35, all auto-optimizer)

| Lint | Count | Status |
|------|-------|--------|
| `collapsible_if` | 13 | addressed in draft PRs #116/#118 |
| `type_complexity` | 4 | deferred — need type-alias design |
| `too_many_arguments` | 4 | deferred — need parameter-struct refactor |
| `needless_late_init` | 4 | addressed in draft PRs #116/#118 |
| `match_single_binding` | 2 | addressed in draft PRs #116/#118 |
| `field_reassign_with_default` | 2 | addressed in draft PRs #116/#118 |
| others (match, borrow, loop) | 4 | addressed in draft PRs #116/#118 |
| `dead_code` (intentional API) | 1 | `GpuSelector::all/from_specs` — intentional |
| `enum_variant_names` | 1 | addressed in draft PRs #116/#118 |

## Test plan

- [x] `cargo clippy --all-targets --all-features` — 50 → 35 warnings, no srv warnings remain
- [x] `cargo fmt --all -- --check` — clean
- [x] `ruff format --check --output-format=github .` — 46 files already formatted
- [x] `ruff check --output-format=github .` — all checks passed
- [x] `python3 -m unittest discover -s cli-stressor-cuda -p test_non_gpu_ci.py` — 19/19 OK
- [x] `python3 -m unittest discover -s cli-stressor-opencl -p test_non_gpu_ci.py` — 14/14 OK

https://claude.ai/code/session_01WWGz85QHjvDVxob8fyfUTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWGz85QHjvDVxob8fyfUTD)_