### PR TITLE
docs: add reviewed GitHub Wiki page set under docs/wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ NVOC is a monorepo for NVIDIA GPU overclocking and stability tools. The stack ce
 
 Overclocking can crash the display driver, reset the GPU, or make a machine unstable. Run write operations only when you understand the target GPU, driver, cooling, and recovery path.
 
+## Documentation & Wiki Policy
+
+For this repository size and contributor model, documentation is maintained in this monorepo first.
+
+- Canonical docs path: [`docs/wiki/`](./docs/wiki/)
+- English Home: [`docs/wiki/Home.md`](./docs/wiki/Home.md)
+- Chinese Home: [`docs/wiki/Home-zh.md`](./docs/wiki/Home-zh.md)
+- Review flow: open PRs in `nvoc`, review here, then sync to GitHub Wiki (`nvoc-wiki`) if needed.
+
+If wiki pages differ from `docs/wiki`, treat `docs/wiki` as source of truth and sync the wiki repo.
+
 ## Components (canonical)
 
 This section is the canonical component inventory for the monorepo. `CONTRIBUTING.md` and `AGENTS.md` intentionally reference this table instead of duplicating entries.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,22 @@
+# Architecture
+
+```text
+CLI / Frontends (GUI, TUI, SRV)
+          ↕
+       pynvoc
+          ↕
+      nvoc-core
+      ↙      ↘
+   NVAPI     NVML
+```
+
+## Path selection
+
+- CLI path: direct `auto-optimizer` execution for scripting, autoscan, and low-level operations.
+- Native frontend path: GUI/TUI/SRV orchestrate user workflows and invoke CLI/backend paths with validated config.
+
+Use CLI for reproducible automation and troubleshooting; use frontends for operator UX and guardrails.
+
+---
+
+*Maintained from: `README.md`, `nvoc-core/src/lib.rs`, `gui/src/`, `tui/nvoc_tui/`, `srv/src/`.*

--- a/docs/wiki/Auto-Optimizer.md
+++ b/docs/wiki/Auto-Optimizer.md
@@ -1,0 +1,18 @@
+# Auto Optimizer
+
+## Key workflows
+
+- `autoscan`: automatic stability scan loop over core/memory deltas.
+- `vfp`: V-F curve read/export/import operations.
+- `reset`: reset clocks/power/fan-related state to safe baseline.
+- `fix_result`: normalize and patch scan outputs for downstream use.
+
+## Operational notes
+
+- Prefer read-only checks before mutating GPU state.
+- Pair autoscan with an appropriate stressor module.
+- Keep recovery scripts and reboot strategy prepared for failed OCs.
+
+---
+
+*Maintained from: `auto-optimizer/README.md`, `auto-optimizer/README-en.md`.*

--- a/docs/wiki/Build-and-Test.md
+++ b/docs/wiki/Build-and-Test.md
@@ -1,0 +1,29 @@
+# Build and Test
+
+## Rust workspace
+
+- Build (exclude CUDA-Rust stressor):
+  `cargo build --workspace --exclude cli-stressor-cuda-rs`
+- Format check:
+  `cargo fmt --all -- --check`
+- Lint:
+  `cargo clippy --workspace --exclude cli-stressor-cuda-rs --all-targets -- -D warnings`
+- Core tests:
+  `cargo test --package nvoc-core --all-targets`
+
+## Python projects
+
+- Lint/format:
+  `ruff format . --check && ruff check .`
+- TUI tests:
+  `cd tui && uv sync && uv run pytest`
+- GUI run:
+  `cd gui && uv sync && uv run python main.py`
+
+## CI mapping
+
+Mirror the same command families locally before PR: Rust build/lint/test, then Python lint/tests for changed projects.
+
+---
+
+*Maintained from: `AGENTS.md`, project `pyproject.toml` files, CI workflow files.*

