### PR TITLE
test(cuda-stressor): Add multi-GPU concurrent stress reference test

### DIFF
--- a/cli-stressor-cuda-rs/test/README.md
+++ b/cli-stressor-cuda-rs/test/README.md
@@ -1,0 +1,68 @@
+# cli-stressor-cuda-rs — multi-GPU reference test
+
+A manual hardware test that verifies the CUDA stressor runs **correctly and
+without per-card throughput loss when one instance is run per GPU concurrently**
+(the way an autoscan fleet exercises many cards), and records reference
+throughput / CPU / power numbers.
+
+This is **not** a CI unit test — it needs real NVIDIA GPUs and a CUDA-feature
+build of the stressor.
+
+## What it checks
+
+`multi_gpu_stress.ps1` runs a single-card baseline on the first selected GPU,
+then runs every selected GPU concurrently (one stressor process pinned per card
+via `--gpu-index`), and reports per-card TFLOPS, validation failures, CPU load
+and total GPU power.
+
+**PASS criteria** (script exits non-zero otherwise):
+1. every instance exits `0` with `val_fail == 0` (no silent corruption), and
+2. concurrent per-card throughput stays ≥ `-MinConcurrentRatio` of the solo
+   baseline (default `0.85`) — i.e. the parallel host-side input generation does
+   not oversubscribe the CPU and starve concurrent instances.
+
+## Prerequisites
+
+1. Build with the CUDA feature:
+   ```
+   cargo build --release -p cli-stressor-cuda-rs --features cuda
+   ```
+2. Make the CUDA 12.x runtime DLLs discoverable (next to the exe, on `PATH`, or
+   via `-DllDir`): `nvrtc64_120_0.dll`, `nvrtc-builtins64_129.dll`,
+   `cublas64_12.dll`, `cublasLt64_12.dll`, `cudart64_12.dll`.
+
+## Usage
+
+```powershell
+# all detected cards, default config
+pwsh ./multi_gpu_stress.ps1
+
+# specific cards, longer run, explicit DLL dir
+pwsh ./multi_gpu_stress.ps1 -Gpus 0,1,2,3 -Duration 60 -DllDir ..\..\cuda-runtime
+```
+
+Key knobs: `-Gpus`, `-Duration`, `-Precisions`, `-MatrixSizes`, `-StreamMode`,
+`-BurstIters`, `-ValidateInterval`, `-MinConcurrentRatio`.
+
+## Reference results
+
+Measured on an 8-GPU host (6× GTX 1080 + 2× GTX 1080 Ti, Pascal SM 6.1, 64-core
+Xeon), config `fp32 / matrix 4096 / single-stream / burst 16`:
+
+| Scenario | Per-card TFLOPS | val_fail | CPU load | Notes |
+|---|---|---|---|---|
+| 1 card (GTX 1080, solo) | 8.49 | 0 | — | baseline |
+| 4 cards concurrent | GPU0 8.40 (**99% of solo**); 1080 Ti ≈ 11.3 | 0 (all) | 28% | total ≈ 39.5 TFLOPS |
+| 8 cards concurrent | 1080 ≈ 8.3–8.6, 1080 Ti ≈ 11.2–11.3 | 0 (all) | 35% | total ≈ 72.3 TFLOPS, ≈ 512 W |
+
+Takeaways used as the standard reference:
+- **No oversubscription:** concurrent per-card throughput holds at ~99% of solo
+  through 8 cards; CPU stays ≤ ~35% of 64 cores.
+- **Correctness:** every instance validates clean (`val_fail=0`) at 1/4/8 cards.
+- Power figures are single 1 Hz `nvidia-smi` snapshots (per-card util bounces by
+  sample timing) — indicative, not a precise sustained number. The pass gate is
+  correctness + no throughput collapse, not an absolute wattage.
+
+> cuBLAS GEMM on Pascal tops out ~50–60% TDP per card regardless of config — see
+> the main crate README and issue #142 for the headless-Vulkan / power-virus
+> direction if you need near-TDP per-card draw.

