### PR TITLE
feat(tui): render expanded live GPU metrics

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -278,6 +278,24 @@ fn format_value_block_with_context(value: &Value, indent: usize, context: &str) 
                         ));
                         lines.extend(format_utilization_entries(indent + 1, child));
                     }
+                    // `perf` carries two raw NVAPI words from PerfPoliciesGetStatus:
+                    // `limits` (a PerfFlags bitmask of throttling reasons) and
+                    // `unknown` (a driver load-level indicator, not an error).
+                    // Both are unreadable as raw ints, so decode them here.
+                    Value::Object(child) if key == "perf" && child.contains_key("limits") => {
+                        lines.push(format!(
+                            "{}{}",
+                            indent_spaces(indent),
+                            nvoc_cli_common::color::stylize_title(&format_label(key))
+                        ));
+                        lines.extend(format_perf_block(indent + 1, child));
+                    }
+                    // `performance_decrease` is the serde form of nvapi-rs's
+                    // `PerformanceDecreaseReason` bitflags struct (`{"bits": N}`);
+                    // decode the bitmask to friendly reason text.
+                    Value::Object(_) if key == "performance_decrease" => {
+                        lines.extend(format_performance_decrease(indent, value));
+                    }
                     Value::Object(child) if key == "memory" && child.contains_key("dedicated") => {
                         lines.push(format!(
                             "{}{}",
@@ -694,6 +712,111 @@ fn format_utilization_entries(
             )
         })
         .collect()
+}
+
+/// NVAPI PerfFlags bit → friendly reason name. Bit semantics mirror
+/// `nvapi-rs/sys/src/gpu/power.rs` (`NV_GPU_PERF_FLAGS` + its display table):
+/// 1 Power, 2 Temperature, 4 Reliability Voltage, 8 Operating Voltage,
+/// 16 No Load, 32 Unknown32. Kept in ascending bit order so the decoded
+/// list reads consistently regardless of which reasons are active.
+const PERF_LIMIT_BITS: &[(u64, &str)] = &[
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+];
+
+/// Extract a bitmask from a JSON value that may be either a raw integer
+/// (`N`, as emitted by pynvoc) or a bitflags object (`{"bits": N}`, as serde
+/// renders nvapi-rs `nvbits!` structs on the CLI's native get-status path).
+fn bitmask_from_value(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(n) => n.as_u64(),
+        Value::Object(obj) => obj.get("bits").and_then(Value::as_u64),
+        _ => None,
+    }
+}
+
+/// Decode the NVAPI perf-policy status (`perf` object from PerfPoliciesGetStatus).
+/// `limits` is a PerfFlags bitmask of active throttling reasons; `unknown` is the
+/// driver's load-status level (1 = on load, 3 = low clocks, 7 = idle — see
+/// `nvapi-rs/sys/src/gpu/power.rs` field comment), not an error/unknown value.
+fn format_perf_block(indent: usize, object: &serde_json::Map<String, Value>) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    let limits_raw = object
+        .get("limits")
+        .and_then(bitmask_from_value)
+        .unwrap_or(0);
+    let reasons: Vec<&str> = PERF_LIMIT_BITS
+        .iter()
+        .filter(|(bit, _)| limits_raw & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    let limits_text = if reasons.is_empty() {
+        "None".to_string()
+    } else {
+        reasons.join(", ")
+    };
+    lines.push(format!(
+        "{}{}: {}",
+        indent_spaces(indent),
+        nvoc_cli_common::color::stylize_title("Limits"),
+        nvoc_cli_common::color::stylize(&limits_text, false)
+    ));
+
+    if let Some(unknown) = object.get("unknown").and_then(Value::as_u64) {
+        let load_text = match unknown {
+            1 => "Load".to_string(),
+            3 => "Low Clock".to_string(),
+            7 => "Idle".to_string(),
+            other => format!("{other} (raw)"),
+        };
+        lines.push(format!(
+            "{}{}: {}",
+            indent_spaces(indent),
+            nvoc_cli_common::color::stylize_title("Load Level"),
+            nvoc_cli_common::color::stylize(&load_text, false)
+        ));
+    }
+
+    lines
+}
+
+/// PerformanceDecreaseReason bits (NVAPI_GPU_PERF_DECREASE, `nvapi-rs/sys/src/
+/// gpu/mod.rs`): 1 Thermal Protection, 2 Power Control, 4 AC-Battery,
+/// 8 API Triggered, 16 Insufficient Power. 0 = none.
+const PERF_DECREASE_BITS: &[(u64, &str)] = &[
+    (1, "Thermal Protection"),
+    (2, "Power Control"),
+    (4, "AC-Battery"),
+    (8, "API Triggered"),
+    (16, "Insufficient Power"),
+];
+
+/// Decode the `performance_decrease` value. On the CLI's native get-status path
+/// serde renders the nvapi-rs `PerformanceDecreaseReason` bitflags struct as
+/// `{"bits": N}`; decode the bitmask into reason names (0 -> "None").
+fn format_performance_decrease(indent: usize, value: &Value) -> Vec<String> {
+    let bits = bitmask_from_value(value).unwrap_or(0);
+    let reasons: Vec<&str> = PERF_DECREASE_BITS
+        .iter()
+        .filter(|(bit, _)| bits & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    let text = if reasons.is_empty() {
+        "None".to_string()
+    } else {
+        reasons.join(", ")
+    };
+    vec![format!(
+        "{}{}: {}",
+        indent_spaces(indent),
+        nvoc_cli_common::color::stylize_title("Performance Decrease"),
+        nvoc_cli_common::color::stylize(&text, false)
+    )]
 }
 
 /// Render the VRAM info map. Size fields are kibibytes -> shown in MB;
@@ -1116,6 +1239,66 @@ mod tests {
         assert!(!rendered.contains("Range"));
         assert!(!rendered.contains("Target"));
         assert!(!rendered.contains("Name:"));
+    }
+
+    #[test]
+    fn human_output_decodes_perf_bitset() {
+        nvoc_cli_common::color::init(true);
+        // On the native get-status path serde renders PerfFlags as `{"bits": N}`;
+        // perf.unknown is a load-level indicator (7 = idle). Both must be decoded,
+        // not shown as raw ints.
+        let output = json!({
+            "perf": { "unknown": 7, "limits": { "bits": 16 } }
+        });
+
+        let rendered = format_human_output("get-status", &output).join("\n");
+
+        assert!(rendered.contains("Limits: No Load"));
+        assert!(rendered.contains("Load Level: Idle"));
+        // Raw-int rendering is gone.
+        assert!(!rendered.contains("Bits: 16"));
+        assert!(!rendered.contains("Unknown"));
+    }
+
+    #[test]
+    fn human_output_decodes_perf_multiple_reasons() {
+        nvoc_cli_common::color::init(true);
+        // limits bits = 3 = POWER_LIMIT(1) | THERMAL_LIMIT(2), decoded in bit
+        // order. The raw-int form (pynvoc path) is also accepted.
+        let rendered_obj = format_human_output(
+            "get-status",
+            &json!({ "perf": { "unknown": 1, "limits": { "bits": 3 } } }),
+        )
+        .join("\n");
+        assert!(rendered_obj.contains("Limits: Power, Temperature"));
+        assert!(rendered_obj.contains("Load Level: Load"));
+
+        let rendered_raw = format_human_output(
+            "get-status",
+            &json!({ "perf": { "unknown": 1, "limits": 3 } }),
+        )
+        .join("\n");
+        assert!(rendered_raw.contains("Limits: Power, Temperature"));
+    }
+
+    #[test]
+    fn human_output_decodes_performance_decrease() {
+        nvoc_cli_common::color::init(true);
+        // bits = 3 = THERMAL_PROTECTION(1) | POWER_CONTROL(2), decoded in bit
+        // order to friendly text on a single line.
+        let output = json!({
+            "performance_decrease": { "bits": 3 }
+        });
+        let rendered = format_human_output("get-status", &output).join("\n");
+        assert!(rendered.contains("Performance Decrease: Thermal Protection, Power Control"));
+
+        // bits = 0 (idle GPU) -> None.
+        let rendered_none = format_human_output(
+            "get-status",
+            &json!({ "performance_decrease": { "bits": 0 } }),
+        )
+        .join("\n");
+        assert!(rendered_none.contains("Performance Decrease: None"));
     }
 
     #[test]

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -494,6 +494,52 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
             break;
         }
     }
