### PR TITLE
Add release roadmap, sprint issue triage tools, and release-management CI

### DIFF
--- a/.github/RELEASE_GUARD.md
+++ b/.github/RELEASE_GUARD.md
@@ -1,0 +1,17 @@
+# Release and tag guard
+
+The `Release and tag guard` workflow runs for `v*` tag pushes and release events. It enforces two rules:
+
+1. Release/tag names must be SemVer-like and start with `v`, for example `v0.1.0-alpha.1` or `v1.0.0`.
+2. The resolved release/tag target commit must be reachable from `origin/sprint`.
+
+## Required repository ruleset
+
+Configure a GitHub repository ruleset for protected tags before relying on release tags:
+
+- Target: tags matching `v*`.
+- Require status checks to pass.
+- Required check: `Require release targets from sprint` from the `Release and tag guard` workflow.
+- Restrict bypass permissions to maintainers who are responsible for release recovery.
+
+Without the repository ruleset, the workflow can report a failing status but cannot by itself prevent a tag or release from being created.

--- a/.github/SPRINT_ISSUE_TRIAGE.md
+++ b/.github/SPRINT_ISSUE_TRIAGE.md
@@ -1,0 +1,60 @@
+# Sprint issue triage plan
+
+This plan is based on the open GitHub issues visible on 2026-06-18. It assigns sprint labels that maintainers can apply directly with `tools/sprint_issue_triage.py`.
+
+## Label set
+
+| Label | Purpose |
+|---|---|
+| `sprint:0-release-gate` | Release governance, release blocking safety, and tag policy work. |
+| `sprint:1-alpha` | Alpha hardening, critical bug fixes, and compatibility decisions. |
+| `sprint:2-beta` | Beta stabilization, UX polish, packaging, and refactor follow-up. |
+| `sprint:3-rc` | Stable release-candidate cleanup and release-note finalization. |
+| `sprint:4-post-stable` | Post-stable expansion and non-blocking roadmap items. |
+| `priority:P0` | Blocks any public pre-release or safe release process. |
+| `priority:P1` | Blocks alpha quality or core release confidence. |
+| `priority:P2` | Blocks beta/stable polish but not an alpha preview. |
+| `priority:P3` | Non-blocking product exploration or future expansion. |
+
+## Current issue assignments
+
+| Issue | Current title | Sprint labels to add | Why |
+|---|---|---|---|
+| #219 | 我们是不是应该锁release和tag？ | `sprint:0-release-gate`, `priority:P0`, `area:release`, `kind:safety` | Release/tag locking is the immediate release governance blocker. |
+| #190 | 内存泄漏 | `sprint:1-alpha`, `priority:P1`, `area:gui`, `kind:bug` | A memory leak should be triaged before broad alpha use, but does not by itself block release governance setup. |
+| #187 | 竞品分析 | `sprint:4-post-stable`, `priority:P3`, `kind:feature` | Competitive analysis is useful product planning, not a pre-release blocker. |
+| #185 | gui: finish TUI-aligned refactor follow-up | `sprint:2-beta`, `priority:P2`, `area:gui`, `kind:tech-debt` | GUI/TUI alignment matters for beta polish and maintainability. |
+| #180 | NVAPI 和 NVML 支持的功能能做到 1:1 吗 | `sprint:1-alpha`, `priority:P1`, `area:cli`, `kind:compatibility` | Backend parity or explicitly documented non-parity is needed before a credible alpha. |
+| #161 | [Bug]: 极端混合压测下产生虚假 "code #1"不过测，底层 FECS 挂起导致级联降频测试失败 | `sprint:1-alpha`, `priority:P1`, `area:auto-optimizer`, `kind:bug` | False stress failures can invalidate autoscan results and must be bounded before alpha. |
+| #156 | 统一单位、编号 | `sprint:2-beta`, `priority:P2`, `area:cli`, `kind:ux` | Unit and numbering consistency improves beta usability and docs. |
+| #153 | INFOMATION ISSUE: 如何使用 Ajax Codex | `sprint:4-post-stable`, `priority:P3`, `kind:docs` | Informational/process issue; not release blocking. |
+| #146 | 画饼: 同时支持 nova GPU 驱动 | `sprint:4-post-stable`, `priority:P3`, `kind:feature` | New driver support is future expansion, not first-release scope. |
+| #142 | 自动超频压力测试严格化 | `sprint:1-alpha`, `priority:P1`, `area:auto-optimizer`, `kind:safety` | Stricter stress validation directly affects release confidence for autoscan. |
+| #5 | 自动超频扫描架构优化 | `sprint:2-beta`, `priority:P2`, `area:auto-optimizer`, `kind:tech-debt` | Architecture optimization is important but should follow alpha safety triage unless a specific blocker is found. |
+
+## Feature ship decision
+
+| Feature area | Ship in next pre-release? | Rationale |
+|---|---|---|
+| Read-only GPU discovery/status and V-F curve export | Yes, as alpha | Read-only paths are the safest useful entry point and can be validated by normal/GPU CI plus smoke tests. |
+| `nvoc-cli` manual setting writes | Yes, as alpha with warnings | Ship only with explicit backend/platform support notes and recovery instructions. |
+| Auto optimizer autoscan | Yes, as experimental alpha | Useful core workflow, but release notes must call out stress false-positive risk and hardware validation limits. |
+| CUDA Rust stressor | Yes, as alpha | Ship with CUDA toolkit/artifact compatibility notes and short stress smoke coverage. |
+| OpenCL stressor | Yes, as alpha fallback | Ship as a fallback path while marking Linux OpenCL GPU CI as not yet complete. |
+| GUI and TUI | Yes, as alpha frontends | Frontends can ship as alpha if they clearly depend on external CLI binaries and packaged smoke checks are documented. |
+| Windows service / localhost control | No stable ship; optional experimental artifact only | Service lifecycle and security review should be completed before beta/stable claims. |
+| NVML autoscan parity and nova driver support | No | These are roadmap/compatibility items and should not be advertised as shipped capability yet. |
+
+## Maintainer action
+
+Run the triage tool in dry-run mode first:
+
+```bash
+python3 tools/sprint_issue_triage.py --repo Skyworks-Neo/nvoc
+```
+
+After confirming the output, apply labels with a token that can edit issues:
+
+```bash
+GITHUB_TOKEN=<token> python3 tools/sprint_issue_triage.py --repo Skyworks-Neo/nvoc --apply
+```

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - ".github/SPRINT_ISSUE_TRIAGE.md"
+      - ".github/RELEASE_GUARD.md"
       - ".github/workflows/release-management.yml"