--- a/cli-stressor-cuda-rs/test/multi_gpu_stress.ps1
+++ b/cli-stressor-cuda-rs/test/multi_gpu_stress.ps1
@@ -1,0 +1,191 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Multi-GPU correctness + throughput/power reference test for cli-stressor-cuda-rs.
+
+.DESCRIPTION
+    Runs a single-card baseline on the first selected GPU, then runs every
+    selected GPU concurrently (one stressor process pinned per card), and
+    reports:
+      * per-card TFLOPS, validation failures, and process exit code
+      * concurrent-vs-solo per-card throughput (a CPU-oversubscription check:
+        the parallel host-side input generation must not starve concurrent
+        instances)
+      * peak CPU load and total GPU power drawn during the concurrent run
+
+    PASS criteria (the script exits non-zero if any fail):
+      1. every instance exits 0 with val_fail == 0 (no silent corruption), and
+      2. concurrent per-card throughput stays at or above -MinConcurrentRatio
+         of the solo baseline (default 0.85), i.e. no oversubscription collapse.
+
+    This is a manual hardware reference test, not a CI unit test: it needs real
+    NVIDIA GPUs and a CUDA-feature build of the stressor.
+
+.PARAMETER Exe
+    Path to cli-stressor-cuda-rs(.exe). Defaults to the release build next to
+    this repo (target/release/cli-stressor-cuda-rs[.exe]).
+
+.PARAMETER Gpus
+    GPU indices (PCI-bus-sorted, as shown by `--list-gpus`) to test.
+    Defaults to every CUDA device the binary enumerates.
+
+.PARAMETER DllDir
+    Optional directory prepended to PATH so the CUDA 12.x runtime DLLs
+    (nvrtc64_120_0 / cublas64_12 / cublasLt64_12 / cudart64_12) are found.
+    Not needed if those DLLs already sit next to the exe or on PATH.
+
+.PARAMETER Duration
+    Per-run stress duration in seconds (default 30).
+
+.EXAMPLE
+    pwsh ./multi_gpu_stress.ps1                         # all cards, defaults
+    pwsh ./multi_gpu_stress.ps1 -Gpus 0,1,2,3 -Duration 60
+    pwsh ./multi_gpu_stress.ps1 -DllDir ..\..\cuda-runtime
+#>
+[CmdletBinding()]
+param(
+    [string]$Exe,
+    [int[]]$Gpus,
+    [string]$DllDir,
+    [double]$Duration = 30,
+    [string]$Precisions = 'fp32',
+    [string]$MatrixSizes = '4096',
+    [int]$BurstIters = 16,
+    [string]$StreamMode = 'single',
+    [double]$ValidateInterval = 6,
+    [double]$MinConcurrentRatio = 0.85
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- resolve the stressor binary -------------------------------------------
+if (-not $Exe) {
+    $root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)  # repo root
+    $cand = @(
+        (Join-Path $root 'target/release/cli-stressor-cuda-rs.exe'),
+        (Join-Path $root 'target/release/cli-stressor-cuda-rs')
+    )
+    $Exe = $cand | Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+if (-not $Exe -or -not (Test-Path $Exe)) {
+    throw "stressor binary not found. Build it first: cargo build --release -p cli-stressor-cuda-rs --features cuda  (or pass -Exe)"
+}
+if ($DllDir) { $env:PATH = "$DllDir;$env:PATH" }
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("nvoc-mgpu-" + [System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force $work | Out-Null
+
+$commonArgs = @(
+    '--duration', "$Duration",
+    '--precisions', $Precisions,
+    '--matrix-sizes', $MatrixSizes,
+    '--stream-mode', $StreamMode,
+    '--burst-iters', "$BurstIters",
+    '--minor-mixture-rate', '0',
+    '--kernel-types', 'gemm',
+    '--validate-interval', "$ValidateInterval"
+)
+
+function Get-Metric([string]$log, [string]$pattern) {
+    $m = Select-String -Path $log -Pattern $pattern | Select-Object -First 1
+    if ($m) { $m.Matches[0].Groups[1].Value } else { $null }
+}
+function Get-Tflops([string]$log) { $v = Get-Metric $log '([\d.]+)\s+TFLOPS'; if ($v) { [double]$v } else { 0 } }
+function Get-ValFail([string]$log) { $v = Get-Metric $log 'val_fail=\s*(\d+)'; if ($null -ne $v) { [int]$v } else { -1 } }
+
+function Invoke-Stressor([int]$gpu) {
+    $out = Join-Path $work "gpu$gpu.out"
+    $err = Join-Path $work "gpu$gpu.err"
+    Start-Process -FilePath $Exe -PassThru -WindowStyle Hidden `
+        -RedirectStandardOutput $out -RedirectStandardError $err `
+        -ArgumentList (@('--gpu-index', "$gpu") + $commonArgs)
+}
+
+# --- discover GPUs ----------------------------------------------------------
+if (-not $Gpus -or $Gpus.Count -eq 0) {
+    $list = & $Exe --list-gpus 2>&1
+    $Gpus = $list | ForEach-Object {
+        if ($_ -match '^\s*(\d+)\s+\d+\s+\d{4}:') { [int]$Matches[1] }
+    } | Sort-Object -Unique
+    if (-not $Gpus) { throw "could not enumerate GPUs from --list-gpus output" }
+}
+Write-Host ("Stressor : {0}" -f $Exe)
+Write-Host ("GPUs     : {0}" -f ($Gpus -join ', '))
+Write-Host ("Config   : --precisions {0} --matrix-sizes {1} --stream-mode {2} --burst-iters {3} --duration {4}s" -f $Precisions, $MatrixSizes, $StreamMode, $BurstIters, $Duration)
+Write-Host ""
+
+# --- phase 1: solo baseline on the first GPU --------------------------------
+$first = $Gpus[0]
+Write-Host "== Phase 1: solo baseline on GPU $first =="
+$p = Invoke-Stressor $first
+$p.WaitForExit()
+$soloLog = Join-Path $work "gpu$first.out"
+$soloTf = Get-Tflops $soloLog
+$soloVf = Get-ValFail $soloLog
+Write-Host ("  GPU{0}: {1} TFLOPS  val_fail={2}  exit={3}" -f $first, $soloTf, $soloVf, $p.ExitCode)
+Write-Host ""
+
+# --- phase 2: all selected GPUs concurrently --------------------------------
+Write-Host ("== Phase 2: {0} card(s) concurrent ==" -f $Gpus.Count)
+$procs = @{}
+foreach ($g in $Gpus) { $procs[$g] = Invoke-Stressor $g }
+
+# sample CPU + GPU power roughly mid-run
+Start-Sleep -Seconds ([Math]::Max(6, [int]($Duration / 2)))
+$totalPower = 0.0
+try {
+    $smi = nvidia-smi --query-gpu=index,power.draw --format=csv,noheader,nounits 2>$null
+    foreach ($line in ($smi -split "`n")) {
+        if ($line -match '^\s*(\d+)\s*,\s*([\d.]+)') {
+            if ([int]$Matches[1] -in $Gpus) { $totalPower += [double]$Matches[2] }
+        }
+    }
+} catch { $totalPower = $null }
+$cpu = $null
+try { $cpu = (Get-CimInstance Win32_Processor | Measure-Object -Property LoadPercentage -Average).Average } catch {}
+
+foreach ($g in $Gpus) { $procs[$g].WaitForExit() }
+
+# --- collect + verdict ------------------------------------------------------
+Write-Host ""
+Write-Host "Per-card results (concurrent):"
+$rows = @()
+$allCorrect = $true
+$noCollapse = $true
+$totalTf = 0.0
+foreach ($g in $Gpus) {
+    $log = Join-Path $work "gpu$g.out"
+    $tf = Get-Tflops $log
+    $vf = Get-ValFail $log
+    $ec = $procs[$g].ExitCode
+    $totalTf += $tf
+    if ($ec -ne 0 -or $vf -ne 0) { $allCorrect = $false }
+    Write-Host ("  GPU{0}: {1,7} TFLOPS  val_fail={2}  exit={3}" -f $g, $tf, $vf, $ec)
+    $rows += [pscustomobject]@{ Gpu = $g; Tflops = $tf; ValFail = $vf; Exit = $ec }
+}
+
+# The first GPU ran both phases; $soloTf was captured before the concurrent
+# run overwrote its log, so compare the captured solo value to its concurrent
+# throughput (from $rows) to detect oversubscription.
+$firstConcurrent = ($rows | Where-Object { $_.Gpu -eq $first }).Tflops
+$ratio = if ($soloTf -gt 0) { [math]::Round($firstConcurrent / $soloTf, 3) } else { 0 }
+if ($soloTf -gt 0 -and $ratio -lt $MinConcurrentRatio) { $noCollapse = $false }
+
+Write-Host ""
+Write-Host "Summary:"
+Write-Host ("  total throughput   : {0} TFLOPS across {1} card(s)" -f [math]::Round($totalTf, 1), $Gpus.Count)
+Write-Host ("  GPU{0} solo->concurrent: {1} -> {2} TFLOPS ({3}%)" -f $first, $soloTf, $firstConcurrent, [math]::Round($ratio * 100))
+if ($null -ne $cpu) { Write-Host ("  CPU load (mid-run) : {0}%" -f $cpu) }
+if ($null -ne $totalPower) { Write-Host ("  total GPU power     : {0} W (single mid-run sample)" -f [math]::Round($totalPower)) }
+
+Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+
+Write-Host ""
+if ($allCorrect -and $noCollapse) {
+    Write-Host "RESULT: PASS (all instances val_fail=0/exit=0; no throughput collapse)" -ForegroundColor Green
+    exit 0
+} else {
+    if (-not $allCorrect) { Write-Host "RESULT: FAIL - an instance reported val_fail!=0 or a non-zero exit." -ForegroundColor Red }
+    if (-not $noCollapse) { Write-Host ("RESULT: FAIL - concurrent throughput {0}% < {1}% of solo (possible CPU oversubscription)." -f [math]::Round($ratio * 100), [math]::Round($MinConcurrentRatio * 100)) -ForegroundColor Red }
+    exit 1
+}


### PR DESCRIPTION
## What

Adds a committed, parametrized **multi-GPU reference test** for the CUDA stressor under `cli-stressor-cuda-rs/test/`:

- `multi_gpu_stress.ps1` — runs a single-card baseline, then one stressor process **per GPU concurrently** (`--gpu-index` pinned), and reports per-card TFLOPS, validation failures, CPU load, and total GPU power.
- `README.md` — purpose, usage, and the **standard reference baselines**.

**PASS criteria** (script exits non-zero otherwise):
1. every instance exits `0` with `val_fail == 0` (no silent corruption), and
2. concurrent per-card throughput >= 85% of the solo baseline — a CPU-oversubscription check on the parallel host-side input generation added in #214.

## Why

#214 parallelized host input generation (one rayon pool per process). This test pins that down as a standing reference: it confirms running N stressors at once (the autoscan fleet pattern) stays correct and does not starve any card. It is a manual hardware test (needs real GPUs + a `--features cuda` build), not CI.

## Reference results (measured)

8-GPU host (6x GTX 1080 + 2x GTX 1080 Ti, 64-core Xeon), config `fp32 / matrix 4096 / single-stream / burst 16`:

| Scenario | Per-card | val_fail | CPU |
|---|---|---|---|
| 1 card solo | 8.49 TFLOPS | 0 | - |
| 4 cards concurrent | GPU0 8.40 (99% of solo) | 0 | 28% |
| 8 cards concurrent | 1080 ~8.3-8.6 / Ti ~11.2-11.3 (~72.3 total) | 0 | 35% |

No per-card degradation through 8 cards; CPU oversubscription empirically ruled out. Harness self-verified on 2 cards (PASS, exit 0).

Draft for review.

[Generated with Claude Code]