+
+    // Per-domain utilization %: { Graphics, FrameBuffer(=memory controller),
+    // VideoEngine, BusInterface }. Serialized verbatim (matches get-status JSON).
+    if let Ok(v) = serde_json::to_value(&status.utilization)
+        && !v.is_null()
+    {
+        map.insert("utilization".into(), v);
+    }
+
+    // VRAM (KiB): used = dedicated - dedicated_available_current.
+    if let Some(mem) = status.memory {
+        let total = mem.dedicated.0;
+        let free = mem.dedicated_available_current.0;
+        let used = total.saturating_sub(free);
+        map.insert(
+            "vram".into(),
+            value_object([
+                ("total_kib", u64_value(total as u64)),
+                ("used_kib", u64_value(used as u64)),
+                ("free_kib", u64_value(free as u64)),
+                ("shared_kib", u64_value(mem.shared.0 as u64)),
+            ]),
+        );
+    }
+
+    // Per-cooler fan status (rpm + level % + active), serialized verbatim.
+    if let Ok(v) = serde_json::to_value(&status.coolers)
+        && !v.is_null()
+    {
+        map.insert("coolers".into(), v);
+    }
+
+    // PCIe link width (downstream lane count).
+    if let Some(lanes) = status.pcie_lanes {
+        map.insert("pcie_lanes".into(), u64_value(lanes as u64));
+    }
+
+    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle reasons).
+    map.insert(
+        "perf".into(),
+        value_object([
+            ("unknown", u64_value(status.perf.unknown as u64)),
+            ("limits", u64_value(status.perf.limits.bits() as u64)),
+        ]),
+    );
+
     Ok(Value::Object(map))
 }
 

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -510,6 +510,33 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
     if let Some((_sensor, temp)) = status.sensors.first() {
         map.insert("temperature_c".into(), f64_value(*temp as f64));
     }