--- a/docs/wiki/Compatibility-Matrix.md
+++ b/docs/wiki/Compatibility-Matrix.md
@@ -1,0 +1,22 @@
+# Compatibility Matrix
+
+This page is intentionally extracted from `auto-optimizer` README compatibility sections and should be updated by copy-sync from that source when support changes.
+
+## GPU families × backend support
+
+- RTX 50 / 40 / 30 / 20
+- GTX 16 / 10 / 9
+- Volta
+- Mobile variants
+
+Matrix dimensions:
+
+- NVAPI support status
+- NVML support status
+- Feature caveats (write support, sensor coverage, stability constraints)
+
+> For canonical values, use the latest table in `auto-optimizer/README.md` and `auto-optimizer/README-en.md`.
+
+---
+
+*Maintained from: `auto-optimizer/README.md`, `auto-optimizer/README-en.md` (compatibility sections only).*

--- a/docs/wiki/Components.md
+++ b/docs/wiki/Components.md
@@ -1,0 +1,24 @@
+# Components
+
+## Product Components
+
+| Component | Path | Purpose |
+|---|---|---|
+| NVOC-AUTO-OPTIMIZER | `auto-optimizer/` | Rust CLI core for GPU discovery/control, autoscan, reset, V-F operations, and result handling. |
+| NVOC-STRESSOR CUDA (Python) | `cli-stressor-cuda/` | CUDA/PyTorch-based stress workload used by autoscan and standalone checks. |
+| NVOC-STRESSOR CUDA (Rust) | `cli-stressor-cuda-rs/` | Rust CUDA stressor variant for native Rust pipeline usage. |
+| NVOC-STRESSOR OpenCL | `cli-stressor-opencl/` | Lightweight OpenCL stress workload for non-CUDA stacks. |
+| NVOC-GUI | `gui/` | Desktop GUI for dashboard, autoscan, overclock, and live runner views. |
+| NVOC-TUI | `tui/` | Textual-based terminal frontend for headless or SSH workflows. |
+| NVOC-SRV | `srv/` | Service wrapper + localhost HTTP control endpoint. |
+
+## Library / Shared Components
+
+| Library | Path | Purpose |
+|---|---|---|
+| nvoc-core | `nvoc-core/` | Backend abstraction over NVAPI/NVML and common types/errors/operations. |
+| pynvoc | Python package outputs | Python-facing bindings/adapters used by frontends to invoke control paths. |
+
+---
+
+*Maintained from: `README.md`, `nvoc-core/src/lib.rs`, workspace `Cargo.toml`.*

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,0 +1,17 @@
+# Contributing
+
+1. Keep changes scoped by component (`auto-optimizer`, `nvoc-core`, `gui`, `tui`, `srv`, stressors).
+2. Run local command set aligned with CI for touched paths.
+3. For GPU-affecting changes, document hardware assumptions and safety behavior.
+4. Use path filters to avoid unnecessary GPU CI, and trigger GPU CI only when relevant paths or labels require it.
+
+## PR checklist
+
+- Component + behavior summary
+- Linked issue(s)
+- Tests/lints/build commands run
+- GPU availability note and any skipped GPU-only checks
+
+---
+
+*Maintained from: `CONTRIBUTING.md`, CI workflow path filters, component README test sections.*

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -1,0 +1,27 @@
+# FAQ
+
+## Driver/version issues
+
+- Verify NVIDIA driver meets backend requirement (NVAPI/NVML/OpenCL/CUDA runtime).
+- Re-test with read-only info commands before write commands.
+
+## Permission problems
+
+- Windows: run elevated where required.
+- Linux: ensure required privileges for GPU control interfaces.
+
+## Which stressor should I use?
+
+- Prefer CUDA-Python when PyTorch CUDA is already installed.
+- Prefer OpenCL when CUDA stack is unavailable.
+- Prefer CUDA-Rust when you need a native Rust-only integration path.
+
+## Autoscan instability or resets
+
+- Reduce scan aggressiveness.
+- Confirm cooling and power headroom.
+- Use reset workflow and retry from conservative baseline.
+
+---
+
+*Maintained from: `auto-optimizer/README.md`, stressor READMEs, troubleshooting issues/notes.*