+      - ".github/workflows/release-tag-guard.yml"
       - "docs/wiki/Home.md"
       - "docs/wiki/Home-zh.md"
       - "docs/wiki/Release-Roadmap.md"
@@ -14,7 +16,9 @@ on:
     branches: [main]
     paths:
       - ".github/SPRINT_ISSUE_TRIAGE.md"
+      - ".github/RELEASE_GUARD.md"
       - ".github/workflows/release-management.yml"
+      - ".github/workflows/release-tag-guard.yml"
       - "docs/wiki/Home.md"
       - "docs/wiki/Home-zh.md"
       - "docs/wiki/Release-Roadmap.md"

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -1,0 +1,42 @@
+name: Release management docs
+
+on:
+  pull_request:
+    paths:
+      - ".github/SPRINT_ISSUE_TRIAGE.md"
+      - ".github/workflows/release-management.yml"
+      - "docs/wiki/Home.md"
+      - "docs/wiki/Home-zh.md"
+      - "docs/wiki/Release-Roadmap.md"
+      - "tools/sprint_issue_triage.py"
+      - "tools/validate_release_management.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/SPRINT_ISSUE_TRIAGE.md"
+      - ".github/workflows/release-management.yml"
+      - "docs/wiki/Home.md"
+      - "docs/wiki/Home-zh.md"
+      - "docs/wiki/Release-Roadmap.md"
+      - "tools/sprint_issue_triage.py"
+      - "tools/validate_release_management.py"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release management docs
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Compile triage tools
+        run: python -m py_compile tools/sprint_issue_triage.py tools/validate_release_management.py
+      - name: Validate roadmap and sprint issue triage consistency
+        run: python tools/validate_release_management.py
+      - name: Check triage dry-run
+        run: python tools/sprint_issue_triage.py --repo Skyworks-Neo/nvoc