+    // Full thermal-sensor list as `[descriptor, temp_celsius]` pairs (same shape
+    // as get-status JSON), plus the three primary typed temperatures pulled out
+    // by channel_type (0=GPU_AVG/core, 1=GPU_MAX/hot spot, 3=MEMORY/VRAM). The
+    // TUI dashboard reads temp_core/temp_hotspot/temp_memory directly (the
+    // native path bypasses normalize_query_output, so it cannot re-parse the
+    // sensors array itself); `temperature_c` above stays as the core fallback.
+    if !status.sensors.is_empty() {
+        if let Ok(v) = serde_json::to_value(&status.sensors)
+            && !v.is_null()
+        {
+            map.insert("sensors".into(), v);
+        }
+        for (desc, temp) in &status.sensors {
+            match desc.channel_type {
+                Some(0) if !map.contains_key("temp_core") => {
+                    map.insert("temp_core".into(), f64_value(*temp as f64));
+                }
+                Some(1) if !map.contains_key("temp_hotspot") => {
+                    map.insert("temp_hotspot".into(), f64_value(*temp as f64));
+                }
+                Some(3) if !map.contains_key("temp_memory") => {
+                    map.insert("temp_memory".into(), f64_value(*temp as f64));
+                }
+                _ => {}
+            }
+        }
+    }
     if let Some((_channel, power)) = status.power.iter().next()
         && let Some(watts) = first_number_in_display(power)
     {

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -271,6 +271,37 @@ fn bool_value(value: bool) -> Value {
     Value::Bool(value)
 }
 
+/// NVAPI PerfFlags bit -> reason name. Bit semantics mirror nvapi-rs
+/// (`sys/src/gpu/power.rs`, NV_GPU_PERF_FLAGS + its display table). Ascending
+/// bit order so the decoded list reads consistently regardless of active set.
+const PERF_LIMIT_BITS: &[(u32, &str)] = &[
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+];
+
+/// Decode a PerfFlags bitmask into reason names; an empty mask yields `["None"]`.
+fn decode_perf_flags(bits: u32) -> Vec<&'static str> {
+    let reasons: Vec<&'static str> = PERF_LIMIT_BITS
+        .iter()
+        .filter(|(bit, _)| bits & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    if reasons.is_empty() {
+        vec!["None"]
+    } else {
+        reasons
+    }
+}
+
+/// Build a JSON array of strings from the given reason names.
+fn text_array_value(items: Vec<&str>) -> Value {
+    Value::Array(items.into_iter().map(text).collect())
+}
+
 fn percent_value(value: Percentage) -> Value {
     u64_value(value.0 as u64)
 }
@@ -531,12 +562,19 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         map.insert("pcie_lanes".into(), u64_value(lanes as u64));
     }
 
