### PR TITLE
fix(clippy,ci): resolve all 37 warnings and enable -D warnings in CI

### DIFF
--- a/.github/workflows/enforce-fmt-lint.yml
+++ b/.github/workflows/enforce-fmt-lint.yml
@@ -52,5 +52,4 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup update stable && rustup component add clippy
-      - run: cargo clippy --all-targets --all-features
-      # - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/auto-optimizer/src/basic_func.rs
+++ b/auto-optimizer/src/basic_func.rs
@@ -38,11 +38,13 @@ pub struct GpuSelector(Option<Vec<String>>);
 
 impl GpuSelector {
     /// Select all available GPUs (no filter).
+    #[allow(dead_code)]
     pub fn all() -> Self {
         Self(None)
     }
 
     /// Select GPUs by the given specification strings (indices or PCI bus IDs).
+    #[allow(dead_code)]
     pub fn from_specs(specs: impl IntoIterator<Item = String>) -> Self {
         Self(Some(specs.into_iter().collect()))
     }
@@ -503,19 +505,19 @@ pub fn handle_status(
 
                         human::print_status(&status);
                         human::print_settings(gpu, requires_set(gpu, &mut set)?);
-                        if let Ok(info) = gpu.info() {
-                            if let Some(thresholds) = nvml.and_then(|n| {
+                        if let Ok(info) = gpu.info()
+                            && let Some(thresholds) = nvml.and_then(|n| {
                                 crate::oc_get_set_function_nvml::get_nvml_temperature_thresholds(
                                     n,
                                     info.id as u32,
                                 )
-                            }) {
-                                println!("NVML Temperature Thresholds:");
-                                for (name, value) in thresholds {
-                                    match value {
-                                        Some(temp) => println!("  {:<16} : {} C", name, temp),
-                                        None => println!("  {:<16} : N/A", name),
-                                    }
+                            })
+                        {
+                            println!("NVML Temperature Thresholds:");
+                            for (name, value) in thresholds {
+                                match value {
+                                    Some(temp) => println!("  {:<16} : {} C", name, temp),
+                                    None => println!("  {:<16} : N/A", name),
                                 }
                             }
                         }

--- a/auto-optimizer/src/error.rs
+++ b/auto-optimizer/src/error.rs
@@ -71,7 +71,7 @@ quick_error! {
         ParseInt(err: ParseIntError) {from()source(err)display("{}", err)}
         ParseFloat(err: ParseFloatError) {from()source(err)display("{}", err)}
         Str(err: &'static str) {from()display("{}", err)}
-        ResetError { setting: ResetSettings, err: nvapi_hi::Error } {
+        Reset { setting: ResetSettings, err: nvapi_hi::Error } {
             from(s: (ResetSettings, nvapi_hi::Error)) -> {setting: s.0,err: s.1}
             display("Reset {:?} failed: {}", setting, err)
         }

--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -161,7 +161,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 Some(("nvml-cooler", sub_matches)) => match nvml_ref {
@@ -169,7 +169,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                         handle_nvml_cooler_with_ids(&nvml_selected, sub_matches)?;
                     }
                     None => {
-                        return Err(format!("NVML backend unavailable").into());
+                        return Err("NVML backend unavailable".into());
                     }
                 },
                 _ => {

--- a/auto-optimizer/src/oc_get_set_function_nvapi.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvapi.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 /// 适用于 900 系（Maxwell）及更早不支持 ClientVoltRailsSetControl 的 GPU。
 /// delta_uv 单位为 μV，正值加压，负值降压，范围由 GPU 自身 voltDelta_uV.{min,max} 决定。
 /// target_pstate 指定目标 pstate，默认应传入 PState::P0。
+#[allow(clippy::field_reassign_with_default)] // struct literal form fails: V2 type uses different field names at the call site
 pub fn set_pstate_base_voltage(
     gpu: &Gpu,
     delta_uv: MicrovoltsDelta,
@@ -112,6 +113,7 @@ pub fn set_pstate_base_voltage(
 /// 将所有 pstate 的 Core baseVoltage delta 清零（适用于 Maxwell / 9 系及更早）。
 /// 遍历驱动报告的全部 pstate，对每个含有可编辑 Core baseVoltage 的条目发起单独写入，
 /// 单个 pstate 失败时打印警告并继续，不中断其他 pstate 的清零。
+#[allow(clippy::field_reassign_with_default)] // struct literal form fails: V2 type uses different field names at the call site
 pub fn reset_all_pstate_base_voltages(gpu: &Gpu) -> Result<(), Error> {
     use nvapi_hi::sys::gpu::pstate as sys_pstate;
 
@@ -268,12 +270,12 @@ fn parse_lock_frequency(
             None
         };
 
-    if let Some(lower) = lower_mhz {
-        if lower > upper_mhz {
-            return Err(Error::from(
-                "--clock expects upper bound first and lower bound second",
-            ));
-        }
+    if let Some(lower) = lower_mhz
+        && lower > upper_mhz
+    {
+        return Err(Error::from(
+            "--clock expects upper bound first and lower bound second",
+        ));
     }
 
     let domain = match matches
@@ -993,7 +995,7 @@ pub fn handle_pointwiseoc(gpus: &[&Gpu], matches: &ArgMatches) -> Result<(), Err
     );
 
     for gpu in gpus {
-        set_vfp_range(&gpu, start..=end, delta)?;
+        set_vfp_range(gpu, start..=end, delta)?;
     }
 
     Ok(())
@@ -1025,38 +1027,35 @@ pub fn handle_test_voltage_limits(
             }
         }
 
-        match gpu_type {
-            Ok(ref t) => {
-                let vlp = t.voltage_limit_params();
-                upper_init_point = vlp.upper_init_point;
-                lower_init_point = vlp.lower_init_point;
-                if vlp.vfp_strict_inc_flag {
-                    vfp_strict_inc_flag = 1;
-                }
-                if vlp.margin_threshold_check {
-                    margin_threshold_check = 1;
-                }
-
-                // 9 系及 Volta/Unknown 的特殊打印（无 VFP 支持）
-                match t {
-                    GpuType::Mobile9Series => {
-                        println!("Mobile 9 Series GPU detected.");
-                        drop(Error::VfpUnsupported);
-                    }
-                    GpuType::Desktop9Series => {
-                        println!("Desktop 9 Series GPU detected.");
-                        drop(Error::VfpUnsupported);
-                    }
-                    GpuType::ComputationVolta => {
-                        println!("Computation Volta GPU detected.");
-                    }
-                    GpuType::Unknown => {
-                        println!("Unknown GPU type detected.");
-                    }
-                    _ => {}
-                }
+        if let Ok(ref t) = gpu_type {
+            let vlp = t.voltage_limit_params();
+            upper_init_point = vlp.upper_init_point;
+            lower_init_point = vlp.lower_init_point;
+            if vlp.vfp_strict_inc_flag {
+                vfp_strict_inc_flag = 1;
             }
-            _ => {}
+            if vlp.margin_threshold_check {
+                margin_threshold_check = 1;
+            }
+
+            // 9 系及 Volta/Unknown 的特殊打印（无 VFP 支持）
+            match t {
+                GpuType::Mobile9Series => {
+                    println!("Mobile 9 Series GPU detected.");
+                    drop(Error::VfpUnsupported);
+                }
+                GpuType::Desktop9Series => {
+                    println!("Desktop 9 Series GPU detected.");
+                    drop(Error::VfpUnsupported);
+                }
+                GpuType::ComputationVolta => {
+                    println!("Computation Volta GPU detected.");
+                }
+                GpuType::Unknown => {
+                    println!("Unknown GPU type detected.");
+                }
+                _ => {}
+            }
         }
     }
 
@@ -1177,6 +1176,7 @@ pub fn handle_test_voltage_limits(
     ))
 }
 
+#[allow(clippy::type_complexity)]
 pub fn get_gpu_tdp_temp_limit(
     arg_matches: ArgMatches,
 ) -> Result<

--- a/auto-optimizer/src/oc_get_set_function_nvml.rs
+++ b/auto-optimizer/src/oc_get_set_function_nvml.rs
@@ -10,12 +10,11 @@ fn find_nvml_device<'n>(nvml: &'n Nvml, gpu_id: u32) -> Option<nvml_wrapper::Dev
     let pci_bus = gpu_id / 256;
     let count = nvml.device_count().ok()?;
     for i in 0..count {
-        if let Ok(dev) = nvml.device_by_index(i) {
-            if let Ok(pci) = dev.pci_info() {
-                if pci.bus == pci_bus {
-                    return Some(dev);
-                }
-            }
+        if let Ok(dev) = nvml.device_by_index(i)
+            && let Ok(pci) = dev.pci_info()
+            && pci.bus == pci_bus
+        {
+            return Some(dev);
         }
     }
     None
@@ -75,25 +74,25 @@ pub fn query_nvml_power_watts_by_pci(pci_bus_id_str: &str) -> Option<(f32, f32, 
             let device_count = nvml.device_count()?;
 
             for i in 0..device_count {
-                if let Ok(dev) = nvml.device_by_index(i) {
-                    if let Ok(pci_info) = dev.pci_info() {
-                        // 匹配策略：比较 PCI Bus 编号
-                        if let Some(target_bus) = nvapi_bus_num {
-                            if pci_info.bus == target_bus {
-                                return Ok(dev);
-                            }
-                        }
+                if let Ok(dev) = nvml.device_by_index(i)
+                    && let Ok(pci_info) = dev.pci_info()
+                {
+                    // 匹配策略：比较 PCI Bus 编号
+                    if let Some(target_bus) = nvapi_bus_num
+                        && pci_info.bus == target_bus
+                    {
+                        return Ok(dev);
+                    }
 
-                        // 备用：宽松字符串匹配
-                        let nvml_pci_str = format!(
-                            "{:04x}:{:02x}:{:02x}.0",
-                            pci_info.domain, pci_info.bus, pci_info.device
-                        );
-                        let nvapi_stripped = pci_bus_id_str.trim_start_matches("0000:");
-                        let nvml_stripped = nvml_pci_str.trim_start_matches("0000:");
-                        if nvapi_stripped.eq_ignore_ascii_case(nvml_stripped) {
-                            return Ok(dev);
-                        }
+                    // 备用：宽松字符串匹配
+                    let nvml_pci_str = format!(
+                        "{:04x}:{:02x}:{:02x}.0",
+                        pci_info.domain, pci_info.bus, pci_info.device
+                    );
+                    let nvapi_stripped = pci_bus_id_str.trim_start_matches("0000:");
+                    let nvml_stripped = nvml_pci_str.trim_start_matches("0000:");
+                    if nvapi_stripped.eq_ignore_ascii_case(nvml_stripped) {
+                        return Ok(dev);
                     }
                 }
             }
@@ -282,6 +281,7 @@ pub fn get_nvml_temperature_thresholds(
 // P-State info and clock ranges
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::type_complexity)]
 pub fn get_nvml_pstate_info(
     nvml: &Nvml,
     gpu_id: u32,

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -227,22 +227,19 @@ fn extract_default_frequencies(file_path: &str, legacy_flag: bool) -> Result<Vec
 
     for result in rdr.records() {
         let record = result?;
-        let default_frequency_load: u32;
-
-        if legacy_flag {
-            default_frequency_load = record
+        let default_frequency_load: u32 = if legacy_flag {
+            // Read only frequency column
+            record
                 .get(1)
                 .ok_or_else(|| Error::Custom("row too short: missing column 1".into()))?
-                .parse()?;
-        }
-        // Read only frequency column
-        else {
-            default_frequency_load = record
+                .parse()?
+        } else {
+            // Read only default_frequency column
+            record
                 .get(3)
                 .ok_or_else(|| Error::Custom("row too short: missing column 3".into()))?
-                .parse()?;
-        }
-        // Read only default_frequency column
+                .parse()?
+        };
 
         default_frequencies_load.push(default_frequency_load);
     }
@@ -274,7 +271,6 @@ fn update_csv_with_load_and_margin(
         .has_headers(true)
         .from_writer(File::create(&tmp_path)?);
 
-    let mut index = 0;
     let headers = StringRecord::from(vec![
         "voltage",
         "frequency",
@@ -285,21 +281,20 @@ fn update_csv_with_load_and_margin(
         "margin_bin",
     ]);
     wtr.write_record(&headers)?;
-    for result in rdr.records() {
+    for (index, result) in rdr.records().enumerate() {
         let record = result?;
         let voltage = &record[0];
         let frequency = &record[1];
         let delta = &record[2];
         let default_frequency = default_frequencies.get(index).cloned().unwrap_or(0);
-        let margin: i32;
         let default_frequency_load = default_frequencies_load.get(index).cloned().unwrap_or(0);
 
         // Get the corresponding load frequency
-        if legacy_flag {
-            margin = default_frequency_load as i32 - frequency.parse::<i32>()?;
+        let margin: i32 = if legacy_flag {
+            default_frequency_load as i32 - frequency.parse::<i32>()?
         } else {
-            margin = default_frequency_load as i32 - default_frequency as i32;
-        }
+            default_frequency_load as i32 - default_frequency as i32
+        };
 
         let margin_bin = (margin as f32 / minimum_delta_core_freq_step as f32).round() as i32;
         // Write updated row
@@ -312,7 +307,6 @@ fn update_csv_with_load_and_margin(
             &margin.to_string(),
             &margin_bin.to_string(),
         ])?;
-        index += 1;
     }
 
     wtr.flush()?;
@@ -642,8 +636,8 @@ fn interpolate_deltas(
         p4_d = parse_col::<i32>(&lines[p4_idx], 2, "delta")?;
     }
 
-    for i in 0..lines.len() {
-        let current_v = parse_col::<u32>(&lines[i], 0, "voltage")?;
+    for (i, line) in lines.iter_mut().enumerate() {
+        let current_v = parse_col::<u32>(line, 0, "voltage")?;
         let stair_inferred = min(p2_idx - p1_idx, p3_idx - p2_idx);
 
         let new_delta = if i < p1_idx {
@@ -662,7 +656,7 @@ fn interpolate_deltas(
             p4_d
         };
 
-        lines[i][2] = new_delta.to_string();
+        line[2] = new_delta.to_string();
     }
     Ok(())
 }
@@ -776,6 +770,7 @@ pub fn fix_result(gpu: &Gpu, matches: &clap::ArgMatches) -> Result<(), Error> {
     Ok(())
 }
 
+#[allow(clippy::type_complexity)]
 pub fn check_voltage_points(
     log_filename: &str,
 ) -> io::Result<
@@ -865,6 +860,7 @@ fn extract_value_f64(line: &str, pattern: &str) -> Option<f64> {
         .and_then(|s| s.trim_matches(|c| c == ',').parse::<f64>().ok()) // Parse as f64
 }
 
+#[allow(clippy::type_complexity)]
 pub fn break_point_continue(
     log_filename: &str,
     testing_step: usize,
@@ -901,31 +897,30 @@ pub fn break_point_continue(
             break;
         }
 
-        if last_voltage_point.is_none() {
-            if let Some(point) = extract_value(line, "point: #") {
-                last_voltage_point = Some(point as usize);
+        if last_voltage_point.is_none()
+            && let Some(point) = extract_value(line, "point: #")
+        {
+            last_voltage_point = Some(point as usize);
 
-                if line.contains("Finished") {
-                    last_voltage_point = last_voltage_point.map(|v| v + testing_step);
-                    break;
-                }
+            if line.contains("Finished") {
+                last_voltage_point = last_voltage_point.map(|v| v + testing_step);
+                break;
             }
         }
 
-        if last_code_100_freq.is_none() {
-            if line.contains("Test result is code #0") {
-                if let Some(freq) = extract_value_f64(line, "freq_delta: #") {
-                    last_code_100_freq = Some(freq);
-                }
-            }
+        if last_code_100_freq.is_none()
+            && line.contains("Test result is code #0")
+            && let Some(freq) = extract_value_f64(line, "freq_delta: #")
+        {
+            last_code_100_freq = Some(freq);
         }
 
-        if last_code_0_freq.is_none() {
-            if line.contains("Test") && !line.contains("Test result is code #0") {
-                if let Some(freq) = extract_value_f64(line, "freq_delta: #") {
-                    last_code_0_freq = Some(freq);
-                }
-            }
+        if last_code_0_freq.is_none()
+            && line.contains("Test")
+            && !line.contains("Test result is code #0")
+            && let Some(freq) = extract_value_f64(line, "freq_delta: #")
+        {
+            last_code_0_freq = Some(freq);
         }
 
         if last_voltage_point.is_some()
@@ -966,11 +961,11 @@ pub fn export_vfp_from_log(matches: &clap::ArgMatches) -> Result<(), Error> {
             break;
         }
 
-        if line.contains("Finished") {
-            if let Some(point) = extract_value(line, "point: #") {
-                last_voltage_point = Some(point);
-                last_code_100_freq = None;
-            }
+        if line.contains("Finished")
+            && let Some(point) = extract_value(line, "point: #")
+        {
+            last_voltage_point = Some(point);
+            last_code_100_freq = None;
         }
 
         if last_code_100_freq.is_none() && line.contains("Test result is code #100") {
@@ -978,14 +973,14 @@ pub fn export_vfp_from_log(matches: &clap::ArgMatches) -> Result<(), Error> {
             if last_voltage_point.is_none() {
                 continue;
             }
-            if let Some(point) = extract_value(line, "point: #") {
-                if last_voltage_point != Some(point) {
-                    eprintln!(
-                        "Warning: export_vfp_from_log: expected voltage point {:?}, got {} — skipping",
-                        last_voltage_point, point
-                    );
-                    continue;
-                }
+            if let Some(point) = extract_value(line, "point: #")
+                && last_voltage_point != Some(point)
+            {
+                eprintln!(
+                    "Warning: export_vfp_from_log: expected voltage point {:?}, got {} — skipping",
+                    last_voltage_point, point
+                );
+                continue;
             }
             if let Some(voltage) = extract_value_f64(line, "voltage: #") {
                 last_voltage = Some(voltage);

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -307,6 +307,7 @@ mod pressure_runner {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn test_pressure(
     gpu: &&Gpu,
     matches: &ArgMatches,
@@ -359,6 +360,7 @@ struct CommonPhaseArgs<'a> {
     stressor_extra_args: &'a [String],
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_common_phase_args<'a>(
     matches: &'a ArgMatches,
     minimum_delta_core_freq_step: i32,
@@ -764,6 +766,7 @@ fn apply_arch_safety_policy(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
     l: &mut fs::File,
     gpu: &Gpu,
@@ -829,8 +832,7 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
             KilohertzDelta(*init_core_oc_value),
         )?;
 
-        let test_flag;
-        test_flag = test_pressure(
+        let test_flag = test_pressure(
             &gpu,
             args.common.matches,
             point,
@@ -909,6 +911,7 @@ fn run_gpuboostv3_short_phase<V: std::fmt::Display + Copy>(
     Ok(test_code)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_gpuboostv3_long_phase<V: std::fmt::Display + Copy>(
     l: &mut fs::File,
     gpu: &Gpu,
@@ -1054,8 +1057,7 @@ fn run_mem_oc_phase<V: std::fmt::Display + Copy>(
             KilohertzDelta(*init_vmem_oc_value),
         )?;
 
-        let mem_test_flag;
-        mem_test_flag = test_pressure(
+        let mem_test_flag = test_pressure(
             &gpu,
             args.common.matches,
             args.point,
@@ -1268,32 +1270,30 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(),
         let mut last_failed_freq = core_oc_safe_limit_ref;
         let recovery_method_switch: bool = cfg.recovery_method.unwrap_or(is_50_series);
 
-        match break_point_continue(log_filename, testing_step)? {
-            (succeeded_freq, failed_freq, last_voltage_point, ultrafast_flag) => {
-                println!("Extracted Values:");
+        let (succeeded_freq, failed_freq, last_voltage_point, ultrafast_flag) =
+            break_point_continue(log_filename, testing_step)?;
+        println!("Extracted Values:");
 
-                if let Some(freq_s) = succeeded_freq {
-                    println!("  - Last freq_delta succeeded: {} MHz", freq_s);
-                    last_succeeded_freq = (freq_s * 1000.0) as i32; // Update if present
-                }
+        if let Some(freq_s) = succeeded_freq {
+            println!("  - Last freq_delta succeeded: {} MHz", freq_s);
+            last_succeeded_freq = (freq_s * 1000.0) as i32; // Update if present
+        }
 
-                if let Some(freq_f) = failed_freq {
-                    println!("  - Last freq_delta failed: {} MHz", freq_f);
-                    last_failed_freq = (freq_f * 1000.0) as i32; // Update if present
-                }
+        if let Some(freq_f) = failed_freq {
+            println!("  - Last freq_delta failed: {} MHz", freq_f);
+            last_failed_freq = (freq_f * 1000.0) as i32; // Update if present
+        }
 
-                if let Some(voltage_point) = last_voltage_point {
-                    println!("  - Last voltage point: {}", voltage_point);
-                    point = voltage_point; // Update if present
-                    resuming_flag = true;
-                }
+        if let Some(voltage_point) = last_voltage_point {
+            println!("  - Last voltage point: {}", voltage_point);
+            point = voltage_point; // Update if present
+            resuming_flag = true;
+        }
 
-                if let Some(ultrafast_flag) = ultrafast_flag {
-                    println!("Inheriting last scanner flag...");
-                    is_ultrafast = ultrafast_flag; // Update if present
-                    resuming_flag = true;
-                }
-            }
+        if let Some(ultrafast_flag) = ultrafast_flag {
+            println!("Inheriting last scanner flag...");
+            is_ultrafast = ultrafast_flag; // Update if present
+            resuming_flag = true;
         }
 
         if is_ultrafast {
@@ -1682,22 +1682,20 @@ pub fn autoscan_legacy(gpus: &Vec<&Gpu>, matches: &ArgMatches) -> Result<(), Err
         let mut last_succeeded_freq = init_core_oc_value;
         let mut last_failed_freq = core_oc_safe_limit_ref;
 
-        match break_point_continue(log_filename, 1 /* single point, step=1 */)? {
-            (succeeded_freq, failed_freq, last_voltage_point, _ultrafast_flag) => {
-                if let Some(freq_s) = succeeded_freq {
-                    println!("  - Last freq_delta succeeded: {} MHz", freq_s);
-                    last_succeeded_freq = (freq_s * 1000.0) as i32;
-                }
-                if let Some(freq_f) = failed_freq {
-                    println!("  - Last freq_delta failed: {} MHz", freq_f);
-                    last_failed_freq = (freq_f * 1000.0) as i32;
-                }
-                if last_voltage_point.is_some() {
-                    // For legacy, any breakpoint means we can resume
-                    resuming_flag = true;
-                    println!("Resuming legacy scan from breakpoint...");
-                }
-            }
+        let (succeeded_freq, failed_freq, last_voltage_point, _ultrafast_flag) =
+            break_point_continue(log_filename, 1 /* single point, step=1 */)?;
+        if let Some(freq_s) = succeeded_freq {
+            println!("  - Last freq_delta succeeded: {} MHz", freq_s);
+            last_succeeded_freq = (freq_s * 1000.0) as i32;
+        }
+        if let Some(freq_f) = failed_freq {
+            println!("  - Last freq_delta failed: {} MHz", freq_f);
+            last_failed_freq = (freq_f * 1000.0) as i32;
+        }
+        if last_voltage_point.is_some() {
+            // For legacy, any breakpoint means we can resume
+            resuming_flag = true;
+            println!("Resuming legacy scan from breakpoint...");
         }
 
         // Apply breakpoint-restored values

--- a/srv/src/bin/nvoc_service.rs
+++ b/srv/src/bin/nvoc_service.rs
@@ -8,6 +8,7 @@
 // extern crate nvml_wrapper;
 // extern crate nvml_wrapper_sys;
 
+#[cfg(windows)]
 #[path = "../websrv.rs"]
 mod websrv;
 


### PR DESCRIPTION
## Summary

Builds on the ruff typo fix already on this branch (same as PR #122) and adds a full clippy warning sweep, enabling `-D warnings` in CI.

**Supersedes draft PRs #116, #118, #120, and #121** — all their changes are included here.

### Root causes fixed

| Warning | Count | Fix |
|---------|-------|-----|
| `dead_code` in `websrv.rs` (13 items) | 13 | `#[cfg(windows)]` on `mod websrv;` in nvoc_service.rs — module not compiled on Linux at all (cleaner than `#[cfg_attr]`) |
| `dead_code` — `GpuSelector::all` / `from_specs` | 1 | `#[allow(dead_code)]` — intentional future public API |
| `useless_format` | 2 | `format!("static str")` → `"static str".into()` |
| `enum_variant_names` | 1 | `ResetError` → `Reset` |
| `field_reassign_with_default` | 2 | `#[allow]` — struct literal form blocked by nvapi V1/V2 type-alias mismatch |
| `type_complexity` | 4 | `#[allow(clippy::type_complexity)]` — need `type` alias refactor (design decision) |
| `too_many_arguments` | 4 | `#[allow(clippy::too_many_arguments)]` — domain-driven helpers, API refactor out of scope |
| `collapsible_if` | 13 | Collapsed to `&&` / let-chains |
| `needless_late_init` | 4 | `let x = if … { … } else { … };` |
| `explicit_counter_loop` | 1 | `.enumerate()` |
| `needless_range_loop` | 1 | `.iter_mut().enumerate()` |
| `match_single_binding` | 2 | `let (…) = expr;` |
| `needless_borrow` | 1 | Removed `&` on loop variable |
| `-D warnings` in CI | — | Uncommented in `enforce-fmt-lint.yml` |

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — **zero warnings/errors**
- [x] `cargo fmt --all -- --check` — clean
- [x] `ruff format --check --output-format=github .` — 46 files already formatted
- [x] `ruff check --output-format=github .` — all checks passed
- [ ] CI enforce-fmt-lint workflow — all four jobs including Clippy with `-D warnings`

## Supersedes

- Draft PR #116 — overlapping auto-optimizer lint sweep
- Draft PR #118 — overlapping auto-optimizer lint sweep
- Draft PR #120 — subset of changes here (ruff fix + websrv cfg + useless_format)
- Draft PR #121 — same scope but uses `#[cfg_attr]` in websrv.rs; this PR uses the cleaner `#[cfg(windows)]` on the mod declaration instead

https://claude.ai/code/session_017swPpXRvHMdwAzxmfzrqGj

---
_Generated by [Claude Code](https://claude.ai/code/session_017swPpXRvHMdwAzxmfzrqGj)_