### PR TITLE
Sync main into scanner-refactor (#191 gui space-behaviour fix)

### DIFF
--- a/gui/src/tabs/vfcurve.py
+++ b/gui/src/tabs/vfcurve.py
@@ -48,6 +48,8 @@ class VFCurveTab:
         # Frequency lock state (core/memory): (min_mhz, max_mhz)
         self._freq_core_lock = None  # type: Optional[Tuple[int, int]]
         self._freq_mem_lock = None  # type: Optional[Tuple[int, int]]
+        self._freq_core_lock_backend = None  # type: Optional[str]
+        self._freq_mem_lock_backend = None  # type: Optional[str]
 
         # Drag state
         self._dragging = False
@@ -666,6 +668,11 @@ class VFCurveTab:
             self.app.console.append(f"[GUI] CSV not found: {path}\n")
             return
 
+        previous_selection = (
+            (self._sel_start, self._sel_end)
+            if self._sel_start is not None and self._sel_end is not None
+            else None
+        )
         voltages = []
         frequencies = []
         defaults = []
@@ -700,6 +707,12 @@ class VFCurveTab:
         self._sel_start = None
         self._sel_end = None
         self._drag_orig_freqs = None
+        if previous_selection is not None and voltages:
+            max_idx = len(voltages) - 1
+            start, end = previous_selection
+            self._sel_start = max(0, min(start, max_idx))
+            self._sel_end = max(0, min(end, max_idx))
+            self._sync_selection_to_adj()
 
         # Apply any pending lock set before data was loaded
         pending_mv = getattr(self, "_pending_lock_mv", None)
@@ -1119,10 +1132,19 @@ class VFCurveTab:
         new_mem_lock = (
             (mem_min, mem_max) if mem_min is not None and mem_max is not None else None
         )
-        changed = new_core_lock != self._freq_core_lock
+        new_core_backend = "nvapi" if new_core_lock is not None else None
+        new_mem_backend = "nvapi" if new_mem_lock is not None else None
+        changed = (
+            new_core_lock != self._freq_core_lock
+            or new_core_backend != self._freq_core_lock_backend
+            or new_mem_lock != self._freq_mem_lock
+            or new_mem_backend != self._freq_mem_lock_backend
+        )
 
         self._freq_core_lock = new_core_lock
         self._freq_mem_lock = new_mem_lock
+        self._freq_core_lock_backend = new_core_backend
+        self._freq_mem_lock_backend = new_mem_backend
         self.app._dashboard_gpu_lock_active = new_core_lock is not None
         self.app._dashboard_mem_lock_active = new_mem_lock is not None
         self.core_lock_min_var.set(str(core_min if core_min is not None else 0))
@@ -1180,9 +1202,7 @@ class VFCurveTab:
 
     def _apply_vfp_lock_ui(self, idx: Optional[int]):
         """Update UI state after a successful VFP point lock."""
-        self._freq_core_lock = None
-        self.core_lock_min_var.set("0")
-        self.core_lock_max_var.set("0")
+        self._clear_core_freq_lock_ui()
         self._locked_points.clear()
         if idx is not None:
             self._locked_points.add(idx)
@@ -1301,6 +1321,71 @@ class VFCurveTab:
     def _selected_freq_lock_backend_label(self) -> str:
         return self._selected_freq_lock_backend().upper()
 
+    def _backend_label(self, backend: str) -> str:
+        return backend.upper()
+
+    def _set_core_freq_lock_ui(self, min_mhz: int, max_mhz: int, backend: str) -> None:
+        self._freq_core_lock = (min_mhz, max_mhz)
+        self._freq_core_lock_backend = backend
+        self.core_lock_min_var.set(str(min_mhz))
+        self.core_lock_max_var.set(str(max_mhz))
+
+    def _clear_core_freq_lock_ui(self) -> None:
+        self._freq_core_lock = None
+        self._freq_core_lock_backend = None
+        self.core_lock_min_var.set("0")
+        self.core_lock_max_var.set("0")
+
+    def _set_mem_freq_lock_ui(self, min_mhz: int, max_mhz: int, backend: str) -> None:
+        self._freq_mem_lock = (min_mhz, max_mhz)
+        self._freq_mem_lock_backend = backend
+        self.mem_lock_min_var.set(str(min_mhz))
+        self.mem_lock_max_var.set(str(max_mhz))
+
+    def _clear_mem_freq_lock_ui(self) -> None:
+        self._freq_mem_lock = None
+        self._freq_mem_lock_backend = None
+        self.mem_lock_min_var.set("0")
+        self.mem_lock_max_var.set("0")
+
+    def _core_reset_backend(self, default_backend: str) -> str:
+        if self._freq_core_lock is not None and self._freq_core_lock_backend:
+            return self._freq_core_lock_backend
+        return default_backend
+
+    def _mem_reset_backend(self, default_backend: str) -> str:
+        if self._freq_mem_lock is not None and self._freq_mem_lock_backend:
+            return self._freq_mem_lock_backend
+        return default_backend
+
+    def _lock_core_native(
+        self, native, gpu: str, backend: str, min_mhz: int, max_mhz: int
+    ) -> None:
+        if backend == "nvapi":
+            native.set_vfp_frequency_lock(gpu, "core", max_mhz * 1000, min_mhz * 1000)
+        else:
+            native.set_locked_clocks(gpu, backend, "core", min_mhz, max_mhz)
+
+    def _reset_core_native(self, native, gpu: str, backend: str) -> None:
+        if backend == "nvapi":
+            native.reset_vfp_frequency_lock(gpu, "core")
+        else:
+            native.reset_core_clocks(gpu, backend)
+
+    def _lock_mem_native(
+        self, native, gpu: str, backend: str, min_mhz: int, max_mhz: int
+    ) -> None:
+        if backend == "nvapi":
+            native.set_vfp_frequency_lock(gpu, "memory", max_mhz * 1000, min_mhz * 1000)
+        else:
+            native.set_locked_clocks(gpu, backend, "memory", min_mhz, max_mhz)
+
+    def _reset_mem_native(self, native, gpu: str, backend: str) -> None:
+        if backend == "nvapi":
+            native.reset_vfp_frequency_lock(gpu, "memory")
+        else:
+            native.reset_mem_clocks(gpu, backend)
+
     # ── Left / Shift-Tab : move selection left (lower index) ──
     def _on_key_left(self, event=None):
         if not self._voltages or self._sel_start is None:
@@ -1414,31 +1499,21 @@ class VFCurveTab:
             self._freq_core_lock is not None and self._freq_core_lock == (min_f, max_f)
         )
         has_vfp_locks = len(self._locked_points) > 0
