### PR TITLE
docs: Add release download verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ single source of truth is `[workspace.package].version` in the root
 ### Changed
 
 - CI now runs the `nvoc-auto-optimizer` non-GPU unit test suite.
+- README Quick Start now documents prebuilt release downloads, checksum
+  validation, and GitHub build-provenance verification (#232).
 
 ## [0.1.0] — historical
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ Platform support and feature availability vary by GPU generation and backend. Th
 
 ## Quick Start
 
+### Download a prebuilt release (recommended)
+
+Download the executable for your operating system and architecture from the
+[GitHub Releases page](https://github.com/Skyworks-Neo/nvoc/releases), together with
+`SHA256SUMS`. Artifact names include the component, version, operating system, and
+architecture; for example, choose the `nvoc-auto-optimizer-...-linux-amd64` artifact
+for 64-bit x86 Linux.
+
+Keep the executable and `SHA256SUMS` in the same directory, then verify the downloaded
+artifact on Linux, WSL, or another environment providing GNU `sha256sum`:
+
+```bash
+sha256sum --check --ignore-missing SHA256SUMS
+gh attestation verify <downloaded-artifact> --repo Skyworks-Neo/nvoc
+```
+
+The checksum command must report the downloaded artifact as `OK`, and the GitHub CLI
+command must verify its build-provenance attestation before you run it. Linux
+executables may also need `chmod +x <downloaded-artifact>`.
+
+Windows executables are not currently Authenticode-signed, so a SmartScreen warning is
+expected. NVIDIA driver, CUDA, Vulkan, and OpenCL runtime libraries are not bundled;
+consult the relevant component README for runtime requirements.
+
 ### 1 — Clone the monorepo
 
 ```bash
@@ -371,6 +395,27 @@ NVOC 是一个 NVIDIA GPU 超频与稳定性工具的 monorepo。核心是 Rust 
 不同 GPU 世代与后端支持的功能不同，请以 CLI README 中的兼容性矩阵为准。
 
 ## 快速开始
+
+### 下载预构建版本（推荐）
+
+从 [GitHub Releases 页面](https://github.com/Skyworks-Neo/nvoc/releases)下载与操作系统和
+架构匹配的可执行文件，并同时下载 `SHA256SUMS`。产物名包含组件、版本、操作系统和架构；
+例如，64 位 x86 Linux 应选择 `nvoc-auto-optimizer-...-linux-amd64` 产物。
+
+将可执行文件与 `SHA256SUMS` 放在同一目录，然后在 Linux、WSL 或其他提供 GNU
+`sha256sum` 的环境中验证下载的产物：
+
+```bash
+sha256sum --check --ignore-missing SHA256SUMS
+gh attestation verify <下载的产物> --repo Skyworks-Neo/nvoc
+```
+
+运行产物前，校验和命令必须将下载的产物报告为 `OK`，GitHub CLI 命令必须成功验证其构建
+来源证明。Linux 可执行文件可能还需要执行 `chmod +x <下载的产物>`。
+
+Windows 产物目前没有 Authenticode 签名，因此出现 SmartScreen 警告属于预期行为。
+发布产物不捆绑 NVIDIA 驱动、CUDA、Vulkan 和 OpenCL 运行库；运行要求请查阅对应组件的
+README。
 
 ### 1 — 克隆 monorepo
 


### PR DESCRIPTION
## Summary

- add a recommended prebuilt-release path to the English and Chinese Quick Start sections
- document SHA256SUMS and GitHub build-provenance verification
- document Windows SmartScreen and external runtime-library expectations
- record the documentation change in CHANGELOG.md

## Verification

- git diff --check
- downloaded nvoc-cli-v0.2.0-alpha.1-linux-amd64 and SHA256SUMS from the published release
- sha256sum verification passed
- gh attestation verification passed against Skyworks-Neo/nvoc

Closes #232