### PR TITLE
fix(cli): show full help when arguments are missing

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -980,6 +980,9 @@ fn command_specific_arg(name: &'static str) -> Arg {
 fn clap_subcommand(command: Command) -> ClapCommand {
     let mut subcommand = ClapCommand::new(command.name()).about(command.about());
     let (min_args, _) = command.arity();
+    if min_args > 0 {
+        subcommand = subcommand.arg_required_else_help(true);
+    }
     for (index, positional) in command.positional_args().into_iter().enumerate() {
         subcommand = subcommand.arg(positional_arg(positional, index < min_args));
     }
@@ -2750,6 +2753,15 @@ mod tests {
             .to_string();
         assert!(help.contains("<ENABLED>"));
         assert!(help.contains("[possible values: on, off]"));
+    }
+
+    #[test]
+    fn missing_required_positionals_prints_full_subcommand_help() {
+        let help = parse_args(["set-fan-percent"]).unwrap_err().to_string();
+
+        assert!(help.contains("<PERCENT>"));
+        assert!(help.contains("--fan"));
+        assert!(help.contains("--policy"));
     }
 
     #[test]


### PR DESCRIPTION
Extracted from #267 as a single-function PR.

Subcommands with required positionals now use clap's full-help path when invoked without arguments, so command-specific options remain visible instead of being hidden behind a terse usage error. Includes a regression test using `set-fan-percent`.

Validation:
- `cargo test --package nvoc-cli --all-targets`
- `cargo clippy --package nvoc-cli --all-targets -- -D warnings`

No GPU access or writes are involved.