### PR TITLE
feat(tui): render expanded live GPU metrics

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -796,6 +796,17 @@ fn format_sensor_descriptor(
     if let Some(chan) = descriptor.get("channel_num") {
         lines.push(field("channel_num", chan));
     }
+    // Cross-reference to the raw sibling channel: RTSS exposes two channels
+    // per physical sensor — `(dev, 0)` raw and `(dev, 1)` with `offset_hw`
+    // already applied by the driver. Annotate the `(dev, 1)` half.
+    if let Some(sibling) = descriptor.get("same_sensor_as").and_then(Value::as_i64) {
+        lines.push(format!(
+            "{}{}: ch[{}] with offset_hw",
+            indent_spaces(indent),
+            nvoc_cli_common::color::stylize_title("Same Sensor As"),
+            nvoc_cli_common::color::stylize(&sibling.to_string(), false)
+        ));
+    }
     // RTSS ThermChannel metadata (research fields from GetInfo). channel_type
     // gets a human tag; offsets/scaling are shown raw (semantics undocumented).
     if let Some(ch_type) = descriptor.get("channel_type").and_then(Value::as_i64) {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -798,6 +798,31 @@ fn format_sensor_descriptor(
     if let Some(mask) = descriptor.get("sensor_mask_number") {
         lines.push(field("sensor_mask_number", mask));
     }
+    // RTSS ThermChannel metadata (research fields from GetInfo). channel_type
+    // gets a human tag; offsets/scaling are shown raw (semantics undocumented).
+    if let Some(ch_type) = descriptor.get("channel_type").and_then(Value::as_i64) {
+        let tag = match ch_type {
+            0 => " (GPU_AVG)",
+            1 => " (GPU_MAX)",
+            2 => " (BOARD)",
+            3 => " (MEMORY)",
+            4 => " (PWR_SUPPLY)",
+            255 => " (unclassified)",
+            _ => "",
+        };
+        lines.push(format!(
+            "{}{}: {}{}",
+            indent_spaces(indent),
+            nvoc_cli_common::color::stylize_title("Channel Type"),
+            nvoc_cli_common::color::stylize(&ch_type.to_string(), false),
+            tag
+        ));
+    }
+    for key in ["offset_sw", "offset_hw", "scaling"] {
+        if let Some(val) = descriptor.get(key) {
+            lines.push(field(key, val));
+        }
+    }
     lines
 }
 
@@ -1027,7 +1052,7 @@ mod tests {
                     {
                         "target": "Gpu",
                         "name": "Core",
-                        "sensor_mask_number": 8,
+                        "sensor_mask_number": 0,
                         "range": { "max": 139, "min": -35 }
                     },
                     52.58203125
@@ -1049,7 +1074,7 @@ mod tests {
         // Sensors: target dropped, temperature gets a C unit.
         assert!(!rendered.contains("Target"));
         assert!(rendered.contains("Name: Core"));
-        assert!(rendered.contains("Sensor Mask Number: 8"));
+        assert!(rendered.contains("Sensor Mask Number: 0"));
         assert!(rendered.contains("Range: Max 139 C, Min -35 C"));
         assert!(rendered.contains("- 52.58203125 C"));
     }
@@ -1065,7 +1090,7 @@ mod tests {
                     {
                         "target": "Gpu",
                         "name": "Hot Spot",
-                        "sensor_mask_number": 9,
+                        "sensor_mask_number": 1,
                         "range": { "max": 0, "min": 0 }
                     },
                     78.5

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -753,10 +753,11 @@ fn format_sensors_array(indent: usize, items: &[Value]) -> Vec<String> {
 }
 
 /// Render a sensor descriptor (everything except `target`) as indented fields.
-/// `name` and `sensor_mask_number` are emitted verbatim; `range` is a
+/// `channel_num` is emitted verbatim; `channel_type` gets a human tag
+/// (GPU_AVG/GPU_MAX/BOARD/MEMORY/PWR_SUPPLY/unclassified); `range` is a
 /// temperature limit shown as `Max N C, Min N C`, skipped when it is `{0, 0}`
-/// (the undocumented thermal-sensors API reports no limits for hot-spot /
-/// memory sensors, so a zero range carries no information).
+/// (the RTSS GetInfo record may report no limits for a channel, so a zero
+/// range carries no information).
 fn format_sensor_descriptor(
     indent: usize,
     descriptor: &serde_json::Map<String, Value>,
@@ -771,9 +772,6 @@ fn format_sensor_descriptor(
     };
 
     let mut lines = Vec::new();
-    if let Some(name) = descriptor.get("name") {
-        lines.push(field("name", name));
-    }
     if let Some(range) = descriptor.get("range").and_then(Value::as_object) {
         let max = range.get("max").and_then(Value::as_f64);
         let min = range.get("min").and_then(Value::as_f64);
@@ -795,8 +793,8 @@ fn format_sensor_descriptor(
             ));
         }
     }
-    if let Some(mask) = descriptor.get("sensor_mask_number") {
-        lines.push(field("sensor_mask_number", mask));
+    if let Some(chan) = descriptor.get("channel_num") {
+        lines.push(field("channel_num", chan));
     }
     // RTSS ThermChannel metadata (research fields from GetInfo). channel_type
     // gets a human tag; offsets/scaling are shown raw (semantics undocumented).
@@ -1051,8 +1049,8 @@ mod tests {
                 [
                     {
                         "target": "Gpu",
-                        "name": "Core",
-                        "sensor_mask_number": 0,
+                        "channel_num": 0,
+                        "channel_type": 0,
                         "range": { "max": 139, "min": -35 }
                     },
                     52.58203125
@@ -1071,10 +1069,12 @@ mod tests {
         assert!(rendered.contains("Shared: 32573.785 MB"));
         assert!(rendered.contains("Dedicated Evictions: 0"));
         assert!(!rendered.contains("Dedicated: 8384512"));
-        // Sensors: target dropped, temperature gets a C unit.
+        // Sensors: target dropped, classified by channel type (no Name line),
+        // temperature gets a C unit.
         assert!(!rendered.contains("Target"));
-        assert!(rendered.contains("Name: Core"));
-        assert!(rendered.contains("Sensor Mask Number: 0"));
+        assert!(!rendered.contains("Name:"));
+        assert!(rendered.contains("Channel Num: 0"));
+        assert!(rendered.contains("Channel Type: 0 (GPU_AVG)"));
         assert!(rendered.contains("Range: Max 139 C, Min -35 C"));
         assert!(rendered.contains("- 52.58203125 C"));
     }
@@ -1082,15 +1082,15 @@ mod tests {
     #[test]
     fn human_output_hides_zero_sensor_range() {
         nvoc_cli_common::color::init(true);
-        // Undocumented sensors (hot spot / memory junction) carry no limit data,
-        // so their range is {0, 0}; that uninformative line is suppressed.
+        // A channel whose GetInfo record reports no limit data has range
+        // {0, 0}; that uninformative line is suppressed.
         let output = json!({
             "sensors": [
                 [
                     {
                         "target": "Gpu",
-                        "name": "Hot Spot",
-                        "sensor_mask_number": 1,
+                        "channel_num": 1,
+                        "channel_type": 1,
                         "range": { "max": 0, "min": 0 }
                     },
                     78.5
@@ -1100,10 +1100,11 @@ mod tests {
 
         let rendered = format_human_output("get-status", &output).join("\n");
 
-        assert!(rendered.contains("Name: Hot Spot"));
+        assert!(rendered.contains("Channel Type: 1 (GPU_MAX)"));
         assert!(rendered.contains("- 78.5 C"));
         assert!(!rendered.contains("Range"));
         assert!(!rendered.contains("Target"));
+        assert!(!rendered.contains("Name:"));
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ pub use gpu::GpuSelector;
 pub use gpu_type::{
     ArchOcPrior, GpuOcParams, GpuType, GpuVoltageLimitParams, GpuVoltageLockParams, OcPriorPoint,
 };
-pub use nvapi::{CoolerTarget, GpuTdpTempLimits, ThermalSensors, VfpLockRequest};
+pub use nvapi::{CoolerTarget, GpuTdpTempLimits, VfpLockRequest};
 pub use operation::{
     CheckVoltageFrequency, ClearEdid, GpuOperation, ProbeVoltageLimits, QueryApiRestriction,
     QueryAutoBoost, QueryClockOffset, QueryDisplays, QueryDomainVfpIndices, QueryDomainVfpPoints,
@@ -34,8 +34,8 @@ pub use operation::{
     detect_gpu_type, fetch_gpu_type, find_matching_vfp_point, legacy_core_overvolt_ranges,
     legacy_p0_core_max_voltage_delta, nvml_pstate_to_index, nvml_pstate_to_str,
     parse_nvapi_locked_voltage_target, parse_nvml_fan_control_policy, parse_nvml_pstate,
-    probe_thermal_sensors_mask, query_domain_vf_points_indexed, query_domain_vfp_indices,
-    read_thermal_sensors, run, run_many, set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas,
+    query_domain_vf_points_indexed, query_domain_vfp_indices,
+    run, run_many, set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas,
     set_nvapi_legacy_clocks, set_nvapi_pstate_clock_offsets, set_nvapi_vfp_curve_delta,
     sync_memory_pstate_as_p0, try_parse_nvml_pstate,
 };

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,10 +34,10 @@ pub use operation::{
     detect_gpu_type, fetch_gpu_type, find_matching_vfp_point, legacy_core_overvolt_ranges,
     legacy_p0_core_max_voltage_delta, nvml_pstate_to_index, nvml_pstate_to_str,
     parse_nvapi_locked_voltage_target, parse_nvml_fan_control_policy, parse_nvml_pstate,
-    query_domain_vf_points_indexed, query_domain_vfp_indices,
-    run, run_many, set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas,
-    set_nvapi_legacy_clocks, set_nvapi_pstate_clock_offsets, set_nvapi_vfp_curve_delta,
-    sync_memory_pstate_as_p0, try_parse_nvml_pstate,
+    query_domain_vf_points_indexed, query_domain_vfp_indices, run, run_many,
+    set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas, set_nvapi_legacy_clocks,
+    set_nvapi_pstate_clock_offsets, set_nvapi_vfp_curve_delta, sync_memory_pstate_as_p0,
+    try_parse_nvml_pstate,
 };
 pub use result::{
     ApiRestrictionState, AppliedValue, AutoBoostState, BatchReport, ClockOffset, DisplayInfo,

--- a/core/src/nvapi.rs
+++ b/core/src/nvapi.rs
@@ -7,7 +7,6 @@ use super::nvml::{
 };
 use super::result::PstateBaseVoltage;
 use super::types::{NvapiLockedVoltageTarget, VfpResetDomain};
-pub use nvapi_hi::ThermalSensors;
 use nvapi_hi::nvapi::{CelsiusShifted, DisplayIdsFlags, VoltageDomain};
 use nvapi_hi::{
     Celsius, ClockDomain, ClockLockEntry, ClockLockValue, ConnectedIdsFlags, CoolerPolicy,
@@ -1290,20 +1289,4 @@ pub fn set_legacy_clocks_nvapi(gpu: &Gpu, core_mhz: u32, mem_mhz: u32) -> Result
     }
 
     Ok(())
-}
-
-pub(crate) fn probe_thermal_sensors_mask(gpu: &Gpu) -> Result<i32, Error> {
-    for i in 0..32 {
-        let mask: i32 = 1 << i;
-        if let Ok(sensors) = gpu.thermal_sensors(mask)
-            && sensors.values.iter().any(|&v| v != 0)
-        {
-            return Ok(mask);
-        }
-    }
-    Err(Error::Str("no valid NVAPI thermal sensor mask found"))
-}
-
-pub(crate) fn read_thermal_sensors(gpu: &Gpu, mask: i32) -> Result<ThermalSensors, Error> {
-    gpu.thermal_sensors(mask).map_err(Error::from)
 }

--- a/core/src/operation.rs
+++ b/core/src/operation.rs
@@ -1484,17 +1484,6 @@ pub fn percentage(value: u32) -> Percentage {
     Percentage(value)
 }
 
-pub fn probe_thermal_sensors_mask(target: &GpuTarget<'_>) -> Result<i32, Error> {
-    low_nvapi::probe_thermal_sensors_mask(target.nvapi()?)
-}
-
-pub fn read_thermal_sensors(
-    target: &GpuTarget<'_>,
-    mask: i32,
-) -> Result<nvapi_hi::ThermalSensors, Error> {
-    low_nvapi::read_thermal_sensors(target.nvapi()?, mask)
-}
-
 pub fn set_nvapi_vfp_curve_delta(
     target: &GpuTarget<'_>,
     point: usize,

--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -504,3 +504,31 @@ fn nvapi_vf_check_bad_point() {
     let target = first_target(&inv);
     assert!(run(&target, CheckVoltageFrequency { point: usize::MAX }).is_err());
 }
+
+#[test]
+#[ignore]
+fn nvapi_thermal_channels_have_core_first_and_unique_indices() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    if !target.has_nvapi() {
+        return;
+    }
+
+    let status = run(&target, QueryGpuStatus)
+        .expect("GPU status should include best-effort thermal channels")
+        .output;
+    let (core, _) = status
+        .sensors
+        .first()
+        .expect("at least the GPU average thermal channel should be present");
+    assert_eq!(core.channel_type, Some(0), "GPU_AVG must remain first");
+
+    let mut channels = status
+        .sensors
+        .iter()
+        .filter_map(|(sensor, _)| sensor.channel_num)
+        .collect::<Vec<_>>();
+    channels.sort_unstable();
+    channels.dedup();
+    assert_eq!(channels.len(), status.sensors.len());
+}

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -494,6 +494,52 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
             break;
         }
     }
+
+    // Per-domain utilization %: { Graphics, FrameBuffer(=memory controller),
+    // VideoEngine, BusInterface }. Serialized verbatim (matches get-status JSON).
+    if let Ok(v) = serde_json::to_value(&status.utilization)
+        && !v.is_null()
+    {
+        map.insert("utilization".into(), v);
+    }
+
+    // VRAM (KiB): used = dedicated - dedicated_available_current.
+    if let Some(mem) = status.memory {
+        let total = mem.dedicated.0;
+        let free = mem.dedicated_available_current.0;
+        let used = total.saturating_sub(free);
+        map.insert(
+            "vram".into(),
+            value_object([
+                ("total_kib", u64_value(total as u64)),
+                ("used_kib", u64_value(used as u64)),
+                ("free_kib", u64_value(free as u64)),
+                ("shared_kib", u64_value(mem.shared.0 as u64)),
+            ]),
+        );
+    }
+
+    // Per-cooler fan status (rpm + level % + active), serialized verbatim.
+    if let Ok(v) = serde_json::to_value(&status.coolers)
+        && !v.is_null()
+    {
+        map.insert("coolers".into(), v);
+    }
+
+    // PCIe link width (downstream lane count).
+    if let Some(lanes) = status.pcie_lanes {
+        map.insert("pcie_lanes".into(), u64_value(lanes as u64));
+    }
+
+    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle reasons).
+    map.insert(
+        "perf".into(),
+        value_object([
+            ("unknown", u64_value(status.perf.unknown as u64)),
+            ("limits", u64_value(status.perf.limits.bits() as u64)),
+        ]),
+    );
+
     Ok(Value::Object(map))
 }
 

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -477,7 +477,7 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         }
     }
     if let Some((_sensor, temp)) = status.sensors.first() {
-        map.insert("temperature_c".into(), f64_value(temp.0 as f64));
+        map.insert("temperature_c".into(), f64_value(*temp as f64));
     }
     if let Some((_channel, power)) = status.power.iter().next()
         && let Some(watts) = first_number_in_display(power)

--- a/tui/nvoc_tui/controllers/dashboard.py
+++ b/tui/nvoc_tui/controllers/dashboard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from rich.text import Text
 from textual.widgets import Button, Input, Static
 
+from ..metrics_format import _format_metric_lines
 from ..widgets import mnemonic_text
 from .base import PaneController
 
@@ -52,23 +53,7 @@ class DashboardController(PaneController):
         info = self.app.cache.info
         status = self.app.cache.status
         architecture = info.get("arch") or info.get("codename") or "---"
-        if status.get("vfp_locked"):
-            lock_mv = status.get("vfp_lock_mv")
-            if isinstance(lock_mv, (int, float)):
-                vfp_lock_text = f"ON ({lock_mv} mV)"
-            else:
-                vfp_lock_text = "ON"
-        else:
-            vfp_lock_text = "OFF"
-        lines = [
-            f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
-            f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
-            f"VOLT: {status.get('voltage_mv', '---')} mV",
-            f"VFP LOCK: {vfp_lock_text}",
-            f"TEMP: {status.get('temperature_c', '---')} C",
-            f"PWR: {status.get('power_w', '---')} W",
-            f"ARCH: {architecture}",
-        ]
+        lines = _format_metric_lines(status, architecture)
         self.app.query_one("#metrics", Static).update("\n".join(lines))
 
     def activate_button(self, button_id: str) -> bool:

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+# Pure formatting helpers for the dashboard metrics panel. Kept separate from
+# the Textual controller so they can be unit-tested without a widget app.
+
+
+def _temp_c_str(value) -> str:
+    """Format a temperature for display as a rounded integer (°C)."""
+    if value is None:
+        return "---"
+    try:
+        return f"{round(float(value))}"
+    except (TypeError, ValueError):
+        return "---"
+
+
+def _format_metric_lines(status: dict, architecture: str) -> list[str]:
+    """Build the dashboard metric lines from a normalized status dict.
+
+    `status` is the pynvoc `query_status` output (see ``normalize_status`` in
+    ``nvoc-python/src/lib.rs``). Missing fields render as ``---``.
+    """
+    if status.get("vfp_locked"):
+        lock_mv = status.get("vfp_lock_mv")
+        if isinstance(lock_mv, (int, float)):
+            vfp_lock_text = f"ON ({lock_mv} mV)"
+        else:
+            vfp_lock_text = "ON"
+    else:
+        vfp_lock_text = "OFF"
+
+    util = status.get("utilization") or {}
+
+    def _pct(key: str) -> str:
+        value = util.get(key)
+        return f"{round(float(value))}%" if isinstance(value, (int, float)) else "---"
+
+    load_text = " | ".join(
+        [
+            f"GPU {_pct('Graphics')}",
+            # FrameBuffer is NVAPI's name for the memory-controller utilization domain.
+            f"MC {_pct('FrameBuffer')}",
+            f"VEN {_pct('VideoEngine')}",
+            f"BUS {_pct('BusInterface')}",
+        ]
+    )
+
+    vram = status.get("vram") or {}
+
+    def _vram_gb(key: str) -> float | None:
+        value = vram.get(key)
+        if not isinstance(value, (int, float)):
+            return None
+        return float(value) / (1024.0 * 1024.0)
+
+    used_gb = _vram_gb("used_kib")
+    total_gb = _vram_gb("total_kib")
+    vram_text = (
+        f"{used_gb:.1f} / {total_gb:.1f} GB"
+        if used_gb is not None and total_gb is not None
+        else "---"
+    )
+
+    coolers = status.get("coolers") or {}
+    valid_coolers = [
+        (cid, c) for cid, c in sorted(coolers.items()) if isinstance(c, dict)
+    ]
+    fan_parts: list[str] = []
+    for idx, (_, cooler) in enumerate(valid_coolers, start=1):
+        rpm = cooler.get("current_tach")
+        level = cooler.get("current_level")
+        rpm_s = f"{round(float(rpm))}" if isinstance(rpm, (int, float)) else "---"
+        level_s = (
+            f"{round(float(level))}%" if isinstance(level, (int, float)) else "---"
+        )
+        label = "FAN" if len(valid_coolers) == 1 else f"FAN{idx}"
+        fan_parts.append(f"{label}: {rpm_s} RPM @ {level_s}")
+    fan_text = " | ".join(fan_parts) if fan_parts else "---"
+
+    lanes = status.get("pcie_lanes")
+    pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
+
+    perf = status.get("perf") or {}
+    perf_limits = perf.get("limits") if isinstance(perf, dict) else None
+    perf_text = (
+        f"0x{int(perf_limits):x}" if isinstance(perf_limits, (int, float)) else "---"
+    )
+
+    return [
+        f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
+        f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
+        f"VOLT: {status.get('voltage_mv', '---')} mV",
+        f"VFP LOCK: {vfp_lock_text}",
+        f"TEMP: {_temp_c_str(status.get('temperature_c'))} C",
+        f"PWR: {status.get('power_w', '---')} W",
+        f"LOAD: {load_text}",
+        f"VRAM: {vram_text}",
+        f"FAN: {fan_text}",
+        f"PCIE: {pcie_text}",
+        f"PSTATE: {status.get('pstate', '---')}",
+        f"PERF: {perf_text}",
+        f"ARCH: {architecture}",
+    ]

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -35,15 +35,13 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
         value = util.get(key)
         return f"{round(float(value))}%" if isinstance(value, (int, float)) else "---"
 
-    load_text = " | ".join(
-        [
-            f"GPU {_pct('Graphics')}",
-            # FrameBuffer is NVAPI's name for the memory-controller utilization domain.
-            f"MC {_pct('FrameBuffer')}",
-            f"VEN {_pct('VideoEngine')}",
-            f"BUS {_pct('BusInterface')}",
-        ]
-    )
+    load_text = " | ".join([
+        f"GPU {_pct('Graphics')}",
+        # FrameBuffer is NVAPI's name for the memory-controller utilization domain.
+        f"MC {_pct('FrameBuffer')}",
+        f"VEN {_pct('VideoEngine')}",
+        f"BUS {_pct('BusInterface')}",
+    ])
 
     vram = status.get("vram") or {}
 

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -1,0 +1,70 @@
+from nvoc_tui.metrics_format import _format_metric_lines
+
+
+def test_format_metric_lines_full() -> None:
+    status = {
+        "gpu_clock_mhz": 1800,
+        "mem_clock_mhz": 7500,
+        "voltage_mv": 950,
+        "temperature_c": 62.4,
+        "power_w": 132,
+        "pstate": "P0",
+        "utilization": {
+            "Graphics": 100,
+            "FrameBuffer": 0,
+            "VideoEngine": 12,
+            "BusInterface": 2,
+        },
+        "vram": {
+            # 8 GiB total, 2 GiB used (KiB).
+            "total_kib": 8_388_608,
+            "used_kib": 2_097_152,
+            "free_kib": 6_291_456,
+            "shared_kib": 0,
+        },
+        "coolers": {
+            "Cooler1": {"current_level": 45, "current_tach": 1234, "active": True},
+        },
+        "pcie_lanes": 16,
+        "perf": {"unknown": 0, "limits": 64},
+    }
+
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+
+    assert "GPU: 1800 MHz" in text
+    assert "MEM: 7500 MHz" in text
+    assert "VOLT: 950 mV" in text
+    assert "TEMP: 62 C" in text
+    assert "PWR: 132 W" in text
+    assert "PSTATE: P0" in text
+    assert "LOAD: GPU 100% | MC 0% | VEN 12% | BUS 2%" in text
+    assert "VRAM: 2.0 / 8.0 GB" in text
+    assert "FAN: 1234 RPM @ 45%" in text
+    assert "PCIE: x16" in text
+    assert "PERF: 0x40" in text
+    assert "ARCH: Ada" in text
+
+
+def test_format_metric_lines_missing_fields_render_dashes() -> None:
+    text = "\n".join(_format_metric_lines({}, "---"))
+
+    assert "LOAD: GPU --- | MC --- | VEN --- | BUS ---" in text
+    assert "VRAM: ---" in text
+    assert "FAN: ---" in text
+    assert "PCIE: ---" in text
+    assert "PSTATE: ---" in text
+    assert "PERF: ---" in text
+
+
+def test_format_metric_lines_multi_cooler_labels() -> None:
+    status = {
+        "coolers": {
+            "Cooler1": {"current_level": 30, "current_tach": 1000, "active": True},
+            "Cooler2": {"current_level": 50, "current_tach": 2000, "active": True},
+        }
+    }
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    assert "FAN1: 1000 RPM @ 30%" in text
+    assert "FAN2: 2000 RPM @ 50%" in text


### PR DESCRIPTION
Replacement for #276, which was merged into its intermediate base branch rather than into `main`.

Extracted from #267 as the TUI live-metrics child PR.

Depends on #275 (`split/thermal-channels`).

Expands pynvoc status normalization with utilization, VRAM, cooler, PCIe width, P-state, and perf-limit fields. Moves dashboard line construction into a Textual-free formatter and renders the new LOAD/VRAM/FAN/PCIE/PSTATE/PERF rows with focused tests. It also adapts the core-temperature reading to the RTSS float schema from #275.

Validation after rebuilding on current `main`:
- `cargo fmt --all -- --check`
- `cargo build --workspace --exclude cli-stressor-cuda-rs`
- covered by the stack-tip TUI suite (`54 passed`)

No GPU writes were executed.