-
-        def _lock_core(native, local_min: int, local_max: int) -> None:
-            if lock_backend == "nvapi":
-                native.set_vfp_frequency_lock(
-                    gpu, "core", local_max * 1000, local_min * 1000
-                )
-            else:
-                native.set_locked_clocks(
-                    gpu, lock_backend, "core", local_min, local_max
-                )
+        active_freq_backend = self._core_reset_backend(lock_backend)
+        active_freq_backend_label = self._backend_label(active_freq_backend)
 
         if s == e and is_vfp_locked:
             description = "convert VFP lock to frequency lock"
 
             def action(native) -> str:
                 native.reset_vfp_lock(gpu)
-                _lock_core(native, cur_f, cur_f)
+                self._lock_core_native(native, gpu, lock_backend, cur_f, cur_f)
                 return f"Applied {lock_backend_label} lock for point {idx}."
 
-            def done(rc: int, local_f=cur_f) -> None:
+            def done(rc: int, local_f=cur_f, backend=lock_backend) -> None:
                 self._locked_points.clear()
                 if rc == 0:
-                    self._freq_core_lock = (local_f, local_f)
-                    self.core_lock_min_var.set(str(local_f))
-                    self.core_lock_max_var.set(str(local_f))
+                    self._set_core_freq_lock_ui(local_f, local_f, backend)
                 self._redraw()
                 self.canvas.draw()
                 self._is_toggling_lock = False