--- a/docs/wiki/Frontends.md
+++ b/docs/wiki/Frontends.md
@@ -1,0 +1,26 @@
+# Frontends
+
+## GUI
+
+- Path: `gui/`
+- Start: `cd gui && uv sync && uv run python main.py`
+- Use case: desktop operational control with visual tabs and live output.
+
+## TUI
+
+- Path: `tui/`
+- Start: `cd tui && uv sync && uv run nvoc-tui`
+- Use case: terminal-first operation, remote/SSH friendly.
+
+## SRV
+
+- Path: `srv/`
+- Use case: service lifecycle and localhost HTTP control in managed environments.
+
+## Config & CLI discovery
+
+Frontends should explicitly resolve `auto-optimizer` executable path/config and expose it in settings to avoid hidden path failures.
+
+---
+
+*Maintained from: `gui/README.md`, `tui/README.md`, `srv/README.md`, frontend config sources.*

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,32 @@
+# Getting Started
+
+1. Clone repository.
+   ```bash
+   git clone https://github.com/Skyworks-Neo/nvoc.git
+   cd nvoc
+   ```
+2. Install Rust toolchain `1.95.0` and Python `uv`.
+3. Build optimizer first.
+   ```bash
+   cd auto-optimizer
+   cargo build --release
+   ```
+4. Run one frontend.
+
+GUI:
+```bash
+cd gui
+uv sync
+uv run python main.py
+```
+
+TUI:
+```bash
+cd tui
+uv sync
+uv run nvoc-tui
+```
+
+---
+
+*Maintained from: `README.md`, `rust-toolchain.toml`, `gui/README.md`, `tui/README.md`.*

--- a/docs/wiki/Home-zh.md
+++ b/docs/wiki/Home-zh.md
@@ -1,0 +1,23 @@
+# NVOC Wiki 中文首页
+
+NVOC 是一个围绕 NVIDIA GPU 超频与稳定性验证的 Rust/Python monorepo。核心控制链路为 `auto-optimizer` + NVAPI/NVML，GUI/TUI/SRV 提供不同运行环境下的操作入口。
+
+> ⚠️ **安全警告**：超频写入可能导致驱动崩溃、GPU 重置、系统不稳定甚至数据丢失。请先做只读验证，确认散热/供电/回退方案后再执行写入。
+
+## 导航
+
+- [组件总览](./Components.md)
+- [快速开始](./Getting-Started.md)
+- [构建与测试](./Build-and-Test.md)
+- [架构](./Architecture.md)
+- [自动优化器](./Auto-Optimizer.md)
+- [压力测试器](./Stressors.md)
+- [前端](./Frontends.md)
+- [兼容性矩阵](./Compatibility-Matrix.md)
+- [安全与恢复](./Safety-and-Recovery.md)
+- [贡献指南](./Contributing.md)
+- [FAQ](./FAQ.md)
+
+---
+
+*维护来源：`README.md`、`auto-optimizer/README.md`、`auto-optimizer/README-en.md`。*

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,26 @@
+# NVOC Wiki Home
+
+NVOC is a Rust + Python monorepo for NVIDIA GPU overclocking, validation, and frontend orchestration. The core control path is `auto-optimizer` with NVAPI/NVML backends, while GUI/TUI/SRV wrap operational flows for different environments.
+
+> ⚠️ **Safety first**: Overclock writes can crash drivers, reset GPUs, and cause data loss. Start with read-only commands, verify cooling and power limits, and ensure you know recovery steps before applying write operations.
+
+This wiki is split by component responsibilities, architecture, build/test commands, compatibility, and operational safety. Each page is mapped to one or more source-of-truth files to avoid drift.
+
+## Navigation
+
+- [Components](./Components.md)
+- [Getting Started](./Getting-Started.md)
+- [Build and Test](./Build-and-Test.md)
+- [Architecture](./Architecture.md)
+- [Auto Optimizer](./Auto-Optimizer.md)
+- [Stressors](./Stressors.md)
+- [Frontends](./Frontends.md)
+- [Compatibility Matrix](./Compatibility-Matrix.md)
+- [Safety and Recovery](./Safety-and-Recovery.md)
+- [Contributing](./Contributing.md)
+- [FAQ](./FAQ.md)
+- [中文首页](./Home-zh.md)
+
+---
+
+*Maintained from: `README.md`, `auto-optimizer/README-en.md`, `auto-optimizer/README.md`.*

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,15 @@
+# Wiki Source Policy
+
+This directory is the canonical source for long-form project documentation.
+
+## Workflow
+
+1. Edit docs in `docs/wiki/*.md` in this repository.
+2. Open a PR in `nvoc` for technical and language review.
+3. After merge, sync the approved markdown to the GitHub Wiki repository (`nvoc-wiki`).
+
+## Rationale
+
+For NVOC's current project scope, keeping docs in the monorepo keeps review, versioning, and code/docs consistency in one place.
+
+Maintained from: repository policy and reviewer guidance.

