### PR TITLE
gui: Add memory diagnostics for leak investigation

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -11,6 +11,8 @@ from typing import Any, Callable, Optional
 # Ensure the project root is in path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from src.memory_debug import configure_memory_debug_from_env
+
 # Fix blurry/tiny rendering on Windows HiDPI displays (e.g. 150% scaling).
 if sys.platform == "win32":
     try:
@@ -78,6 +80,7 @@ def _require_gui_runtime(
 
 
 def main() -> int:
+    memory_debug_config = configure_memory_debug_from_env()
     _require_gui_runtime()
 
     from src.app import App
@@ -98,7 +101,7 @@ def main() -> int:
     start_time = time.perf_counter()
 
     try:
-        app = App(single_instance_guard=guard)
+        app = App(single_instance_guard=guard, memory_debug_config=memory_debug_config)
 
         def log_startup_time() -> None:
             elapsed_time = time.perf_counter() - start_time

--- a/gui/src/app.py
+++ b/gui/src/app.py
@@ -32,6 +32,7 @@ from src.parsing import (
     write_vfp_points,
 )
 from src.task_runner import GuiTaskRunner
+from src.memory_debug import MemoryDebugConfig, schedule_memory_reports
 from src.widgets.output_console import OutputConsole
 from src.widgets.lightweight_controls import LiteButton
 from src.tabs.dashboard import DashboardTab
@@ -56,7 +57,11 @@ def find_cli_exe() -> str:
 class App(ctk.CTk):
     """Main application window."""
 
-    def __init__(self, single_instance_guard: Optional["SingleInstanceGuard"] = None):
+    def __init__(
+        self,
+        single_instance_guard: Optional["SingleInstanceGuard"] = None,
+        memory_debug_config: Optional[MemoryDebugConfig] = None,
+    ):
         super().__init__()
 
         # Global resize session state (used to coalesce expensive per-tab redraw work)
@@ -69,6 +74,7 @@ class App(ctk.CTk):
         self.geometry("768x672")
         self.minsize(768, 360)
         self._single_instance_guard = single_instance_guard
+        self._memory_debug_config = memory_debug_config
 
         # Appearance
         ctk.set_appearance_mode("dark")
@@ -121,6 +127,15 @@ class App(ctk.CTk):
             self.console.append(
                 "[GUI] CLI executable not found in PATH.\n"
                 "[GUI] Please click '⚙ CLI Path' to locate nvoc-autooptimizer.exe manually.\n"
+            )
+
+        if self._memory_debug_config is not None:
+            self.console.append(
+                "[GUI][mem] Memory diagnostics enabled; "
+                f"logging every {self._memory_debug_config.interval_seconds:.0f}s.\n"
+            )
+            schedule_memory_reports(
+                self.after, self.console.append, self._memory_debug_config
             )
 
         # GPU index → display name mapping

--- a/gui/src/memory_debug.py
+++ b/gui/src/memory_debug.py
@@ -73,10 +73,14 @@ def current_rss_bytes() -> Optional[int]:
 
 
 def _windows_current_rss_bytes() -> Optional[int]:
+    # ``ctypes.wintypes`` only exists on Windows; import it lazily here so the
+    # module remains importable on Linux/macOS where this helper is never called.
+    from ctypes import wintypes
+
     class PROCESS_MEMORY_COUNTERS(ctypes.Structure):
         _fields_ = [
-            ("cb", ctypes.wintypes.DWORD),
-            ("PageFaultCount", ctypes.wintypes.DWORD),
+            ("cb", wintypes.DWORD),
+            ("PageFaultCount", wintypes.DWORD),
             ("PeakWorkingSetSize", ctypes.c_size_t),
             ("WorkingSetSize", ctypes.c_size_t),
             ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),

--- a/gui/src/memory_debug.py
+++ b/gui/src/memory_debug.py
@@ -7,7 +7,6 @@ import gc
 import os
 import sys
 import tracemalloc
-from ctypes import wintypes
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -76,8 +75,8 @@ def current_rss_bytes() -> Optional[int]:
 def _windows_current_rss_bytes() -> Optional[int]:
     class PROCESS_MEMORY_COUNTERS(ctypes.Structure):
         _fields_ = [
-            ("cb", wintypes.DWORD),
-            ("PageFaultCount", wintypes.DWORD),
+            ("cb", ctypes.wintypes.DWORD),
+            ("PageFaultCount", ctypes.wintypes.DWORD),
             ("PeakWorkingSetSize", ctypes.c_size_t),
             ("WorkingSetSize", ctypes.c_size_t),
             ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),

--- a/gui/src/memory_debug.py
+++ b/gui/src/memory_debug.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ctypes
 import gc
 import os
 import sys
@@ -75,12 +74,14 @@ def current_rss_bytes() -> Optional[int]:
 def _windows_current_rss_bytes() -> Optional[int]:
     # ``ctypes.wintypes`` only exists on Windows; import it lazily here so the
     # module remains importable on Linux/macOS where this helper is never called.
-    from ctypes import wintypes
+    # Use ``import`` (not ``from ... import``) to keep a single import style for
+    # ``ctypes`` and avoid CodeQL's mixed-import warning.
+    import ctypes.wintypes
 
     class PROCESS_MEMORY_COUNTERS(ctypes.Structure):
         _fields_ = [
-            ("cb", wintypes.DWORD),
-            ("PageFaultCount", wintypes.DWORD),
+            ("cb", ctypes.wintypes.DWORD),
+            ("PageFaultCount", ctypes.wintypes.DWORD),
             ("PeakWorkingSetSize", ctypes.c_size_t),
             ("WorkingSetSize", ctypes.c_size_t),
             ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),

--- a/gui/src/memory_debug.py
+++ b/gui/src/memory_debug.py
@@ -1,0 +1,158 @@
+"""Optional memory diagnostics for long-running NVOC-GUI sessions."""
+
+from __future__ import annotations
+
+import ctypes
+import gc
+import os
+import sys
+import tracemalloc
+from ctypes import wintypes
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+_DEFAULT_TOP_STATS = 5
+_MIN_INTERVAL_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class MemoryDebugConfig:
+    """Runtime settings for GUI memory diagnostics."""
+
+    interval_seconds: float
+    top_stats: int = _DEFAULT_TOP_STATS
+
+
+def configure_memory_debug_from_env() -> Optional[MemoryDebugConfig]:
+    """Enable tracemalloc when requested through environment variables.
+
+    Set ``NVOC_GUI_MEMORY_LOG_INTERVAL_SEC`` to a positive interval to emit
+    periodic memory samples to the GUI console. ``NVOC_GUI_MEMORY_TOP`` controls
+    how many allocation sites are included in each sample.
+    """
+
+    raw_interval = os.environ.get("NVOC_GUI_MEMORY_LOG_INTERVAL_SEC", "").strip()
+    if not raw_interval:
+        return None
+    try:
+        interval_seconds = float(raw_interval)
+    except ValueError:
+        return None
+    if interval_seconds <= 0:
+        return None
+
+    interval_seconds = max(_MIN_INTERVAL_SECONDS, interval_seconds)
+    top_stats = _DEFAULT_TOP_STATS
+    raw_top = os.environ.get("NVOC_GUI_MEMORY_TOP", "").strip()
+    if raw_top:
+        try:
+            top_stats = max(1, min(20, int(raw_top)))
+        except ValueError:
+            top_stats = _DEFAULT_TOP_STATS
+
+    if not tracemalloc.is_tracing():
+        tracemalloc.start(25)
+    return MemoryDebugConfig(interval_seconds=interval_seconds, top_stats=top_stats)
+
+
+def current_rss_bytes() -> Optional[int]:
+    """Return current resident set size in bytes when the platform exposes it."""
+
+    if sys.platform.startswith("linux"):
+        try:
+            with open("/proc/self/status", encoding="utf-8") as status_file:
+                for line in status_file:
+                    if line.startswith("VmRSS:"):
+                        parts = line.split()
+                        return int(parts[1]) * 1024
+        except (OSError, ValueError, IndexError):
+            return None
+    if sys.platform == "win32":
+        return _windows_current_rss_bytes()
+    return None
+
+
+def _windows_current_rss_bytes() -> Optional[int]:
+    class PROCESS_MEMORY_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("cb", wintypes.DWORD),
+            ("PageFaultCount", wintypes.DWORD),
+            ("PeakWorkingSetSize", ctypes.c_size_t),
+            ("WorkingSetSize", ctypes.c_size_t),
+            ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+            ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+            ("PagefileUsage", ctypes.c_size_t),
+            ("PeakPagefileUsage", ctypes.c_size_t),
+        ]
+
+    counters = PROCESS_MEMORY_COUNTERS()
+    counters.cb = ctypes.sizeof(PROCESS_MEMORY_COUNTERS)
+    try:
+        handle = ctypes.windll.kernel32.GetCurrentProcess()
+        ok = ctypes.windll.psapi.GetProcessMemoryInfo(
+            handle, ctypes.byref(counters), counters.cb
+        )
+    except (AttributeError, OSError):
+        return None
+    if not ok:
+        return None
+    return int(counters.WorkingSetSize)
+
+
+def format_memory_report(top_stats: int = _DEFAULT_TOP_STATS) -> str:
+    """Build a compact tracemalloc/RSS report for console output."""
+
+    gc.collect()
+    rss = current_rss_bytes()
+    current, peak = (
+        tracemalloc.get_traced_memory() if tracemalloc.is_tracing() else (0, 0)
+    )
+    lines = [
+        "[GUI][mem] RSS={} Python={} peak={} objects={}".format(
+            _format_bytes(rss),
+            _format_bytes(current),
+            _format_bytes(peak),
+            len(gc.get_objects()),
+        )
+    ]
+    if tracemalloc.is_tracing():
+        snapshot = tracemalloc.take_snapshot()
+        stats = snapshot.statistics("lineno")[:top_stats]
+        for index, stat in enumerate(stats, start=1):
+            frame = stat.traceback[0]
+            lines.append(
+                f"[GUI][mem] #{index} {stat.size / 1024:.1f} KiB in "
+                f"{stat.count} blocks at {frame.filename}:{frame.lineno}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def schedule_memory_reports(
+    after: Callable[[int, Callable[[], None]], object],
+    append: Callable[[str], None],
+    config: MemoryDebugConfig,
+) -> None:
+    """Schedule periodic memory reports on a Tk-compatible event loop."""
+
+    interval_ms = int(config.interval_seconds * 1000)
+
+    def emit() -> None:
+        append(format_memory_report(config.top_stats))
+        after(interval_ms, emit)
+
+    after(interval_ms, emit)
+
+
+def _format_bytes(value: Optional[int]) -> str:
+    if value is None:
+        return "n/a"
+    units = ["B", "KiB", "MiB", "GiB"]
+    amount = float(value)
+    for unit in units:
+        if amount < 1024 or unit == units[-1]:
+            return f"{amount:.1f} {unit}"
+        amount /= 1024
+    return f"{amount:.1f} GiB"

