### PR TITLE
refactor(monitoring): use RTSS thermal channel layout

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -796,6 +796,17 @@ fn format_sensor_descriptor(
     if let Some(chan) = descriptor.get("channel_num") {
         lines.push(field("channel_num", chan));
     }
+    // Cross-reference to the raw sibling channel: RTSS exposes two channels
+    // per physical sensor — `(dev, 0)` raw and `(dev, 1)` with `offset_hw`
+    // already applied by the driver. Annotate the `(dev, 1)` half.
+    if let Some(sibling) = descriptor.get("same_sensor_as").and_then(Value::as_i64) {
+        lines.push(format!(
+            "{}{}: ch[{}] with offset_hw",
+            indent_spaces(indent),
+            nvoc_cli_common::color::stylize_title("Same Sensor As"),
+            nvoc_cli_common::color::stylize(&sibling.to_string(), false)
+        ));
+    }
     // RTSS ThermChannel metadata (research fields from GetInfo). channel_type
     // gets a human tag; offsets/scaling are shown raw (semantics undocumented).
     if let Some(ch_type) = descriptor.get("channel_type").and_then(Value::as_i64) {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -798,6 +798,31 @@ fn format_sensor_descriptor(
     if let Some(mask) = descriptor.get("sensor_mask_number") {
         lines.push(field("sensor_mask_number", mask));
     }
+    // RTSS ThermChannel metadata (research fields from GetInfo). channel_type
+    // gets a human tag; offsets/scaling are shown raw (semantics undocumented).
+    if let Some(ch_type) = descriptor.get("channel_type").and_then(Value::as_i64) {
+        let tag = match ch_type {
+            0 => " (GPU_AVG)",
+            1 => " (GPU_MAX)",
+            2 => " (BOARD)",
+            3 => " (MEMORY)",
+            4 => " (PWR_SUPPLY)",
+            255 => " (unclassified)",
+            _ => "",
+        };
+        lines.push(format!(
+            "{}{}: {}{}",
+            indent_spaces(indent),
+            nvoc_cli_common::color::stylize_title("Channel Type"),
+            nvoc_cli_common::color::stylize(&ch_type.to_string(), false),
+            tag
+        ));
+    }
+    for key in ["offset_sw", "offset_hw", "scaling"] {
+        if let Some(val) = descriptor.get(key) {
+            lines.push(field(key, val));
+        }
+    }
     lines
 }
 
@@ -1027,7 +1052,7 @@ mod tests {
                     {
                         "target": "Gpu",
                         "name": "Core",
-                        "sensor_mask_number": 8,
+                        "sensor_mask_number": 0,
                         "range": { "max": 139, "min": -35 }
                     },
                     52.58203125
@@ -1049,7 +1074,7 @@ mod tests {
         // Sensors: target dropped, temperature gets a C unit.
         assert!(!rendered.contains("Target"));
         assert!(rendered.contains("Name: Core"));
-        assert!(rendered.contains("Sensor Mask Number: 8"));
+        assert!(rendered.contains("Sensor Mask Number: 0"));
         assert!(rendered.contains("Range: Max 139 C, Min -35 C"));
         assert!(rendered.contains("- 52.58203125 C"));
     }
@@ -1065,7 +1090,7 @@ mod tests {
                     {
                         "target": "Gpu",
                         "name": "Hot Spot",
-                        "sensor_mask_number": 9,
+                        "sensor_mask_number": 1,
                         "range": { "max": 0, "min": 0 }
                     },
                     78.5

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -753,10 +753,11 @@ fn format_sensors_array(indent: usize, items: &[Value]) -> Vec<String> {
 }
 
 /// Render a sensor descriptor (everything except `target`) as indented fields.
-/// `name` and `sensor_mask_number` are emitted verbatim; `range` is a
+/// `channel_num` is emitted verbatim; `channel_type` gets a human tag
+/// (GPU_AVG/GPU_MAX/BOARD/MEMORY/PWR_SUPPLY/unclassified); `range` is a
 /// temperature limit shown as `Max N C, Min N C`, skipped when it is `{0, 0}`
-/// (the undocumented thermal-sensors API reports no limits for hot-spot /
-/// memory sensors, so a zero range carries no information).
+/// (the RTSS GetInfo record may report no limits for a channel, so a zero
+/// range carries no information).
 fn format_sensor_descriptor(
     indent: usize,
     descriptor: &serde_json::Map<String, Value>,
@@ -771,9 +772,6 @@ fn format_sensor_descriptor(
     };
 
     let mut lines = Vec::new();
-    if let Some(name) = descriptor.get("name") {
-        lines.push(field("name", name));
-    }
     if let Some(range) = descriptor.get("range").and_then(Value::as_object) {
         let max = range.get("max").and_then(Value::as_f64);
         let min = range.get("min").and_then(Value::as_f64);
@@ -795,8 +793,8 @@ fn format_sensor_descriptor(
             ));
         }
     }
-    if let Some(mask) = descriptor.get("sensor_mask_number") {
-        lines.push(field("sensor_mask_number", mask));
+    if let Some(chan) = descriptor.get("channel_num") {
+        lines.push(field("channel_num", chan));
     }
     // RTSS ThermChannel metadata (research fields from GetInfo). channel_type
     // gets a human tag; offsets/scaling are shown raw (semantics undocumented).
@@ -1051,8 +1049,8 @@ mod tests {
                 [
                     {
                         "target": "Gpu",
-                        "name": "Core",
-                        "sensor_mask_number": 0,
+                        "channel_num": 0,
+                        "channel_type": 0,
                         "range": { "max": 139, "min": -35 }
                     },
                     52.58203125
@@ -1071,10 +1069,12 @@ mod tests {
         assert!(rendered.contains("Shared: 32573.785 MB"));
         assert!(rendered.contains("Dedicated Evictions: 0"));
         assert!(!rendered.contains("Dedicated: 8384512"));
-        // Sensors: target dropped, temperature gets a C unit.
+        // Sensors: target dropped, classified by channel type (no Name line),
+        // temperature gets a C unit.
         assert!(!rendered.contains("Target"));
-        assert!(rendered.contains("Name: Core"));
-        assert!(rendered.contains("Sensor Mask Number: 0"));
+        assert!(!rendered.contains("Name:"));
+        assert!(rendered.contains("Channel Num: 0"));
+        assert!(rendered.contains("Channel Type: 0 (GPU_AVG)"));
         assert!(rendered.contains("Range: Max 139 C, Min -35 C"));
         assert!(rendered.contains("- 52.58203125 C"));
     }
@@ -1082,15 +1082,15 @@ mod tests {
     #[test]
     fn human_output_hides_zero_sensor_range() {
         nvoc_cli_common::color::init(true);
-        // Undocumented sensors (hot spot / memory junction) carry no limit data,
-        // so their range is {0, 0}; that uninformative line is suppressed.
+        // A channel whose GetInfo record reports no limit data has range
+        // {0, 0}; that uninformative line is suppressed.
         let output = json!({
             "sensors": [
                 [
                     {
                         "target": "Gpu",
-                        "name": "Hot Spot",
-                        "sensor_mask_number": 1,
+                        "channel_num": 1,
+                        "channel_type": 1,
                         "range": { "max": 0, "min": 0 }
                     },
                     78.5
@@ -1100,10 +1100,11 @@ mod tests {
 
         let rendered = format_human_output("get-status", &output).join("\n");
 
-        assert!(rendered.contains("Name: Hot Spot"));
+        assert!(rendered.contains("Channel Type: 1 (GPU_MAX)"));
         assert!(rendered.contains("- 78.5 C"));
         assert!(!rendered.contains("Range"));
         assert!(!rendered.contains("Target"));
+        assert!(!rendered.contains("Name:"));
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ pub use gpu::GpuSelector;
 pub use gpu_type::{
     ArchOcPrior, GpuOcParams, GpuType, GpuVoltageLimitParams, GpuVoltageLockParams, OcPriorPoint,
 };
-pub use nvapi::{CoolerTarget, GpuTdpTempLimits, ThermalSensors, VfpLockRequest};
+pub use nvapi::{CoolerTarget, GpuTdpTempLimits, VfpLockRequest};
 pub use operation::{
     CheckVoltageFrequency, ClearEdid, GpuOperation, ProbeVoltageLimits, QueryApiRestriction,
     QueryAutoBoost, QueryClockOffset, QueryDisplays, QueryDomainVfpIndices, QueryDomainVfpPoints,
@@ -34,8 +34,8 @@ pub use operation::{
     detect_gpu_type, fetch_gpu_type, find_matching_vfp_point, legacy_core_overvolt_ranges,
     legacy_p0_core_max_voltage_delta, nvml_pstate_to_index, nvml_pstate_to_str,
     parse_nvapi_locked_voltage_target, parse_nvml_fan_control_policy, parse_nvml_pstate,
-    probe_thermal_sensors_mask, query_domain_vf_points_indexed, query_domain_vfp_indices,
-    read_thermal_sensors, run, run_many, set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas,
+    query_domain_vf_points_indexed, query_domain_vfp_indices,
+    run, run_many, set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas,
     set_nvapi_legacy_clocks, set_nvapi_pstate_clock_offsets, set_nvapi_vfp_curve_delta,
     sync_memory_pstate_as_p0, try_parse_nvml_pstate,
 };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,10 +34,10 @@ pub use operation::{
     detect_gpu_type, fetch_gpu_type, find_matching_vfp_point, legacy_core_overvolt_ranges,
     legacy_p0_core_max_voltage_delta, nvml_pstate_to_index, nvml_pstate_to_str,
     parse_nvapi_locked_voltage_target, parse_nvml_fan_control_policy, parse_nvml_pstate,
-    query_domain_vf_points_indexed, query_domain_vfp_indices,
-    run, run_many, set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas,
-    set_nvapi_legacy_clocks, set_nvapi_pstate_clock_offsets, set_nvapi_vfp_curve_delta,
-    sync_memory_pstate_as_p0, try_parse_nvml_pstate,
+    query_domain_vf_points_indexed, query_domain_vfp_indices, run, run_many,
+    set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas, set_nvapi_legacy_clocks,
+    set_nvapi_pstate_clock_offsets, set_nvapi_vfp_curve_delta, sync_memory_pstate_as_p0,
+    try_parse_nvml_pstate,
 };
 pub use result::{
     ApiRestrictionState, AppliedValue, AutoBoostState, BatchReport, ClockOffset, DisplayInfo,

--- a/core/src/nvapi.rs
+++ b/core/src/nvapi.rs
@@ -7,7 +7,6 @@ use super::nvml::{
 };
 use super::result::PstateBaseVoltage;
 use super::types::{NvapiLockedVoltageTarget, VfpResetDomain};
-pub use nvapi_hi::ThermalSensors;
 use nvapi_hi::nvapi::{CelsiusShifted, DisplayIdsFlags, VoltageDomain};
 use nvapi_hi::{
     Celsius, ClockDomain, ClockLockEntry, ClockLockValue, ConnectedIdsFlags, CoolerPolicy,
@@ -1290,20 +1289,4 @@ pub fn set_legacy_clocks_nvapi(gpu: &Gpu, core_mhz: u32, mem_mhz: u32) -> Result
     }
 
     Ok(())
-}
-
-pub(crate) fn probe_thermal_sensors_mask(gpu: &Gpu) -> Result<i32, Error> {
-    for i in 0..32 {
-        let mask: i32 = 1 << i;
-        if let Ok(sensors) = gpu.thermal_sensors(mask)
-            && sensors.values.iter().any(|&v| v != 0)
-        {
-            return Ok(mask);
-        }
-    }
-    Err(Error::Str("no valid NVAPI thermal sensor mask found"))
-}
-
-pub(crate) fn read_thermal_sensors(gpu: &Gpu, mask: i32) -> Result<ThermalSensors, Error> {
-    gpu.thermal_sensors(mask).map_err(Error::from)
 }

--- a/core/src/operation.rs
+++ b/core/src/operation.rs
@@ -1484,17 +1484,6 @@ pub fn percentage(value: u32) -> Percentage {
     Percentage(value)
 }
 
-pub fn probe_thermal_sensors_mask(target: &GpuTarget<'_>) -> Result<i32, Error> {
-    low_nvapi::probe_thermal_sensors_mask(target.nvapi()?)
-}
-
-pub fn read_thermal_sensors(
-    target: &GpuTarget<'_>,
-    mask: i32,
-) -> Result<nvapi_hi::ThermalSensors, Error> {
-    low_nvapi::read_thermal_sensors(target.nvapi()?, mask)
-}
-
 pub fn set_nvapi_vfp_curve_delta(
     target: &GpuTarget<'_>,
     point: usize,

--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -504,3 +504,31 @@ fn nvapi_vf_check_bad_point() {
     let target = first_target(&inv);
     assert!(run(&target, CheckVoltageFrequency { point: usize::MAX }).is_err());
 }
+
+#[test]
+#[ignore]
+fn nvapi_thermal_channels_have_core_first_and_unique_indices() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    if !target.has_nvapi() {
+        return;
+    }
+
+    let status = run(&target, QueryGpuStatus)
+        .expect("GPU status should include best-effort thermal channels")
+        .output;
+    let (core, _) = status
+        .sensors
+        .first()
+        .expect("at least the GPU average thermal channel should be present");
+    assert_eq!(core.channel_type, Some(0), "GPU_AVG must remain first");
+
+    let mut channels = status
+        .sensors
+        .iter()
+        .filter_map(|(sensor, _)| sensor.channel_num)
+        .collect::<Vec<_>>();
+    channels.sort_unstable();
+    channels.dedup();
+    assert_eq!(channels.len(), status.sensors.len());
+}

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -477,7 +477,7 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         }
     }
     if let Some((_sensor, temp)) = status.sensors.first() {
-        map.insert("temperature_c".into(), f64_value(temp.0 as f64));
+        map.insert("temperature_c".into(), f64_value(*temp as f64));
     }
     if let Some((_channel, power)) = status.power.iter().next()
         && let Some(watts) = first_number_in_display(power)


### PR DESCRIPTION
Extracted from #267 as the thermal-channel child PR.

#274 is now merged into `main`. The remaining focused dependency is Skyworks-Neo/nvapi-rs#1. After the former downstream PRs were merged into intermediate branches, this head was restored and rebased so its diff is thermal-only again; replacements #282-#287 carry the downstream features.

Replaces the old positional `values[40]` thermal probe with the RTSS `ThermChannelGetInfo` + `ThermChannelGetStatus` layout, classifies channels by `channel_type`, preserves GPU_AVG as sensor 0, and annotates offset_hw-applied sibling channels. Removes the obsolete superproject mask-probe wrappers and updates CLI rendering/tests for the channel schema.

The submodule commit is published from a fork through the upstream dependency PR and is fetchable from the original `Skyworks-Neo/nvapi-rs` URL. Its net change from NVOC's current dependency is thermal-only; unrelated power, fan, private-control, and raw-probe history is excluded.

Validation:
- `cargo fmt --all -- --check`
- `cargo test --package nvoc-core --all-targets`
- `cargo test --package nvoc-cli --all-targets` (32 passed)
- `cargo check --package pynvoc`
- `cargo clippy --workspace --exclude cli-stressor-cuda-rs --all-targets -- -D warnings`
- `cargo test --workspace --lib --tests` in the focused `nvapi-rs` dependency (2 integration tests passed)
- elevated read-only `nvapi_thermal_channels_have_core_first_and_unique_indices`: passed on the local GPU

No GPU writes were executed. Large raw RE probes from #267 were intentionally omitted.