@@ -1447,17 +1522,29 @@ class VFCurveTab:
             description = "reset frequency lock"
 
             def action(native) -> str:
-                if lock_backend == "nvapi":
-                    native.reset_vfp_frequency_lock(gpu, "core")
-                else:
-                    native.reset_core_clocks(gpu, lock_backend)
-                return f"Reset {lock_backend_label} lock."
+                self._reset_core_native(native, gpu, active_freq_backend)
+                return f"Reset {active_freq_backend_label} lock."
 
             def done(rc: int) -> None:
                 if rc == 0:
-                    self._freq_core_lock = None
-                    self.core_lock_min_var.set("0")
-                    self.core_lock_max_var.set("0")
+                    self._clear_core_freq_lock_ui()
+                self._redraw()
+                self.canvas.draw()
+                self._is_toggling_lock = False
+
+        elif s == e and lock_backend == "nvml":
+            description = "lock NVML frequency point"
+
+            def action(native) -> str:
+                if has_vfp_locks:
+                    native.reset_vfp_lock(gpu)
+                self._lock_core_native(native, gpu, lock_backend, cur_f, cur_f)
+                return f"Applied {lock_backend_label} lock for point {idx}."
+
+            def done(rc: int, local_f=cur_f, backend=lock_backend) -> None:
+                self._locked_points.clear()
+                if rc == 0:
+                    self._set_core_freq_lock_ui(local_f, local_f, backend)
                 self._redraw()
                 self.canvas.draw()
                 self._is_toggling_lock = False
@@ -1466,17 +1553,12 @@ class VFCurveTab:
             description = "lock VFP point"
 
             def action(native) -> str:
-                if lock_backend == "nvapi":
-                    native.reset_vfp_frequency_lock(gpu, "core")
-                else:
-                    native.reset_core_clocks(gpu, lock_backend)
+                self._reset_core_native(native, gpu, lock_backend)
                 native.set_vfp_voltage_lock(gpu, idx, None, False)
                 return f"Locked VFP point {idx}."
 
             def done(rc: int, local_idx=idx) -> None:
-                self._freq_core_lock = None
-                self.core_lock_min_var.set("0")
-                self.core_lock_max_var.set("0")
+                self._clear_core_freq_lock_ui()
                 if rc == 0:
                     self._locked_points.clear()
                     self._locked_points.add(local_idx)
@@ -1491,17 +1573,12 @@ class VFCurveTab:
             description = "reset frequency range lock"
 
             def action(native) -> str:
-                if lock_backend == "nvapi":
-                    native.reset_vfp_frequency_lock(gpu, "core")
-                else:
-                    native.reset_core_clocks(gpu, lock_backend)
-                return f"Reset {lock_backend_label} range lock."
+                self._reset_core_native(native, gpu, active_freq_backend)
+                return f"Reset {active_freq_backend_label} range lock."
 
             def done(rc: int) -> None:
                 if rc == 0:
-                    self._freq_core_lock = None
-                    self.core_lock_min_var.set("0")
-                    self.core_lock_max_var.set("0")
+                    self._clear_core_freq_lock_ui()
                 self._redraw()
                 self.canvas.draw()
                 self._is_toggling_lock = False
@@ -1512,18 +1589,16 @@ class VFCurveTab:
             def action(native) -> str:
                 if has_vfp_locks:
                     native.reset_vfp_lock(gpu)
-                _lock_core(native, min_f, max_f)
+                self._lock_core_native(native, gpu, lock_backend, min_f, max_f)
                 return (
                     f"Applied {lock_backend_label} lock for range {s}-{e} "
                     f"({min_f}-{max_f} MHz)."
                 )
 