--- a/gui/src/widgets/output_console.py
+++ b/gui/src/widgets/output_console.py
@@ -10,7 +10,8 @@ import customtkinter as ctk
 class OutputConsole(ctk.CTkFrame):
     """A docked output console that displays CLI output in real-time."""
 
-    _MAX_LINES = 100
+    _MAX_LINES = 500
+    _MAX_CHARS = 250_000
 
     def __init__(self, master, **kwargs) -> None:
         super().__init__(master, **kwargs)
@@ -61,7 +62,7 @@ class OutputConsole(ctk.CTkFrame):
             self.textbox.pack_forget()
 
     def append(self, text: str) -> None:
-        """Append text to the console (thread-safe) and keep only the last 1000 lines."""
+        """Append text to the console and bound retained text/tag ranges."""
         with self._lock:
             self.textbox.configure(state="normal")
 
@@ -80,13 +81,21 @@ class OutputConsole(ctk.CTkFrame):
                 # If it's a message with a return code that isn't 0
                 self.textbox.tag_add("red", start_index, end_index)
 
-            # Keep only the last 1000 lines
-            line_count = int(float(self.textbox.index("end-1c")))
-            if line_count > self._MAX_LINES:
-                self.textbox.delete("1.0", f"{line_count - self._MAX_LINES}.0")
+            self._trim_history()
 
             self.textbox.see("end")
             self.textbox.configure(state="disabled")