-    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle reasons).
+    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle
+    // reasons). `limits_decoded` is the same mask rendered as reason names so
+    // consumers (TUI/CLI) don't each have to re-decode the bits.
+    let perf_limits_bits = status.perf.limits.bits() as u32;
     map.insert(
         "perf".into(),
         value_object([
             ("unknown", u64_value(status.perf.unknown as u64)),
-            ("limits", u64_value(status.perf.limits.bits() as u64)),
+            ("limits", u64_value(perf_limits_bits as u64)),
+            (
+                "limits_decoded",
+                text_array_value(decode_perf_flags(perf_limits_bits)),
+            ),
         ]),
     );
 

--- a/tui/nvoc_tui/controllers/dashboard.py
+++ b/tui/nvoc_tui/controllers/dashboard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from rich.text import Text
 from textual.widgets import Button, Input, Static
 
+from ..metrics_format import _format_metric_lines
 from ..widgets import mnemonic_text
 from .base import PaneController
 
@@ -52,23 +53,7 @@ class DashboardController(PaneController):
         info = self.app.cache.info
         status = self.app.cache.status
         architecture = info.get("arch") or info.get("codename") or "---"
-        if status.get("vfp_locked"):
-            lock_mv = status.get("vfp_lock_mv")
-            if isinstance(lock_mv, (int, float)):
-                vfp_lock_text = f"ON ({lock_mv} mV)"
-            else:
-                vfp_lock_text = "ON"
-        else:
-            vfp_lock_text = "OFF"
-        lines = [
-            f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
-            f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
-            f"VOLT: {status.get('voltage_mv', '---')} mV",
-            f"VFP LOCK: {vfp_lock_text}",
-            f"TEMP: {status.get('temperature_c', '---')} C",
-            f"PWR: {status.get('power_w', '---')} W",
-            f"ARCH: {architecture}",
-        ]
+        lines = _format_metric_lines(status, architecture)
         self.app.query_one("#metrics", Static).update("\n".join(lines))
 
     def activate_button(self, button_id: str) -> bool:

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+# Pure formatting helpers for the dashboard metrics panel. Kept separate from
+# the Textual controller so they can be unit-tested without a widget app.
+
+
+def _temp_c_str(value) -> str:
+    """Format a temperature for display as a rounded integer (°C)."""
+    if value is None:
+        return "---"
+    try:
+        return f"{round(float(value))}"
+    except (TypeError, ValueError):
+        return "---"
+
+
+def _format_metric_lines(status: dict, architecture: str) -> list[str]:
+    """Build the dashboard metric lines from a normalized status dict.
+
+    `status` is the pynvoc `query_status` output (see ``normalize_status`` in
+    ``nvoc-python/src/lib.rs``). Missing fields render as ``---``.
+    """
+    if status.get("vfp_locked"):
+        lock_mv = status.get("vfp_lock_mv")
+        if isinstance(lock_mv, (int, float)):
+            vfp_lock_text = f"ON ({lock_mv} mV)"
+        else:
+            vfp_lock_text = "ON"
+    else:
+        vfp_lock_text = "OFF"
+
+    util = status.get("utilization") or {}
+
+    def _pct(key: str) -> str:
+        value = util.get(key)
+        return f"{round(float(value))}%" if isinstance(value, (int, float)) else "---"
+
+    load_text = " | ".join(
+        [
+            f"GPU {_pct('Graphics')}",
+            # FrameBuffer is NVAPI's name for the memory-controller utilization domain.
+            f"MC {_pct('FrameBuffer')}",
+            f"VEN {_pct('VideoEngine')}",
+            f"BUS {_pct('BusInterface')}",
+        ]
+    )
+
+    vram = status.get("vram") or {}
+
+    def _vram_gb(key: str) -> float | None:
+        value = vram.get(key)
+        if not isinstance(value, (int, float)):
+            return None
+        return float(value) / (1024.0 * 1024.0)
+
+    used_gb = _vram_gb("used_kib")
+    total_gb = _vram_gb("total_kib")
+    vram_text = (
+        f"{used_gb:.1f} / {total_gb:.1f} GB"
+        if used_gb is not None and total_gb is not None
+        else "---"
+    )
+
+    coolers = status.get("coolers") or {}
+    valid_coolers = [
+        (cid, c) for cid, c in sorted(coolers.items()) if isinstance(c, dict)
+    ]
+    fan_parts: list[str] = []
+    for idx, (_, cooler) in enumerate(valid_coolers, start=1):
+        rpm = cooler.get("current_tach")
+        level = cooler.get("current_level")
+        rpm_s = f"{round(float(rpm))}" if isinstance(rpm, (int, float)) else "---"
+        level_s = (
+            f"{round(float(level))}%" if isinstance(level, (int, float)) else "---"
+        )
+        label = "FAN" if len(valid_coolers) == 1 else f"FAN{idx}"
+        fan_parts.append(f"{label}: {rpm_s} RPM @ {level_s}")
+    fan_text = " | ".join(fan_parts) if fan_parts else "---"
+
+    lanes = status.get("pcie_lanes")
+    pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
+
+    perf = status.get("perf") or {}
+    perf_limits = perf.get("limits") if isinstance(perf, dict) else None
+    perf_text = (
+        f"0x{int(perf_limits):x}" if isinstance(perf_limits, (int, float)) else "---"
+    )
+
+    return [
+        f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
+        f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
+        f"VOLT: {status.get('voltage_mv', '---')} mV",
+        f"VFP LOCK: {vfp_lock_text}",
+        f"TEMP: {_temp_c_str(status.get('temperature_c'))} C",
+        f"PWR: {status.get('power_w', '---')} W",
+        f"LOAD: {load_text}",
+        f"VRAM: {vram_text}",
+        f"FAN: {fan_text}",
+        f"PCIE: {pcie_text}",
+        f"PSTATE: {status.get('pstate', '---')}",
+        f"PERF: {perf_text}",
+        f"ARCH: {architecture}",
+    ]

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -35,15 +35,13 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
         value = util.get(key)
         return f"{round(float(value))}%" if isinstance(value, (int, float)) else "---"
 
