### PR TITLE
fix(clippy): suppress deferred warnings — dead_code, too_many_arguments, type_complexity

### DIFF
--- a/auto-optimizer/src/basic_func.rs
+++ b/auto-optimizer/src/basic_func.rs
@@ -38,11 +38,13 @@ pub struct GpuSelector(Option<Vec<String>>);
 
 impl GpuSelector {
     /// Select all available GPUs (no filter).
+    #[allow(dead_code)]
     pub fn all() -> Self {
         Self(None)
     }
 
     /// Select GPUs by the given specification strings (indices or PCI bus IDs).
+    #[allow(dead_code)]
     pub fn from_specs(specs: impl IntoIterator<Item = String>) -> Self {
         Self(Some(specs.into_iter().collect()))
     }

--- a/auto-optimizer/src/oc_get_set_function_nvml.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvml.rs
@@ -231,6 +231,7 @@ pub fn set_nvml_temperature_limit(nvml: &Nvml, gpu_id: u32, limit_c: i32) -> Res
     )
 }
 
+#[allow(clippy::type_complexity)]
 pub fn get_nvml_temperature_thresholds(
     nvml: &Nvml,
     gpu_id: u32,
@@ -310,6 +311,7 @@ pub fn get_nvml_pstate_info(
 }
 
 /// Returns supported memory clocks and, for each, the supported graphics clocks.
+#[allow(clippy::type_complexity)]
 pub fn get_nvml_supported_applications_clocks(
     nvml: &Nvml,
     gpu_id: u32,

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -776,6 +776,7 @@ pub fn fix_result(gpu: &Gpu, matches: &clap::ArgMatches) -> Result<(), Error> {
     Ok(())
 }
 
+#[allow(clippy::type_complexity)]
 pub fn check_voltage_points(
     log_filename: &str,
 ) -> io::Result<
@@ -865,6 +866,7 @@ fn extract_value_f64(line: &str, pattern: &str) -> Option<f64> {
         .and_then(|s| s.trim_matches(|c| c == ',').parse::<f64>().ok()) // Parse as f64
 }
 
+#[allow(clippy::type_complexity)]
 pub fn break_point_continue(
     log_filename: &str,
     testing_step: usize,

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -307,6 +307,7 @@ mod pressure_runner {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn test_pressure(
     gpu: &&Gpu,
     matches: &ArgMatches,
@@ -359,6 +360,7 @@ struct CommonPhaseArgs<'a> {
     stressor_extra_args: &'a [String],
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_common_phase_args<'a>(
     matches: &'a ArgMatches,
     minimum_delta_core_freq_step: i32,
@@ -764,6 +766,7 @@ fn apply_arch_safety_policy(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
     l: &mut fs::File,
     gpu: &Gpu,
@@ -909,6 +912,7 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
     Ok(test_code)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_gpuboostv3_long_phase<V: std::fmt::Display + Copy>(
     l: &mut fs::File,
     gpu: &Gpu,


### PR DESCRIPTION
## Summary

Clears the 9 clippy warnings that PRs #116 and #118 explicitly deferred as \"requiring API redesign or design discussion.\" Adds targeted `#[allow]` attributes — no logic changes.\n\n| Lint | Count | Location |\n|------|-------|----------|\n| `dead_code` | 2 items | `basic_func.rs` — `GpuSelector::all`, `GpuSelector::from_specs` — intentional future public API |\n| `too_many_arguments` | 4 fns | `oc_scanner.rs` — `test_pressure` (15), `build_common_phase_args` (11), `run_gpuboostv3_short_phase` (9), `run_gpuboostv3_long_phase` (8) |\n| `type_complexity` | 4 fns | `oc_get_set_function_nvml.rs` ×2, `oc_profile_function.rs` ×2 |\n\nOnce #115 + #117 + #118 + this PR all land, the commented-out line in #119 can be uncommented to enforce zero-warning CI.\n\nPR #116 (`claude/friendly-dirac-9uMWk`) is being closed — it overlaps with #115 and #118 and is superseded by this split.\n\nhttps://claude.ai/code/session_014pvEsr77yiMeUrZHJmSUJs

---
_Generated by [Claude Code](https://claude.ai/code/session_014pvEsr77yiMeUrZHJmSUJs)_