+
+    def _trim_history(self) -> None:
+        """Keep long-running console output from retaining unbounded Tk state."""
+        line_count = int(float(self.textbox.index("end-1c")))
+        if line_count > self._MAX_LINES:
+            self.textbox.delete("1.0", f"{line_count - self._MAX_LINES + 1}.0")
+
+        char_count = int(self.textbox.count("1.0", "end-1c", "chars")[0])
+        if char_count > self._MAX_CHARS:
+            overflow = char_count - self._MAX_CHARS
+            self.textbox.delete("1.0", f"1.0+{overflow}c")
 
     def clear(self) -> None:
         """Clear all console text."""

--- a/gui/src/widgets/output_console.py
+++ b/gui/src/widgets/output_console.py
@@ -92,7 +92,7 @@ class OutputConsole(ctk.CTkFrame):
         if line_count > self._MAX_LINES:
             self.textbox.delete("1.0", f"{line_count - self._MAX_LINES + 1}.0")
 
-        char_count = int(self.textbox.count("1.0", "end-1c", "chars")[0])
+        char_count = len(self.textbox.get("1.0", "end-1c"))
         if char_count > self._MAX_CHARS:
             overflow = char_count - self._MAX_CHARS
             self.textbox.delete("1.0", f"1.0+{overflow}c")