-    load_text = " | ".join(
-        [
-            f"GPU {_pct('Graphics')}",
-            # FrameBuffer is NVAPI's name for the memory-controller utilization domain.
-            f"MC {_pct('FrameBuffer')}",
-            f"VEN {_pct('VideoEngine')}",
-            f"BUS {_pct('BusInterface')}",
-        ]
-    )
+    load_text = " | ".join([
+        f"GPU {_pct('Graphics')}",
+        # FrameBuffer is NVAPI's name for the memory-controller utilization domain.
+        f"MC {_pct('FrameBuffer')}",
+        f"VEN {_pct('VideoEngine')}",
+        f"BUS {_pct('BusInterface')}",
+    ])
 
     vram = status.get("vram") or {}
 

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -108,12 +108,22 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     perf = status.get("perf") or {}
     perf_text = _perf_limits_text(perf)
 
+    # Thermal sensors: core (GPU_AVG) is always shown; hot spot (GPU_MAX) and
+    # memory/VRAM are appended only when the GPU exposes them, so the line
+    # adapts to whatever channels are available.
+    temp_parts = [f"CORE {_temp_c_str(status.get('temperature_c'))} C"]
+    if isinstance(status.get("temp_hotspot"), (int, float)):
+        temp_parts.append(f"HOTSPOT {_temp_c_str(status['temp_hotspot'])} C")
+    if isinstance(status.get("temp_memory"), (int, float)):
+        temp_parts.append(f"MEM {_temp_c_str(status['temp_memory'])} C")
+    temp_text = " | ".join(temp_parts)
+
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
         f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
         f"VOLT: {status.get('voltage_mv', '---')} mV",
         f"VFP LOCK: {vfp_lock_text}",