-            def done(rc: int, lf_min=min_f, lf_max=max_f) -> None:
+            def done(rc: int, lf_min=min_f, lf_max=max_f, backend=lock_backend) -> None:
                 self._locked_points.clear()
                 if rc == 0:
-                    self._freq_core_lock = (lf_min, lf_max)
-                    self.core_lock_min_var.set(str(lf_min))
-                    self.core_lock_max_var.set(str(lf_max))
+                    self._set_core_freq_lock_ui(lf_min, lf_max, backend)
                 self._redraw()
                 self.canvas.draw()
                 self._is_toggling_lock = False
@@ -1695,30 +1770,20 @@ class VFCurveTab:
         self.app.run_native_action(
             "lock core clocks",
             lambda native, gpu=gpu, backend=backend, min_clk=min_clk, max_clk=max_clk: (
-                (
-                    native.set_vfp_frequency_lock(
-                        gpu, "core", max_clk * 1000, min_clk * 1000
-                    )
-                    if backend == "nvapi"
-                    else native.set_locked_clocks(
-                        gpu, backend, "core", min_clk, max_clk
-                    )
-                )
+                self._lock_core_native(native, gpu, backend, min_clk, max_clk)
                 or f"Successfully locked {backend_label} core clocks."
             ),
-            on_finished=lambda rc, label=backend_label: self._on_core_lock_done(
-                rc, min_clk, max_clk, label
+            on_finished=lambda rc, label=backend_label, backend=backend: (
+                self._on_core_lock_done(rc, min_clk, max_clk, backend, label)
             ),
         )
 
     def _on_core_lock_done(
-        self, rc: int, min_clk: int, max_clk: int, backend_label: str
+        self, rc: int, min_clk: int, max_clk: int, backend: str, backend_label: str
     ):
         def _update_ui():
             if rc == 0:
-                self._freq_core_lock = (min_clk, max_clk)
-                self.core_lock_min_var.set(str(min_clk))
-                self.core_lock_max_var.set(str(max_clk))
+                self._set_core_freq_lock_ui(min_clk, max_clk, backend)
                 self.app.console.append(
                     f"[GUI] {backend_label} core clock locked successfully.\n"
                 )
@@ -1738,17 +1803,13 @@ class VFCurveTab:
 
         self._is_toggling_lock = True
         gpu = self.app.selected_gpu_target()
-        backend = self._selected_freq_lock_backend()
-        backend_label = self._selected_freq_lock_backend_label()
+        backend = self._core_reset_backend(self._selected_freq_lock_backend())
+        backend_label = self._backend_label(backend)
         self.app.console.append(f"[GUI] Resetting {backend_label} core clocks...\n")
         self.app.run_native_action(
             "reset core clocks",
             lambda native, gpu=gpu, backend=backend: (
-                (
-                    native.reset_vfp_frequency_lock(gpu, "core")
-                    if backend == "nvapi"
-                    else native.reset_core_clocks(gpu, backend)
-                )
+                self._reset_core_native(native, gpu, backend)
                 or f"Successfully reset {backend_label} core clocks."
             ),
             on_finished=lambda rc, label=backend_label: self._on_core_reset_done(
@@ -1759,9 +1820,7 @@ class VFCurveTab:
     def _on_core_reset_done(self, rc: int, backend_label: str):
         def _update_ui():
             if rc == 0:
-                self._freq_core_lock = None
-                self.core_lock_min_var.set("0")
-                self.core_lock_max_var.set("0")
+                self._clear_core_freq_lock_ui()
                 self.app.console.append(
                     f"[GUI] {backend_label} core clock reset successfully.\n"
                 )
@@ -1794,35 +1853,61 @@ class VFCurveTab:
         self.app.run_native_action(
             "lock memory clocks",
             lambda native, gpu=gpu, backend=backend, min_clk=min_clk, max_clk=max_clk: (
-                (
-                    native.set_vfp_frequency_lock(
-                        gpu, "memory", max_clk * 1000, min_clk * 1000
-                    )
-                    if backend == "nvapi"
-                    else native.set_locked_clocks(
-                        gpu, backend, "memory", min_clk, max_clk
-                    )
-                )
+                self._lock_mem_native(native, gpu, backend, min_clk, max_clk)
                 or f"Successfully locked {backend_label} memory clocks."
+            ),
+            on_finished=lambda rc, label=backend_label, backend=backend: (
+                self._on_mem_lock_done(rc, min_clk, max_clk, backend, label)
             ),
         )
 
+    def _on_mem_lock_done(
+        self, rc: int, min_clk: int, max_clk: int, backend: str, backend_label: str
+    ):
+        def _update_ui():
+            if rc == 0:
+                self._set_mem_freq_lock_ui(min_clk, max_clk, backend)
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock locked successfully.\n"
+                )
+            else:
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock lock failed.\n"
+                )
+            self._redraw()
+
+        self.app.after(0, _update_ui)
+
     def _reset_mem_clocks(self):
         gpu = self.app.selected_gpu_target()
-        backend = self._selected_freq_lock_backend()
-        backend_label = self._selected_freq_lock_backend_label()
+        backend = self._mem_reset_backend(self._selected_freq_lock_backend())
+        backend_label = self._backend_label(backend)
         self.app.console.append(f"[GUI] Resetting {backend_label} memory clocks...\n")
         self.app.run_native_action(
             "reset memory clocks",
             lambda native, gpu=gpu, backend=backend: (
-                (
-                    native.reset_vfp_frequency_lock(gpu, "memory")
-                    if backend == "nvapi"
-                    else native.reset_mem_clocks(gpu, backend)
-                )
+                self._reset_mem_native(native, gpu, backend)
                 or f"Successfully reset {backend_label} memory clocks."
             ),
+            on_finished=lambda rc, label=backend_label: self._on_mem_reset_done(
+                rc, label
+            ),
         )
+
+    def _on_mem_reset_done(self, rc: int, backend_label: str):
+        def _update_ui():
+            if rc == 0:
+                self._clear_mem_freq_lock_ui()
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock reset successfully.\n"
+                )
+            else:
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock reset failed.\n"
+                )
+            self._redraw()
+
+        self.app.after(0, _update_ui)
 
     def _apply_adj(self):
         """Apply the current frequency edits for the selected range to the GPU.

--- a/gui/tests/test_vfcurve_space_lock.py
+++ b/gui/tests/test_vfcurve_space_lock.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from src.tabs.vfcurve import VFCurveTab
+
+
+class FakeVar:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def get(self) -> str:
+        return self.value
+
+    def set(self, value: str) -> None:
+        self.value = value
+
+
+class FakeCanvas:
+    def __init__(self) -> None:
+        self.draw_count = 0
+
+    def draw(self) -> None:
+        self.draw_count += 1
+
+
+class FakeConsole:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def append(self, text: str) -> None:
+        self.messages.append(text)
+
+
+class FakeNative:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def reset_vfp_lock(self, gpu: str) -> None:
+        self.calls.append(("reset_vfp_lock", gpu))
+
+    def set_vfp_voltage_lock(
+        self, gpu: str, point: int | None, voltage_uv: int | None, immediate: bool
+    ) -> None:
+        self.calls.append(("set_vfp_voltage_lock", gpu, point, voltage_uv, immediate))
+
+    def set_vfp_frequency_lock(
+        self, gpu: str, domain: str, upper_khz: int, lower_khz: int
+    ) -> None:
+        self.calls.append(("set_vfp_frequency_lock", gpu, domain, upper_khz, lower_khz))
+
+    def reset_vfp_frequency_lock(self, gpu: str, domain: str) -> None:
+        self.calls.append(("reset_vfp_frequency_lock", gpu, domain))
+
+    def set_locked_clocks(
+        self, gpu: str, backend: str, domain: str, min_mhz: int, max_mhz: int
+    ) -> None:
+        self.calls.append(("set_locked_clocks", gpu, backend, domain, min_mhz, max_mhz))
+
+    def reset_core_clocks(self, gpu: str, backend: str) -> None:
+        self.calls.append(("reset_core_clocks", gpu, backend))
+
+    def reset_mem_clocks(self, gpu: str, backend: str) -> None:
+        self.calls.append(("reset_mem_clocks", gpu, backend))
+
+
+class FakeApp:
+    def __init__(self) -> None:
+        self.console = FakeConsole()
+        self.native = FakeNative()
+        self.actions: list[tuple[str, str | None]] = []
+
+    def selected_gpu_target(self) -> str:
+        return "GPU0"
+
+    def after(self, _delay: int, callback) -> None:
+        callback()
+
+    def run_native_action(self, description: str, action, on_finished=None) -> None:
+        output = action(self.native)
+        self.actions.append((description, output))
+        if on_finished is not None:
+            on_finished(0)
+
+
+def make_tab(api: str, start: int = 1, end: int = 1) -> tuple[VFCurveTab, FakeApp]:
+    app = FakeApp()
+    tab = VFCurveTab.__new__(VFCurveTab)
+    tab.app = app
+    tab._voltages = [800.0, 900.0, 1000.0, 1100.0]
+    tab._frequencies = [1400.0, 1500.0, 1600.0, 1700.0]
+    tab._defaults = list(tab._frequencies)
+    tab._sel_start = start
+    tab._sel_end = end
+    tab._locked_points = set()
+    tab._freq_core_lock = None
+    tab._freq_mem_lock = None
+    tab._freq_core_lock_backend = None
+    tab._freq_mem_lock_backend = None
+    tab.freq_lock_api_var = FakeVar(api)
+    tab.adj_start_var = FakeVar("0")
+    tab.adj_end_var = FakeVar("0")
+    tab.adj_delta_var = FakeVar("0")
+    tab.core_lock_min_var = FakeVar("0")
+    tab.core_lock_max_var = FakeVar("0")
+    tab.mem_lock_min_var = FakeVar("0")
+    tab.mem_lock_max_var = FakeVar("0")
+    tab.canvas = FakeCanvas()
+    tab._redraw = lambda: None
+    return tab, app
+
+
+def press_space(tab: VFCurveTab) -> None:
+    assert tab._on_space_key() == "break"
+
+
+def test_space_nvapi_single_cycles_voltage_freq_unlock() -> None:
+    tab, app = make_tab("NVAPI")
+
+    press_space(tab)
+    assert app.native.calls[-1] == (
+        "set_vfp_voltage_lock",
+        "GPU0",
+        1,
+        None,
+        False,
+    )
+    assert tab._locked_points == {1}
+    assert tab._freq_core_lock is None
+
+    press_space(tab)
+    assert app.native.calls[-2:] == [
+        ("reset_vfp_lock", "GPU0"),
+        ("set_vfp_frequency_lock", "GPU0", "core", 1500000, 1500000),
+    ]
+    assert tab._locked_points == set()
+    assert tab._freq_core_lock == (1500, 1500)
+    assert tab._freq_core_lock_backend == "nvapi"
+
+    press_space(tab)
+    assert app.native.calls[-1] == ("reset_vfp_frequency_lock", "GPU0", "core")
+    assert tab._freq_core_lock is None
+    assert tab._freq_core_lock_backend is None
+
+
+def test_space_nvml_single_cycles_freq_unlock_without_voltage_lock() -> None:
+    tab, app = make_tab("NVML")
+
+    press_space(tab)
+    assert app.native.calls == [
+        ("set_locked_clocks", "GPU0", "nvml", "core", 1500, 1500)
+    ]
+    assert tab._locked_points == set()
+    assert tab._freq_core_lock == (1500, 1500)
+    assert tab._freq_core_lock_backend == "nvml"
+
+    press_space(tab)
+    assert app.native.calls[-1] == ("reset_core_clocks", "GPU0", "nvml")
+    assert not any(call[0] == "set_vfp_voltage_lock" for call in app.native.calls)
+    assert tab._freq_core_lock is None
+    assert tab._freq_core_lock_backend is None
+
+
+def test_space_nvapi_range_cycles_freq_range_unlock() -> None:
+    tab, app = make_tab("NVAPI", start=1, end=3)
+
+    press_space(tab)
+    assert app.native.calls == [
+        ("set_vfp_frequency_lock", "GPU0", "core", 1700000, 1500000)
+    ]
+    assert tab._freq_core_lock == (1500, 1700)
+    assert tab._freq_core_lock_backend == "nvapi"
+
+    press_space(tab)
+    assert app.native.calls[-1] == ("reset_vfp_frequency_lock", "GPU0", "core")
+    assert tab._freq_core_lock is None
+
+
+def test_space_nvml_range_cycles_freq_range_unlock() -> None:
+    tab, app = make_tab("NVML", start=1, end=3)
+
+    press_space(tab)
+    assert app.native.calls == [
+        ("set_locked_clocks", "GPU0", "nvml", "core", 1500, 1700)
+    ]
+    assert tab._freq_core_lock == (1500, 1700)
+    assert tab._freq_core_lock_backend == "nvml"
+
+    press_space(tab)
+    assert app.native.calls[-1] == ("reset_core_clocks", "GPU0", "nvml")
+    assert tab._freq_core_lock is None
+
+
+def test_space_reset_uses_lock_backend_after_selector_change() -> None:
+    tab, app = make_tab("NVML")
+
+    press_space(tab)
+    tab.freq_lock_api_var.set("NVAPI")
+    press_space(tab)
+
+    assert app.native.calls[-1] == ("reset_core_clocks", "GPU0", "nvml")
+    assert not any(
+        call == ("reset_vfp_frequency_lock", "GPU0", "core")
+        for call in app.native.calls
+    )
+
+
+def test_load_csv_preserves_selection_for_space_round_robin_refresh(tmp_path) -> None:
+    tab, _app = make_tab("NVAPI", start=1, end=1)
+    csv_path = tmp_path / "curve.csv"
+    csv_path.write_text(
+        "\n".join([
+            "voltage,frequency,delta,default_frequency",
+            "800000,1400000,0,1400000",
+            "900000,1500000,0,1500000",
+            "1000000,1600000,0,1600000",
+        ]),
+        encoding="utf-8",
+    )
+
+    tab._load_csv(str(csv_path))
+
+    assert tab._sel_start == 1
+    assert tab._sel_end == 1
+    assert tab.adj_start_var.get() == "1"
+    assert tab.adj_end_var.get() == "1"


### PR DESCRIPTION
## Why

After the previous merge landed on `scanner-refactor` (`fc1b314`), `main` picked up one more commit — `805cf0e fix(gui): Restore old space behaviour (#191)` — that wasn't yet in `scanner-refactor`. This PR closes that drift.

## What

Conflict-free merge of `origin/main` into `scanner-refactor`. Brings in only #191:

- `gui/src/tabs/vfcurve.py` — restore old space-key behaviour
- `gui/tests/test_vfcurve_space_lock.py` — accompanying test (new file)

No conflicts; nothing else changed vs `scanner-refactor`.

## Verification

- `py_compile` on both changed files ✅
- `ruff check` ✅
- `ruff format --check` ✅ (already formatted)

(GUI pytest not run here — PyPI access is blocked by the container network policy — but CI will run it. The changed files are main's #191 verbatim.)

https://claude.ai/code/session_01MBTHwFRrPZKG8Sg1C6f3Fo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBTHwFRrPZKG8Sg1C6f3Fo)_