--- a/docs/wiki/Safety-and-Recovery.md
+++ b/docs/wiki/Safety-and-Recovery.md
@@ -1,0 +1,22 @@
+# Safety and Recovery
+
+## High-risk operations
+
+- Any write operation to clocks, voltage/frequency points, power limits, fan settings.
+- Bulk scan loops without thermal/power observation.
+
+## Recovery controls
+
+- TDR registry strategy (Windows) for driver timeout behavior.
+- `auto-optimizer/systemd/` units and scripts for controlled startup/recovery on Linux.
+- Reset command path (`reset`) as first-line rollback.
+
+## Do-not-OC cases
+
+- Unknown cooling or unstable PSU.
+- Production workload without maintenance window.
+- Unsupported/untested GPU + backend combination.
+
+---
+
+*Maintained from: `auto-optimizer/README.md`, `auto-optimizer/systemd/`, platform recovery docs/scripts.*

--- a/docs/wiki/Stressors.md
+++ b/docs/wiki/Stressors.md
@@ -1,0 +1,13 @@
+# Stressors
+
+| Stressor | Stack | Platforms | Best for |
+|---|---|---|---|
+| CUDA (Python) | PyTorch + CUDA | NVIDIA CUDA environments | Autoscan validation with mature Python ecosystem |
+| CUDA (Rust) | Rust + CUDA toolchain | CUDA-capable dev/runtime setups | Native Rust integration and lower Python dependency |
+| OpenCL | OpenCL runtime | Broader GPU runtime coverage | Lightweight checks when CUDA stack is unavailable |
+
+Selection rule: choose the stressor that matches deployment constraints first (driver/runtime), then optimize for workflow integration.
+
+---
+
+*Maintained from: `cli-stressor-cuda/`, `cli-stressor-cuda-rs/`, `cli-stressor-opencl/`, `auto-optimizer/README.md`.*


### PR DESCRIPTION
### Motivation

- Provide a repo-managed, reviewable GitHub Wiki authoring workflow by moving canonical pages into `docs/wiki/` to avoid drift from web edits. 
- Surface a compact README that links to bilingual wiki home pages and points contributors to the reviewed wiki content. 
- Make it explicit which source files should be treated as the single-source-of-truth via per-page "Maintained from …" footers.

### Description

- Added a full initial Wiki draft set under `docs/wiki/` (Home, Home-zh, Components, Getting-Started, Build-and-Test, Architecture, Auto-Optimizer, Stressors, Frontends, Compatibility-Matrix, Safety-and-Recovery, Contributing, FAQ). 
- Updated `README.md` to a concise, English-first entry that links to the new wiki home pages. 
- Appended per-page maintenance footers that reference canonical source files (e.g., `auto-optimizer/README.md`) to reduce documentation drift. 
- Committed the new files and README changes as a docs-only change for PR review and later sync to `.wiki.git` after approval.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16bc82e1c88323b5dd243954c3abcf)