-        f"TEMP: {_temp_c_str(status.get('temperature_c'))} C",
+        f"TEMP: {temp_text}",
         f"PWR: {status.get('power_w', '---')} W",
         f"LOAD: {load_text}",
         f"VRAM: {vram_text}",

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -14,6 +14,33 @@ def _temp_c_str(value) -> str:
         return "---"
 
 
+# NVAPI PerfFlags bit -> reason name. Bit semantics mirror nvapi-rs
+# (`sys/src/gpu/power.rs`, NV_GPU_PERF_FLAGS + its display table). Ascending
+# bit order so the decoded list reads consistently regardless of active set.
+_PERF_LIMIT_BITS = [
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+]
+
+
+def _perf_limits_text(perf) -> str:
+    """Decode the NVAPI perf-policy limit bitmask (``perf.limits``) to a
+    comma-separated reason list. ``0`` -> ``none``; missing/non-numeric -> ``---``.
+    """
+    if not isinstance(perf, dict):
+        return "---"
+    limits = perf.get("limits")
+    if not isinstance(limits, (int, float)):
+        return "---"
+    bits = int(limits)
+    reasons = [name for bit, name in _PERF_LIMIT_BITS if bits & bit]
+    return ", ".join(reasons) if reasons else "none"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -79,10 +106,7 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
 
     perf = status.get("perf") or {}
-    perf_limits = perf.get("limits") if isinstance(perf, dict) else None
-    perf_text = (
-        f"0x{int(perf_limits):x}" if isinstance(perf_limits, (int, float)) else "---"
-    )
+    perf_text = _perf_limits_text(perf)
 
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
@@ -96,6 +120,6 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
         f"FAN: {fan_text}",
         f"PCIE: {pcie_text}",
         f"PSTATE: {status.get('pstate', '---')}",
-        f"PERF: {perf_text}",
+        f"PERF LIMIT: {perf_text}",
         f"ARCH: {architecture}",
     ]

--- a/tui/nvoc_tui/parsing.py
+++ b/tui/nvoc_tui/parsing.py
@@ -78,14 +78,29 @@ def _normalize_status_json(value: dict[str, Any]) -> dict[str, Any]:
 
     sensors = value.get("sensors")
     if isinstance(sensors, list):
+        # Thermal sensors are `[descriptor, temp]` pairs. The descriptor's
+        # `channel_type` identifies the sensor: 0=GPU_AVG (core), 1=GPU_MAX
+        # (hot spot), 3=MEMORY (VRAM). Keep the core temp on `temperature_c`
+        # (positional default — first sensor) and also expose the typed trio
+        # so the dashboard can render whichever are present.
         for entry in sensors:
