### PR TITLE
feat(tui): show core, hotspot, and memory temperatures

### DIFF
--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -480,15 +480,31 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         map.insert("temperature_c".into(), f64_value(*temp as f64));
     }
     // Full thermal-sensor list as `[descriptor, temp_celsius]` pairs (same shape
-    // as get-status JSON). Downstream consumers (the TUI dashboard) read the
-    // typed channels (channel_type 0=core / 1=hot spot / 3=memory) from this to
-    // render the core/hotspot/VRAM temperatures; `temperature_c` above is kept
-    // as the positional core fallback.
-    if !status.sensors.is_empty()
-        && let Ok(v) = serde_json::to_value(&status.sensors)
-        && !v.is_null()
-    {
-        map.insert("sensors".into(), v);
+    // as get-status JSON), plus the three primary typed temperatures pulled out
+    // by channel_type (0=GPU_AVG/core, 1=GPU_MAX/hot spot, 3=MEMORY/VRAM). The
+    // TUI dashboard reads temp_core/temp_hotspot/temp_memory directly (the
+    // native path bypasses normalize_query_output, so it cannot re-parse the
+    // sensors array itself); `temperature_c` above stays as the core fallback.
+    if !status.sensors.is_empty() {
+        if let Ok(v) = serde_json::to_value(&status.sensors)
+            && !v.is_null()
+        {
+            map.insert("sensors".into(), v);
+        }
+        for (desc, temp) in &status.sensors {
+            match desc.channel_type {
+                Some(0) if !map.contains_key("temp_core") => {
+                    map.insert("temp_core".into(), f64_value(*temp as f64));
+                }
+                Some(1) if !map.contains_key("temp_hotspot") => {
+                    map.insert("temp_hotspot".into(), f64_value(*temp as f64));
+                }
+                Some(3) if !map.contains_key("temp_memory") => {
+                    map.insert("temp_memory".into(), f64_value(*temp as f64));
+                }
+                _ => {}
+            }
+        }
     }
     if let Some((_channel, power)) = status.power.iter().next()
         && let Some(watts) = first_number_in_display(power)

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -479,6 +479,17 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
     if let Some((_sensor, temp)) = status.sensors.first() {
         map.insert("temperature_c".into(), f64_value(*temp as f64));
     }
+    // Full thermal-sensor list as `[descriptor, temp_celsius]` pairs (same shape
+    // as get-status JSON). Downstream consumers (the TUI dashboard) read the
+    // typed channels (channel_type 0=core / 1=hot spot / 3=memory) from this to
+    // render the core/hotspot/VRAM temperatures; `temperature_c` above is kept
+    // as the positional core fallback.
+    if !status.sensors.is_empty()
+        && let Ok(v) = serde_json::to_value(&status.sensors)
+        && !v.is_null()
+    {
+        map.insert("sensors".into(), v);
+    }
     if let Some((_channel, power)) = status.power.iter().next()
         && let Some(watts) = first_number_in_display(power)
     {

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -89,7 +89,7 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     # adapts to whatever channels are available.
     temp_parts = [f"CORE {_temp_c_str(status.get('temperature_c'))} C"]
     if isinstance(status.get("temp_hotspot"), (int, float)):
-        temp_parts.append(f"HOT {_temp_c_str(status['temp_hotspot'])} C")
+        temp_parts.append(f"HOTSPOT {_temp_c_str(status['temp_hotspot'])} C")
     if isinstance(status.get("temp_memory"), (int, float)):
         temp_parts.append(f"MEM {_temp_c_str(status['temp_memory'])} C")
     temp_text = " | ".join(temp_parts)

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -84,12 +84,22 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
         f"0x{int(perf_limits):x}" if isinstance(perf_limits, (int, float)) else "---"
     )
 
+    # Thermal sensors: core (GPU_AVG) is always shown; hot spot (GPU_MAX) and
+    # memory/VRAM are appended only when the GPU exposes them, so the line
+    # adapts to whatever channels are available.
+    temp_parts = [f"CORE {_temp_c_str(status.get('temperature_c'))} C"]
+    if isinstance(status.get("temp_hotspot"), (int, float)):
+        temp_parts.append(f"HOT {_temp_c_str(status['temp_hotspot'])} C")
+    if isinstance(status.get("temp_memory"), (int, float)):
+        temp_parts.append(f"MEM {_temp_c_str(status['temp_memory'])} C")
+    temp_text = " | ".join(temp_parts)
+
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
         f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
         f"VOLT: {status.get('voltage_mv', '---')} mV",
         f"VFP LOCK: {vfp_lock_text}",
-        f"TEMP: {_temp_c_str(status.get('temperature_c'))} C",
+        f"TEMP: {temp_text}",
         f"PWR: {status.get('power_w', '---')} W",
         f"LOAD: {load_text}",
         f"VRAM: {vram_text}",

--- a/tui/nvoc_tui/parsing.py
+++ b/tui/nvoc_tui/parsing.py
@@ -78,14 +78,29 @@ def _normalize_status_json(value: dict[str, Any]) -> dict[str, Any]:
 
     sensors = value.get("sensors")
     if isinstance(sensors, list):
+        # Thermal sensors are `[descriptor, temp]` pairs. The descriptor's
+        # `channel_type` identifies the sensor: 0=GPU_AVG (core), 1=GPU_MAX
+        # (hot spot), 3=MEMORY (VRAM). Keep the core temp on `temperature_c`
+        # (positional default — first sensor) and also expose the typed trio
+        # so the dashboard can render whichever are present.
         for entry in sensors:
-            if (
+            if not (
                 isinstance(entry, list)
                 and len(entry) >= 2
                 and isinstance(entry[1], (int, float))
             ):
-                normalized["temperature_c"] = float(entry[1])
-                break
+                continue
+            temp = float(entry[1])
+            if "temperature_c" not in normalized:
+                normalized["temperature_c"] = temp
+            descriptor = entry[0] if isinstance(entry[0], dict) else {}
+            ch_type = descriptor.get("channel_type")
+            if ch_type == 0 and "temp_core" not in normalized:
+                normalized["temp_core"] = temp
+            elif ch_type == 1 and "temp_hotspot" not in normalized:
+                normalized["temp_hotspot"] = temp
+            elif ch_type == 3 and "temp_memory" not in normalized:
+                normalized["temp_memory"] = temp
 
     power = value.get("power")
     if isinstance(power, dict):

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -34,7 +34,7 @@ def test_format_metric_lines_full() -> None:
     assert "GPU: 1800 MHz" in text
     assert "MEM: 7500 MHz" in text
     assert "VOLT: 950 mV" in text
-    assert "TEMP: 62 C" in text
+    assert "TEMP: CORE 62 C" in text
     assert "PWR: 132 W" in text
     assert "PSTATE: P0" in text
     assert "LOAD: GPU 100% | MC 0% | VEN 12% | BUS 2%" in text
@@ -43,6 +43,27 @@ def test_format_metric_lines_full() -> None:
     assert "PCIE: x16" in text
     assert "PERF: 0x40" in text
     assert "ARCH: Ada" in text
+
+
+def test_format_metric_lines_thermal_trio() -> None:
+    status = {
+        "temperature_c": 55,
+        "temp_hotspot": 63.5,
+        "temp_memory": 58,
+    }
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    # All three present — core always shown, hotspot/memory appended in order.
+    assert "TEMP: CORE 55 C | HOT 64 C | MEM 58 C" in text
+
+
+def test_format_metric_lines_core_only_when_no_extra_temps() -> None:
+    text = "\n".join(_format_metric_lines({"temperature_c": 47}, "---"))
+
+    assert "TEMP: CORE 47 C" in text
+    assert "HOT" not in text
+    assert "MEM 47 C" not in text
 
 
 def test_format_metric_lines_missing_fields_render_dashes() -> None:

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -55,7 +55,7 @@ def test_format_metric_lines_thermal_trio() -> None:
     text = "\n".join(_format_metric_lines(status, "---"))
 
     # All three present — core always shown, hotspot/memory appended in order.
-    assert "TEMP: CORE 55 C | HOT 64 C | MEM 58 C" in text
+    assert "TEMP: CORE 55 C | HOTSPOT 64 C | MEM 58 C" in text
 
 
 def test_format_metric_lines_core_only_when_no_extra_temps() -> None:

--- a/tui/tests/test_parsing.py
+++ b/tui/tests/test_parsing.py
@@ -153,8 +153,8 @@ def test_normalize_status_json_output() -> None:
         "sensors": [
           [
             {
-              "controller": "GpuInternal",
-              "target": "Gpu"
+              "target": "Gpu",
+              "channel_type": 0
             },
             37
           ]
@@ -169,6 +169,11 @@ def test_normalize_status_json_output() -> None:
     assert parsed["mem_clock_mhz"] == 405.0
     assert parsed["voltage_mv"] == 650.0
     assert parsed["temperature_c"] == 37.0
+    # Typed core temp mirrors temperature_c (channel_type 0); the unclassified
+    # channel (type 255) must NOT leak into the typed trio.
+    assert parsed["temp_core"] == 37.0
+    assert "temp_hotspot" not in parsed
+    assert "temp_memory" not in parsed
     assert parsed["power_w"] == 1.0
 
 


### PR DESCRIPTION
Replacement for #277, which was merged into its intermediate base branch rather than into `main`.\n\nExtracted from #267 as the focused TUI thermal-display child PR.\n\nDepends on #282 (`split/tui-live-metrics-v2`).\n\nSerializes the full RTSS thermal sensor array from pynvoc, exposes `temp_core`, `temp_hotspot`, and `temp_memory` from channel types 0/1/3, teaches the JSON parser the same mapping, and renders an adaptive `TEMP: CORE ... | HOTSPOT ... | MEM ...` dashboard row. Unsafe NVML live-power polling from the source history remains excluded.\n\nValidation after rebuilding on current `main`:\n- `cargo fmt --all -- --check`\n- `cargo build --workspace --exclude cli-stressor-cuda-rs`\n- `cd tui && uv run pytest` (`50 passed`)\n\nNo GPU writes were executed.