--- a/gui/tests/test_memory_debug.py
+++ b/gui/tests/test_memory_debug.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import tracemalloc
+
+from src import memory_debug
+
+
+def test_configure_memory_debug_from_env_enables_tracing(monkeypatch) -> None:
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+    monkeypatch.setenv("NVOC_GUI_MEMORY_LOG_INTERVAL_SEC", "1")
+    monkeypatch.setenv("NVOC_GUI_MEMORY_TOP", "2")
+
+    config = memory_debug.configure_memory_debug_from_env()
+
+    assert config is not None
+    assert config.interval_seconds == 10.0
+    assert config.top_stats == 2
+    assert tracemalloc.is_tracing()
+    tracemalloc.stop()
+
+
+def test_format_memory_report_includes_requested_number_of_top_stats(
+    monkeypatch,
+) -> None:
+    if not tracemalloc.is_tracing():
+        tracemalloc.start(25)
+    monkeypatch.setattr(memory_debug, "current_rss_bytes", lambda: 1024)
+
+    report = memory_debug.format_memory_report(top_stats=1)
+
+    assert report.startswith("[GUI][mem] RSS=1.0 KiB")
+    assert report.count("[GUI][mem] #") <= 1


### PR DESCRIPTION
### Motivation
- The GUI exhibits long-running memory growth and needs opt-in diagnostics to capture RSS/tracemalloc snapshots and allocation hotspots for investigation.
- The output console retained unbounded Tk text/tags during long sessions, which can magnify apparent memory growth and should be bounded.

### Description
- Add `gui/src/memory_debug.py` implementing `configure_memory_debug_from_env()`, RSS helpers, `tracemalloc`-based top-site reports, `format_memory_report()` and `schedule_memory_reports()` controlled by `NVOC_GUI_MEMORY_LOG_INTERVAL_SEC` and `NVOC_GUI_MEMORY_TOP`.
- Wire diagnostics into startup by calling `configure_memory_debug_from_env()` from `gui/main.py` and passing the resulting `MemoryDebugConfig` into `App(...)` so periodic reports are posted to the console via `schedule_memory_reports()`.
- Limit retained console state by increasing `_MAX_LINES` and adding an overall `_MAX_CHARS` cap plus a `_trim_history()` helper in `gui/src/widgets/output_console.py` to delete old lines/characters and reduce long-session Tk memory/tag growth.
- Add tests `gui/tests/test_memory_debug.py` that exercise env parsing and `format_memory_report()` behavior and update small call sites in `gui/src/app.py` to accept an optional `memory_debug_config` parameter.

### Testing
- Ran style and lint checks with `ruff format . --preview --check` and `ruff check .` and they passed.
- Verified modules compile with `python -m py_compile gui/main.py gui/src/app.py gui/src/widgets/output_console.py gui/src/memory_debug.py gui/tests/test_memory_debug.py` with no errors.
- Ran the GUI unit test suite with `cd gui && uv run --no-sync pytest` and the full GUI tests passed (`28 passed`); an earlier `uv run pytest` attempt that triggered a dependency sync failed due to an unreachable package index in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec9bbb95883238ddd9e4f4ff53dec)