-            if (
+            if not (
                 isinstance(entry, list)
                 and len(entry) >= 2
                 and isinstance(entry[1], (int, float))
             ):
-                normalized["temperature_c"] = float(entry[1])
-                break
+                continue
+            temp = float(entry[1])
+            if "temperature_c" not in normalized:
+                normalized["temperature_c"] = temp
+            descriptor = entry[0] if isinstance(entry[0], dict) else {}
+            ch_type = descriptor.get("channel_type")
+            if ch_type == 0 and "temp_core" not in normalized:
+                normalized["temp_core"] = temp
+            elif ch_type == 1 and "temp_hotspot" not in normalized:
+                normalized["temp_hotspot"] = temp
+            elif ch_type == 3 and "temp_memory" not in normalized:
+                normalized["temp_memory"] = temp
 
     power = value.get("power")
     if isinstance(power, dict):

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -1,0 +1,70 @@
+from nvoc_tui.metrics_format import _format_metric_lines
+
+
+def test_format_metric_lines_full() -> None:
+    status = {
+        "gpu_clock_mhz": 1800,
+        "mem_clock_mhz": 7500,
+        "voltage_mv": 950,
+        "temperature_c": 62.4,
+        "power_w": 132,
+        "pstate": "P0",
+        "utilization": {
+            "Graphics": 100,
+            "FrameBuffer": 0,
+            "VideoEngine": 12,
+            "BusInterface": 2,
+        },
+        "vram": {
+            # 8 GiB total, 2 GiB used (KiB).
+            "total_kib": 8_388_608,
+            "used_kib": 2_097_152,
+            "free_kib": 6_291_456,
+            "shared_kib": 0,
+        },
+        "coolers": {
+            "Cooler1": {"current_level": 45, "current_tach": 1234, "active": True},
+        },
+        "pcie_lanes": 16,
+        "perf": {"unknown": 0, "limits": 64},
+    }
+
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+
+    assert "GPU: 1800 MHz" in text
+    assert "MEM: 7500 MHz" in text
+    assert "VOLT: 950 mV" in text
+    assert "TEMP: 62 C" in text
+    assert "PWR: 132 W" in text
+    assert "PSTATE: P0" in text
+    assert "LOAD: GPU 100% | MC 0% | VEN 12% | BUS 2%" in text
+    assert "VRAM: 2.0 / 8.0 GB" in text
+    assert "FAN: 1234 RPM @ 45%" in text
+    assert "PCIE: x16" in text
+    assert "PERF: 0x40" in text
+    assert "ARCH: Ada" in text
+
+
+def test_format_metric_lines_missing_fields_render_dashes() -> None:
+    text = "\n".join(_format_metric_lines({}, "---"))
+
+    assert "LOAD: GPU --- | MC --- | VEN --- | BUS ---" in text
+    assert "VRAM: ---" in text
+    assert "FAN: ---" in text
+    assert "PCIE: ---" in text
+    assert "PSTATE: ---" in text
+    assert "PERF: ---" in text
+
+
+def test_format_metric_lines_multi_cooler_labels() -> None:
+    status = {
+        "coolers": {
+            "Cooler1": {"current_level": 30, "current_tach": 1000, "active": True},
+            "Cooler2": {"current_level": 50, "current_tach": 2000, "active": True},
+        }
+    }
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    assert "FAN1: 1000 RPM @ 30%" in text
+    assert "FAN2: 2000 RPM @ 50%" in text

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -34,7 +34,7 @@ def test_format_metric_lines_full() -> None:
     assert "GPU: 1800 MHz" in text
     assert "MEM: 7500 MHz" in text
     assert "VOLT: 950 mV" in text
-    assert "TEMP: 62 C" in text
+    assert "TEMP: CORE 62 C" in text
     assert "PWR: 132 W" in text
     assert "PSTATE: P0" in text
     assert "LOAD: GPU 100% | MC 0% | VEN 12% | BUS 2%" in text
@@ -46,18 +46,25 @@ def test_format_metric_lines_full() -> None:
     assert "ARCH: Ada" in text
 
 
-def test_format_metric_lines_perf_decodes_multiple_reasons() -> None:
-    # limits = 18 = THERMAL_LIMIT(2) | NO_LOAD_LIMIT(16), decoded in bit order.
-    text = "\n".join(
-        _format_metric_lines({"perf": {"unknown": 0, "limits": 18}}, "---")
-    )
-    assert "PERF LIMIT: Temperature, No Load" in text
+def test_format_metric_lines_thermal_trio() -> None:
+    status = {
+        "temperature_c": 55,
+        "temp_hotspot": 63.5,
+        "temp_memory": 58,
+    }
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    # All three present — core always shown, hotspot/memory appended in order.
+    assert "TEMP: CORE 55 C | HOTSPOT 64 C | MEM 58 C" in text
 
 
-def test_format_metric_lines_perf_zero_is_none() -> None:
-    # No active limit reason -> "none" (not "0x0").
-    text = "\n".join(_format_metric_lines({"perf": {"unknown": 0, "limits": 0}}, "---"))
-    assert "PERF LIMIT: none" in text
+def test_format_metric_lines_core_only_when_no_extra_temps() -> None:
+    text = "\n".join(_format_metric_lines({"temperature_c": 47}, "---"))
+
+    assert "TEMP: CORE 47 C" in text
+    assert "HOT" not in text
+    assert "MEM 47 C" not in text
 
 
 def test_format_metric_lines_missing_fields_render_dashes() -> None:

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -26,7 +26,7 @@ def test_format_metric_lines_full() -> None:
             "Cooler1": {"current_level": 45, "current_tach": 1234, "active": True},
         },
         "pcie_lanes": 16,