--- a/.github/workflows/release-tag-guard.yml
+++ b/.github/workflows/release-tag-guard.yml
@@ -1,0 +1,72 @@
+name: Release and tag guard
+
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types: [created, edited, prereleased, published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-tag-guard-${{ github.ref }}-${{ github.event.release.tag_name || '' }}
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Require release targets from sprint
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Validate tag/release target
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name || '' }}
+          RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish || '' }}
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin sprint:refs/remotes/origin/sprint
+          git fetch --tags --force origin 'refs/tags/v*:refs/tags/v*'
+
+          if [[ "${EVENT_NAME}" == "release" ]]; then
+            tag_name="${RELEASE_TAG_NAME}"
+            target_ref="${RELEASE_TAG_NAME}"
+            if [[ -n "${RELEASE_TARGET_COMMITISH}" ]]; then
+              target_ref="${RELEASE_TARGET_COMMITISH}"
+            fi
+          else
+            tag_name="${REF_NAME}"
+            target_ref="${REF_NAME}"
+          fi
+
+          if [[ ! "${tag_name}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release/tag name must be SemVer-like and start with v: ${tag_name}" >&2
+            exit 1
+          fi
+
+          target_commit=""
+          if git rev-parse --verify --quiet "refs/tags/${tag_name}^{commit}" >/dev/null; then
+            target_commit="$(git rev-parse "refs/tags/${tag_name}^{commit}")"
+          elif git rev-parse --verify --quiet "${target_ref}^{commit}" >/dev/null; then
+            target_commit="$(git rev-parse "${target_ref}^{commit}")"
+          else
+            echo "Could not resolve release/tag target: ${target_ref}" >&2
+            exit 1
+          fi
+
+          sprint_commit="$(git rev-parse refs/remotes/origin/sprint)"
+          echo "tag_name=${tag_name}"
+          echo "target_commit=${target_commit}"
+          echo "sprint_commit=${sprint_commit}"
+
+          if ! git merge-base --is-ancestor "${target_commit}" refs/remotes/origin/sprint; then
+            echo "Release/tag target ${target_commit} is not reachable from origin/sprint" >&2
+            exit 1
+          fi

--- a/docs/wiki/Home-zh.md
+++ b/docs/wiki/Home-zh.md
@@ -16,6 +16,7 @@ NVOC 是一个围绕 NVIDIA GPU 超频与稳定性验证的 Rust/Python monorepo
 - [兼容性矩阵](./Compatibility-Matrix.md)
 - [安全与恢复](./Safety-and-Recovery.md)
 - [贡献指南](./Contributing.md)
+- [发布路线图](./Release-Roadmap.md)
 - [FAQ](./FAQ.md)
 
 ---

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -19,6 +19,7 @@ This wiki is split by component responsibilities, architecture, build/test comma
 - [Compatibility Matrix](./Compatibility-Matrix.md)
 - [Safety and Recovery](./Safety-and-Recovery.md)
 - [Contributing](./Contributing.md)
+- [Release Roadmap](./Release-Roadmap.md)
 - [FAQ](./FAQ.md)
 - [中文首页](./Home-zh.md)
 

--- a/docs/wiki/Release-Roadmap.md
+++ b/docs/wiki/Release-Roadmap.md
@@ -1,0 +1,171 @@
+# Release Roadmap
+
+This page turns the current repository state into manageable sprints and a release decision checklist. It is intentionally conservative because NVOC can write overclocking, voltage, clock, power, thermal, and fan settings to real GPUs.
+
+See also: [Sprint issue triage plan](../../.github/SPRINT_ISSUE_TRIAGE.md) for the current issue-to-sprint label mapping and the tool that applies it.
+
+## Release decision as of 2026-06-18
+
+**Decision: do not cut a stable `v1.0.0` tag from the current development state yet.** The project has enough implemented functionality for an internal or community preview, but a stable release should wait until hardware-backed safety, packaging, and known compatibility gaps are closed.
+
+Recommended tag policy:
+
+- **Allowed now:** an explicitly unstable pre-release tag such as `v0.1.0-alpha.1` or `v0.1.0-rc.0`, only from `sprint`, after the release/tag guard is enabled in repository rules.
+- **Not recommended now:** a stable SemVer tag such as `v1.0.0`, because GPU-mutating coverage, platform packaging, and support-matrix unknowns still need sprint ownership.
+- **Required before any public release:** green normal CI, a labeled/manual GPU CI run on known recoverable hardware, release notes that call out unsupported GPU generations/backends, and a tested rollback/recovery path.
+
+## Current achieved features
+
+| Area | Achieved capability | Release value | Remaining release risk |
+|---|---|---|---|
+| Core backend | Shared Rust library for NVAPI/NVML domains and CLI consumers. | Gives the repo a common implementation surface instead of duplicating backend calls. | Hardware-specific behavior still varies by GPU generation, driver, and OS. |
+| NVOC-CLI | Function-style commands for discovery, status, V-F curve reads, offsets, limits, fan controls, clock locks, voltage locks, and backend selection. | Provides the lowest-friction automation and debugging interface. | Some support-matrix rows remain TODO/unknown, especially NVML autoscan paths and server/workstation edge cases. |
+| Auto optimizer | Autoscan, V-F curve export/import, result fixing, retained VFP reset workflows, legacy workflows, crash recovery, breakpoint resumption, and CUDA/OpenCL stress integration. | Main user-facing tuning workflow is present. | Needs final release-gate validation across supported GPU families and backends. |
+| CUDA Rust stressor | CUDA stress workloads with build-time CUDA features and short GPU CI coverage. | Recommended native stress path for CUDA-capable systems. | Release packaging needs CUDA 12.x/13.x split or equivalent compatibility guidance. |
+| OpenCL stressor | Lightweight Python/OpenCL stress path. | Broad fallback for systems without CUDA setup. | Linux OpenCL GPU CI is not currently active. |
+| GUI | Python desktop frontend for dashboard, autoscan, overclocking, V-F curve, fan, and console workflows. | Makes the tool approachable for interactive Windows/Linux users. | Requires packaging validation and dependency/install smoke tests. |
+| TUI | Textual frontend for dashboard, autoscan, overclock, V-F curve, and console workflows. | Supports SSH/server use where GUI is unavailable. | Depends on external CLI availability and tolerant parsing; packaging should be verified. |
+| Service | Windows service and localhost HTTP control layer. | Enables managed or long-running host control. | Needs service-install, stop, recovery, and security review before stable release. |
+| CI | Normal CI covers formatting, linting, Rust/Python tests, component-specific jobs, and a gated GPU CI workflow. | Gives a practical pre-release signal. | GPU CI is intentionally opt-in and read-only for dangerous paths, so manual bench validation remains mandatory. |
+| Release governance | Release/tag guard workflow and documented protected-tag ruleset. | Prevents accidental releases away from `sprint`. | Repository rules must be configured in GitHub before relying on this policy. |
+
+## Current bugs, gaps, and risks to sprint-plan
+
+| Priority | Type | Item | Why it matters | Suggested owner area | Target sprint |
+|---|---|---|---|---|---|
+| P0 | Release governance | Configure GitHub repository rulesets so protected `v*` tags require the release/tag guard status check. | The workflow alone cannot prevent unauthorized tags unless GitHub rules enforce it. | CI / Maintainers | Sprint 0 |
+| P0 | Safety | Run full release-gate validation on a recoverable GPU bench, including read-only GPU CI and human-supervised mutating smoke tests. | Normal CI cannot prove write-path safety for overclocking operations. | Core / Auto optimizer | Sprint 0 |
+| P0 | Safety | Publish an operator recovery checklist covering driver reset, TDR/reboot behavior, retained VFP reset, and how to undo applied settings. | Users need a visible escape path before trying risky writes. | Docs / Auto optimizer | Sprint 0 |
+| P1 | Packaging | Define release artifacts for Windows and Linux, including which binaries are shipped together. | Users need predictable installs for CLI, auto-optimizer, stressors, GUI, TUI, and service. | Build / Release | Sprint 1 |
+| P1 | Compatibility | Resolve or explicitly document TODO rows for NVML autoscan and legacy autoscan support. | A release should not imply unsupported backend combinations are ready. | CLI / Auto optimizer | Sprint 1 |
+| P1 | Compatibility | Decide CUDA 12.x vs CUDA 13.x artifact strategy for legacy and newer GPU coverage. | A single CUDA build may exclude users depending on architecture and toolkit support. | CUDA stressor / Release | Sprint 1 |
+| P1 | Testing | Add or document Linux OpenCL GPU validation, or mark it out of scope for the first release. | OpenCL is the broad fallback path; missing Linux validation should be explicit. | OpenCL stressor / CI | Sprint 1 |
+| P2 | UX | Add release-oriented GUI/TUI smoke scripts or checklists for packaged builds. | Frontends can fail from packaging/resource issues even when unit tests pass. | GUI / TUI | Sprint 2 |
+| P2 | Service | Complete service security and lifecycle review: install, stop, access binding, failure recovery, and logs. | A local HTTP/service surface should have a clear threat model before stable release. | SRV | Sprint 2 |
+| P2 | Documentation | Keep `README.md`, `docs/wiki`, component READMEs, and compatibility tables synchronized before tagging. | Conflicting docs create unsafe assumptions for users. | Docs | Sprint 2 |
+| P3 | Product | Define post-release telemetry-free feedback templates for hardware matrix reports. | Hardware projects need structured user reports without collecting private data. | Maintainers | Sprint 3 |
+
+## Sprint roadmap
+
+### Sprint 0 — Release gate and triage freeze
+
+**Goal:** decide whether the current branch may receive an alpha/pre-release tag and prevent accidental stable releases.
+
+**Scope:**
+
+- Enable repository rules for protected `v*` tags and require the release/tag guard check.
+- Freeze feature intake except fixes to release blockers.
+- Run normal CI and GPU CI on the exact candidate commit from `sprint`.
+- Execute a manual bench checklist for mutating paths on known recoverable hardware:
+  - read GPU information and status;
+  - export V-F curve;
+  - apply and reset safe small core/memory offsets;
+  - apply and reset safe power/fan settings where supported;
+  - run a short stress validation;
+  - verify retained settings can be reset.
+- Produce release notes that clearly label alpha limitations.
+
+**Exit criteria:**
+
+- `sprint` is the only permitted release source.
+- No P0 safety or governance blockers remain.
+- Maintainers choose one of:
+  - tag `v0.1.0-alpha.1`; or
+  - defer tagging and continue to Sprint 1.
+
+### Sprint 1 — Alpha hardening and packaging
+
+**Goal:** turn the current development state into a repeatable alpha release that users can install and test safely.
+
+**Scope:**
+
+- Define artifact matrix:
+  - `nvoc-cli`;
+  - `nvoc-auto-optimizer`;
+  - CUDA Rust stressor artifacts;
+  - OpenCL stressor package or documented Python environment;
+  - GUI package;
+  - TUI package;
+  - optional Windows service artifact.
+- Decide CUDA artifact compatibility strategy, including whether to publish separate CUDA 12.x and CUDA 13.x builds.
+- Replace unknown/TODO compatibility entries with one of: supported, unsupported, experimental, or untested.
+- Add release smoke checklists for Windows and Linux installs.
+- Document backend assumptions for NVAPI/NVML fallback behavior.
+
+**Exit criteria:**
+
+- A contributor can rebuild release artifacts from documented commands.
+- Unsupported GPU/backend combinations are explicit.
+- Alpha release notes include known limitations and recovery instructions.
+
+### Sprint 2 — Beta stabilization
+
+**Goal:** make behavior predictable enough for a broader beta.
+
+**Scope:**
+
+- Expand hardware matrix validation across at least one recent consumer GPU, one older consumer GPU, and one workstation/server-class GPU if available.
+- Add regression tests around recently fixed bugs, especially autoscan/VFP panic cases, service stop handling, GUI sentinel reset behavior, and CUDA stressor performance paths.
+- Validate GUI/TUI packaged resource loading.
+- Review service security posture and local API binding.
+- Reduce noisy or ambiguous CLI output so GUI/TUI parsers have stable inputs.
+
+**Exit criteria:**
+
+- No known P0/P1 safety issues.
+- Beta artifact install and smoke tests pass on at least Windows plus one Linux environment.
+- Hardware matrix report is published with tested driver versions.
+
+### Sprint 3 — Stable release candidate
+
+**Goal:** prepare a stable SemVer release candidate.
+
+**Scope:**
+
+- Lock release scope and block new features.
+- Run all normal CI, GPU CI, packaging smoke tests, and manual recovery tests on the candidate commit.
+- Audit documentation for stale commands, stale feature claims, and missing warnings.
+- Finalize changelog, checksums, artifact names, and upgrade/rollback notes.
+
+**Exit criteria:**
+
+- Candidate can be tagged `v1.0.0-rc.1` from `sprint`.
+- Stable `v1.0.0` is allowed only after the RC receives no release-blocking regressions during the agreed soak window.
+
+### Sprint 4 — Post-stable follow-up
+
+**Goal:** improve coverage and user confidence after the first stable tag.
+
+**Scope:**
+
+- Backfill lower-priority compatibility gaps.
+- Add issue templates for hardware reports, crash/recovery reports, and backend support requests.
+- Improve automated packaging and release-note generation.
+- Consider expanding GPU CI labels/runners for more hardware classes.
+
+**Exit criteria:**
+
+- Maintainers can plan minor releases from structured feedback rather than ad hoc reports.
+
+## Release checklist
+
+Before any release tag:
+
+- [ ] Candidate commit is on `sprint`.
+- [ ] Release/tag guard workflow exists and repository rules require it for `v*` tags.
+- [ ] Normal CI is green.
+- [ ] GPU CI has run on the candidate commit, or release notes explicitly mark GPU CI as unavailable and explain why.
+- [ ] Manual mutating smoke tests were run on recoverable hardware.
+- [ ] Release notes list supported operating systems, GPU classes, drivers/toolkits, and unsupported features.
+- [ ] Recovery and rollback instructions are linked from the release notes.
+- [ ] Artifacts and checksums are attached or documented.
+- [ ] Stable tags are avoided until alpha/beta/RC exit criteria are met.
+
+## Issue organization labels
+
+Use these labels when turning this roadmap into GitHub issues:
+
+- `sprint:0-release-gate`, `sprint:1-alpha`, `sprint:2-beta`, `sprint:3-rc`, `sprint:4-post-stable`
+- `area:core`, `area:cli`, `area:auto-optimizer`, `area:cuda-stressor`, `area:opencl-stressor`, `area:gui`, `area:tui`, `area:srv`, `area:ci`, `area:docs`, `area:release`
+- `kind:bug`, `kind:feature`, `kind:safety`, `kind:compatibility`, `kind:packaging`, `kind:docs`
+- `priority:P0`, `priority:P1`, `priority:P2`, `priority:P3`

--- a/docs/wiki/Release-Roadmap.md
+++ b/docs/wiki/Release-Roadmap.md
@@ -2,7 +2,7 @@
 
 This page turns the current repository state into manageable sprints and a release decision checklist. It is intentionally conservative because NVOC can write overclocking, voltage, clock, power, thermal, and fan settings to real GPUs.
 
-See also: [Sprint issue triage plan](../../.github/SPRINT_ISSUE_TRIAGE.md) for the current issue-to-sprint label mapping and the tool that applies it.
+See also: [Sprint issue triage plan](../../.github/SPRINT_ISSUE_TRIAGE.md) for the current issue-to-sprint label mapping and the tool that applies it. See [Release and tag guard](../../.github/RELEASE_GUARD.md) for the protected-tag ruleset that must back the guard workflow.
 
 ## Release decision as of 2026-06-18
 

--- a/tools/sprint_issue_triage.py
+++ b/tools/sprint_issue_triage.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Create sprint labels and assign them to known NVOC GitHub issues.
+
+Dry-run is the default. Set GITHUB_TOKEN and pass --apply to modify GitHub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Label:
+    name: str
+    color: str
+    description: str
+
+
+LABELS = [
+    Label(
+        "sprint:0-release-gate",
+        "b60205",
+        "Release governance and release-blocking safety work",
+    ),
+    Label("sprint:1-alpha", "d93f0b", "Alpha hardening and compatibility decisions"),
+    Label(
+        "sprint:2-beta",
+        "fbca04",
+        "Beta stabilization, packaging, UX, and refactor polish",
+    ),
+    Label(
+        "sprint:3-rc",
+        "0e8a16",
+        "Stable release-candidate cleanup and final release notes",
+    ),
+    Label(
+        "sprint:4-post-stable",
+        "1d76db",
+        "Post-stable expansion and non-blocking roadmap work",
+    ),
+    Label(
+        "priority:P0", "b60205", "Blocks any public pre-release or safe release process"
+    ),
+    Label("priority:P1", "d93f0b", "Blocks alpha quality or core release confidence"),
+    Label("priority:P2", "fbca04", "Blocks beta/stable polish but not alpha preview"),
+    Label(
+        "priority:P3", "c5def5", "Non-blocking product exploration or future expansion"
+    ),
+    Label("area:release", "5319e7", "Release process, tags, artifacts, and notes"),
+    Label("area:cli", "5319e7", "nvoc-cli and command-line backend behavior"),
+    Label("area:gui", "5319e7", "Python GUI frontend"),
+    Label("area:auto-optimizer", "5319e7", "Auto optimizer workflows and autoscan"),
+    Label("kind:safety", "b60205", "Safety, recovery, or dangerous-operation controls"),
+    Label("kind:bug", "d73a4a", "Incorrect behavior or regression"),
+    Label("kind:feature", "a2eeef", "New capability or product expansion"),
+    Label(
+        "kind:compatibility",
+        "bfdadc",
+        "Backend, OS, GPU, driver, or toolkit compatibility",
+    ),
+    Label("kind:tech-debt", "cccccc", "Refactor, cleanup, or maintainability work"),
+    Label("kind:ux", "c2e0c6", "User experience, consistency, or usability"),
+    Label("kind:docs", "0075ca", "Documentation or process information"),
+]
+
+ISSUE_LABELS: dict[int, list[str]] = {
+    219: ["sprint:0-release-gate", "priority:P0", "area:release", "kind:safety"],
+    190: ["sprint:1-alpha", "priority:P1", "area:gui", "kind:bug"],
+    187: ["sprint:4-post-stable", "priority:P3", "kind:feature"],
+    185: ["sprint:2-beta", "priority:P2", "area:gui", "kind:tech-debt"],
+    180: ["sprint:1-alpha", "priority:P1", "area:cli", "kind:compatibility"],
+    161: ["sprint:1-alpha", "priority:P1", "area:auto-optimizer", "kind:bug"],
+    156: ["sprint:2-beta", "priority:P2", "area:cli", "kind:ux"],
+    153: ["sprint:4-post-stable", "priority:P3", "kind:docs"],
+    146: ["sprint:4-post-stable", "priority:P3", "kind:feature"],
+    142: ["sprint:1-alpha", "priority:P1", "area:auto-optimizer", "kind:safety"],
+    5: ["sprint:2-beta", "priority:P2", "area:auto-optimizer", "kind:tech-debt"],
+}
+
+
+class GitHubClient:
+    def __init__(self, repo: str, token: str | None) -> None:
+        self.repo = repo
+        self.token = token
+
+    def request(
+        self, method: str, path: str, payload: dict[str, object] | None = None
+    ) -> object:
+        data = None if payload is None else json.dumps(payload).encode()
+        request = urllib.request.Request(
+            f"https://api.github.com/repos/{self.repo}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+                "User-Agent": "nvoc-sprint-issue-triage",
+                **({"Authorization": f"Bearer {self.token}"} if self.token else {}),
+            },
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read()
+        return json.loads(body) if body else {}
+
+    def ensure_label(self, label: Label) -> None:
+        try:
+            self.request(
+                "POST",
+                "/labels",
+                {
+                    "name": label.name,
+                    "color": label.color,
+                    "description": label.description,
+                },
+            )
+            print(f"created label {label.name}")
+        except urllib.error.HTTPError as exc:
+            if exc.code != 422:
+                raise
+            self.request(
+                "PATCH",
+                f"/labels/{urllib.parse.quote(label.name, safe='')}",
+                {
+                    "new_name": label.name,
+                    "color": label.color,
+                    "description": label.description,
+                },
+            )
+            print(f"updated label {label.name}")
+
+    def add_issue_labels(self, issue: int, labels: list[str]) -> None:
+        self.request("POST", f"/issues/{issue}/labels", {"labels": labels})
+        print(f"labeled #{issue}: {', '.join(labels)}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", default="Skyworks-Neo/nvoc", help="GitHub repo in owner/name form"
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Modify GitHub labels and issues"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.environ.get("GITHUB_TOKEN")
+    if args.apply and not token:
+        print("error: --apply requires GITHUB_TOKEN", file=sys.stderr)
+        return 2
+
+    if not args.apply:
+        print("dry run: would create/update labels:")
+        for label in LABELS:
+            print(f"  - {label.name}: {label.description}")
+        print("dry run: would label issues:")
+        for issue, labels in ISSUE_LABELS.items():
+            print(f"  - #{issue}: {', '.join(labels)}")
+        return 0
+
+    client = GitHubClient(args.repo, token)
+    for label in LABELS:
+        client.ensure_label(label)
+    for issue, labels in ISSUE_LABELS.items():
+        client.add_issue_labels(issue, labels)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_release_management.py
+++ b/tools/validate_release_management.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate release-management docs and sprint issue triage metadata."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import sprint_issue_triage as triage
+
+ROOT = Path(__file__).resolve().parents[1]
+TRIAGE_DOC = ROOT / ".github" / "SPRINT_ISSUE_TRIAGE.md"
+ROADMAP_DOC = ROOT / "docs" / "wiki" / "Release-Roadmap.md"
+HOME_DOCS = [ROOT / "docs" / "wiki" / "Home.md", ROOT / "docs" / "wiki" / "Home-zh.md"]
+
+
+class ValidationError(RuntimeError):
+    """Raised when release-management metadata is inconsistent."""
+
+
+def validate_unique_labels() -> None:
+    names = [label.name for label in triage.LABELS]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise ValidationError(f"duplicate labels: {', '.join(duplicates)}")
+
+
+def validate_issue_labels() -> None:
+    known = {label.name for label in triage.LABELS}
+    for issue, labels in triage.ISSUE_LABELS.items():
+        missing = sorted(set(labels) - known)
+        if missing:
+            raise ValidationError(
+                f"#{issue} uses undefined labels: {', '.join(missing)}"
+            )
+        if not any(label.startswith("sprint:") for label in labels):
+            raise ValidationError(f"#{issue} has no sprint label")
+        if not any(label.startswith("priority:") for label in labels):
+            raise ValidationError(f"#{issue} has no priority label")
+
+
+def validate_triage_doc() -> None:
+    text = TRIAGE_DOC.read_text(encoding="utf-8")
+    for label in triage.LABELS:
+        if f"`{label.name}`" not in text:
+            raise ValidationError(f"{TRIAGE_DOC} does not document label {label.name}")
+    for issue, labels in triage.ISSUE_LABELS.items():
+        if f"| #{issue} |" not in text:
+            raise ValidationError(f"{TRIAGE_DOC} does not document issue #{issue}")
+        for label in labels:
+            issue_row = next(
+                line for line in text.splitlines() if line.startswith(f"| #{issue} |")
+            )
+            if f"`{label}`" not in issue_row:
+                raise ValidationError(f"{TRIAGE_DOC} row for #{issue} omits {label}")
+
+
+def validate_local_markdown_links() -> None:
+    for path in [TRIAGE_DOC, ROADMAP_DOC, *HOME_DOCS]:
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(r"\[[^\]]+\]\(([^)]+)\)", text):
+            link = match.group(1)
+            if link.startswith(("http://", "https://", "#", "mailto:")):
+                continue
+            target_path = link.split("#", 1)[0]
+            if not target_path:
+                continue
+            target = (path.parent / target_path).resolve()
+            if not target.exists():
+                raise ValidationError(f"{path}: missing local link target {link}")
+
+
+def main() -> int:
+    try:
+        validate_unique_labels()
+        validate_issue_labels()
+        validate_triage_doc()
+        validate_local_markdown_links()
+    except ValidationError as exc:
+        print(f"release-management validation failed: {exc}", file=sys.stderr)
+        return 1
+    print("release-management validation ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_release_management.py
+++ b/tools/validate_release_management.py
@@ -11,6 +11,7 @@ import sprint_issue_triage as triage
 
 ROOT = Path(__file__).resolve().parents[1]
 TRIAGE_DOC = ROOT / ".github" / "SPRINT_ISSUE_TRIAGE.md"
+RELEASE_GUARD_DOC = ROOT / ".github" / "RELEASE_GUARD.md"
 ROADMAP_DOC = ROOT / "docs" / "wiki" / "Release-Roadmap.md"
 HOME_DOCS = [ROOT / "docs" / "wiki" / "Home.md", ROOT / "docs" / "wiki" / "Home-zh.md"]
 
@@ -57,7 +58,7 @@ def validate_triage_doc() -> None:
 
 
 def validate_local_markdown_links() -> None:
-    for path in [TRIAGE_DOC, ROADMAP_DOC, *HOME_DOCS]:
+    for path in [TRIAGE_DOC, RELEASE_GUARD_DOC, ROADMAP_DOC, *HOME_DOCS]:
         text = path.read_text(encoding="utf-8")
         for match in re.finditer(r"\[[^\]]+\]\(([^)]+)\)", text):
             link = match.group(1)


### PR DESCRIPTION
### Motivation

- Provide a documented release roadmap and a reproducible sprint/labeling plan to govern pre-release tagging and safety work. 
- Add programmatic tooling to apply the sprint labels and to validate release-management docs for consistency. 
- Enforce documentation/triage consistency via CI to reduce accidental or unsafe release/tag operations. 

### Description

- Add `.github/SPRINT_ISSUE_TRIAGE.md` with the sprint label set, current issue assignments, feature ship decisions, and maintainer action instructions. 
- Add `docs/wiki/Release-Roadmap.md` and update `docs/wiki/Home.md` and `docs/wiki/Home-zh.md` to link to the new roadmap page. 
- Add `tools/sprint_issue_triage.py` which defines the `LABELS` set and `ISSUE_LABELS` mapping and can create/update labels and apply them to issues (dry-run by default, `--apply` with `GITHUB_TOKEN` to modify). 
- Add `tools/validate_release_management.py` which validates label uniqueness, issue label usage, triage doc coverage, and local markdown link targets. 
- Add `.github/workflows/release-management.yml` to compile and run the triage/validation tools and perform a triage dry-run on PRs and on pushes to `main`. 

### Testing

- Compiled the triage tools with `python -m py_compile tools/sprint_issue_triage.py tools/validate_release_management.py` and the compilation step is expected to succeed. 
- Ran validation with `python tools/validate_release_management.py` which checks label consistency, documentation coverage, and local links and returned success. 
- Performed a triage dry-run with `python tools/sprint_issue_triage.py --repo Skyworks-Neo/nvoc` which prints the labels and issue assignments without modifying GitHub and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336c490f64832cb228b6d6033bda13)