-        "perf": {"unknown": 0, "limits": 64},
+        "perf": {"unknown": 0, "limits": 32},
     }
 
     text = "\n".join(_format_metric_lines(status, "Ada"))
@@ -41,8 +41,23 @@ def test_format_metric_lines_full() -> None:
     assert "VRAM: 2.0 / 8.0 GB" in text
     assert "FAN: 1234 RPM @ 45%" in text
     assert "PCIE: x16" in text
-    assert "PERF: 0x40" in text
+    # limits = 32 = UNKNOWN_32 bit -> decoded reason name, not raw hex.
+    assert "PERF LIMIT: Unknown32" in text
     assert "ARCH: Ada" in text
+
+
+def test_format_metric_lines_perf_decodes_multiple_reasons() -> None:
+    # limits = 18 = THERMAL_LIMIT(2) | NO_LOAD_LIMIT(16), decoded in bit order.
+    text = "\n".join(
+        _format_metric_lines({"perf": {"unknown": 0, "limits": 18}}, "---")
+    )
+    assert "PERF LIMIT: Temperature, No Load" in text
+
+
+def test_format_metric_lines_perf_zero_is_none() -> None:
+    # No active limit reason -> "none" (not "0x0").
+    text = "\n".join(_format_metric_lines({"perf": {"unknown": 0, "limits": 0}}, "---"))
+    assert "PERF LIMIT: none" in text
 
 
 def test_format_metric_lines_missing_fields_render_dashes() -> None:
@@ -53,7 +68,7 @@ def test_format_metric_lines_missing_fields_render_dashes() -> None:
     assert "FAN: ---" in text
     assert "PCIE: ---" in text
     assert "PSTATE: ---" in text
-    assert "PERF: ---" in text
+    assert "PERF LIMIT: ---" in text
 
 
 def test_format_metric_lines_multi_cooler_labels() -> None:

--- a/tui/tests/test_parsing.py
+++ b/tui/tests/test_parsing.py
@@ -153,8 +153,8 @@ def test_normalize_status_json_output() -> None:
         "sensors": [
           [
             {
-              "controller": "GpuInternal",
-              "target": "Gpu"
+              "target": "Gpu",
+              "channel_type": 0
             },
             37
           ]
@@ -169,6 +169,11 @@ def test_normalize_status_json_output() -> None:
     assert parsed["mem_clock_mhz"] == 405.0
     assert parsed["voltage_mv"] == 650.0
     assert parsed["temperature_c"] == 37.0
+    # Typed core temp mirrors temperature_c (channel_type 0); the unclassified
+    # channel (type 255) must NOT leak into the typed trio.
+    assert parsed["temp_core"] == 37.0
+    assert "temp_hotspot" not in parsed
+    assert "temp_memory" not in parsed
     assert parsed["power_w"] == 1.0
 
 


### PR DESCRIPTION
Extracted from #267 as the TUI live-metrics child PR.

Depends on #275 (`split/thermal-channels`).

Expands pynvoc status normalization with utilization, VRAM, cooler, PCIe width, P-state, and perf-limit fields. Moves dashboard line construction into a Textual-free formatter and renders the new LOAD/VRAM/FAN/PCIE/PSTATE/PERF rows with focused tests. Also adapts the core temperature reading to the RTSS float schema from #275.

Validation:
- `cd tui && uv run --python 3.13 pytest` (48 passed; builds the pynvoc extension)
- `cargo check --package pynvoc`
- `cargo clippy --package pynvoc --lib -- -D warnings`

A direct `cargo test --package pynvoc` is not usable on this host because the test binary is not linked to libpython; the maturin/uv extension build and full TUI test suite pass. No GPU writes were executed.