### PR TITLE
feat(monitoring): add read-only PCIe telemetry

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1444,7 +1444,30 @@ fn execute_target(
             let info = run(target, QueryGpuInfo)?.output;
             Ok(Value::String(info.uuid.unwrap_or_default()))
         }
-        Command::GetStatus => Ok(serde_json::to_value(run(target, QueryGpuStatus)?.output)?),
+        Command::GetStatus => {
+            let mut value = serde_json::to_value(run(target, QueryGpuStatus)?.output)?;
+            if let Ok(nvml) = target.nvml()
+                && let Some(map) = value.as_object_mut()
+            {
+                let pcie = nvoc_core::nvml::query_nvml_pcie_telemetry(nvml, target.id.0);
+                if let Some(tx) = pcie.tx_mibps {
+                    map.insert("pcie_tx_mibps".to_string(), json!(tx));
+                }
+                if let Some(rx) = pcie.rx_mibps {
+                    map.insert("pcie_rx_mibps".to_string(), json!(rx));
+                }
+                if let Some(replay) = pcie.replay_counter {
+                    map.insert("pcie_replay_counter".to_string(), json!(replay));
+                }
+                if let Some(generation) = pcie.current_generation {
+                    map.insert("pcie_link_gen".to_string(), json!(generation));
+                }
+                if let Some(generation) = pcie.max_generation {
+                    map.insert("pcie_max_link_gen".to_string(), json!(generation));
+                }
+            }
+            Ok(value)
+        }
         Command::GetSettings => Ok(serde_json::to_value(run(target, QueryGpuSettings)?.output)?),
         Command::GetVfp => get_vfp(target, invocation),
         Command::GetVfpPointVoltageMv => {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -278,6 +278,24 @@ fn format_value_block_with_context(value: &Value, indent: usize, context: &str) 
                         ));
                         lines.extend(format_utilization_entries(indent + 1, child));
                     }
+                    // `perf` carries two raw NVAPI words from PerfPoliciesGetStatus:
+                    // `limits` (a PerfFlags bitmask of throttling reasons) and
+                    // `unknown` (a driver load-level indicator, not an error).
+                    // Both are unreadable as raw ints, so decode them here.
+                    Value::Object(child) if key == "perf" && child.contains_key("limits") => {
+                        lines.push(format!(
+                            "{}{}",
+                            indent_spaces(indent),
+                            nvoc_cli_common::color::stylize_title(&format_label(key))
+                        ));
+                        lines.extend(format_perf_block(indent + 1, child));
+                    }
+                    // `performance_decrease` is the serde form of nvapi-rs's
+                    // `PerformanceDecreaseReason` bitflags struct (`{"bits": N}`);
+                    // decode the bitmask to friendly reason text.
+                    Value::Object(_) if key == "performance_decrease" => {
+                        lines.extend(format_performance_decrease(indent, value));
+                    }
                     Value::Object(child) if key == "memory" && child.contains_key("dedicated") => {
                         lines.push(format!(
                             "{}{}",
@@ -694,6 +712,111 @@ fn format_utilization_entries(
             )
         })
         .collect()
+}
+
+/// NVAPI PerfFlags bit → friendly reason name. Bit semantics mirror
+/// `nvapi-rs/sys/src/gpu/power.rs` (`NV_GPU_PERF_FLAGS` + its display table):
+/// 1 Power, 2 Temperature, 4 Reliability Voltage, 8 Operating Voltage,
+/// 16 No Load, 32 Unknown32. Kept in ascending bit order so the decoded
+/// list reads consistently regardless of which reasons are active.
+const PERF_LIMIT_BITS: &[(u64, &str)] = &[
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+];
+
+/// Extract a bitmask from a JSON value that may be either a raw integer
+/// (`N`, as emitted by pynvoc) or a bitflags object (`{"bits": N}`, as serde
+/// renders nvapi-rs `nvbits!` structs on the CLI's native get-status path).
+fn bitmask_from_value(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(n) => n.as_u64(),
+        Value::Object(obj) => obj.get("bits").and_then(Value::as_u64),
+        _ => None,
+    }
+}
+
+/// Decode the NVAPI perf-policy status (`perf` object from PerfPoliciesGetStatus).
+/// `limits` is a PerfFlags bitmask of active throttling reasons; `unknown` is the
+/// driver's load-status level (1 = on load, 3 = low clocks, 7 = idle — see
+/// `nvapi-rs/sys/src/gpu/power.rs` field comment), not an error/unknown value.
+fn format_perf_block(indent: usize, object: &serde_json::Map<String, Value>) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    let limits_raw = object
+        .get("limits")
+        .and_then(bitmask_from_value)
+        .unwrap_or(0);
+    let reasons: Vec<&str> = PERF_LIMIT_BITS
+        .iter()
+        .filter(|(bit, _)| limits_raw & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    let limits_text = if reasons.is_empty() {
+        "None".to_string()
+    } else {
+        reasons.join(", ")
+    };
+    lines.push(format!(
+        "{}{}: {}",
+        indent_spaces(indent),
+        nvoc_cli_common::color::stylize_title("Limits"),
+        nvoc_cli_common::color::stylize(&limits_text, false)
+    ));
+
+    if let Some(unknown) = object.get("unknown").and_then(Value::as_u64) {
+        let load_text = match unknown {
+            1 => "Load".to_string(),
+            3 => "Low Clock".to_string(),
+            7 => "Idle".to_string(),
+            other => format!("{other} (raw)"),
+        };
+        lines.push(format!(
+            "{}{}: {}",
+            indent_spaces(indent),
+            nvoc_cli_common::color::stylize_title("Load Level"),
+            nvoc_cli_common::color::stylize(&load_text, false)
+        ));
+    }
+
+    lines
+}
+
+/// PerformanceDecreaseReason bits (NVAPI_GPU_PERF_DECREASE, `nvapi-rs/sys/src/
+/// gpu/mod.rs`): 1 Thermal Protection, 2 Power Control, 4 AC-Battery,
+/// 8 API Triggered, 16 Insufficient Power. 0 = none.
+const PERF_DECREASE_BITS: &[(u64, &str)] = &[
+    (1, "Thermal Protection"),
+    (2, "Power Control"),
+    (4, "AC-Battery"),
+    (8, "API Triggered"),
+    (16, "Insufficient Power"),
+];
+
+/// Decode the `performance_decrease` value. On the CLI's native get-status path
+/// serde renders the nvapi-rs `PerformanceDecreaseReason` bitflags struct as
+/// `{"bits": N}`; decode the bitmask into reason names (0 -> "None").
+fn format_performance_decrease(indent: usize, value: &Value) -> Vec<String> {
+    let bits = bitmask_from_value(value).unwrap_or(0);
+    let reasons: Vec<&str> = PERF_DECREASE_BITS
+        .iter()
+        .filter(|(bit, _)| bits & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    let text = if reasons.is_empty() {
+        "None".to_string()
+    } else {
+        reasons.join(", ")
+    };
+    vec![format!(
+        "{}{}: {}",
+        indent_spaces(indent),
+        nvoc_cli_common::color::stylize_title("Performance Decrease"),
+        nvoc_cli_common::color::stylize(&text, false)
+    )]
 }
 
 /// Render the VRAM info map. Size fields are kibibytes -> shown in MB;
@@ -1116,6 +1239,64 @@ mod tests {
         assert!(!rendered.contains("Range"));
         assert!(!rendered.contains("Target"));
         assert!(!rendered.contains("Name:"));
+    }
+
+    #[test]
+    fn human_output_decodes_perf_bitset() {
+        nvoc_cli_common::color::init(true);
+        // On the native get-status path serde renders PerfFlags as `{"bits": N}`;
+        // perf.unknown is a load-level indicator (7 = idle). Both must be decoded,
+        // not shown as raw ints.
+        let output = json!({
+            "perf": { "unknown": 7, "limits": { "bits": 16 } }
+        });
+
+        let rendered = format_human_output("get-status", &output).join("\n");
+
+        assert!(rendered.contains("Limits: No Load"));
+        assert!(rendered.contains("Load Level: Idle"));
+        // Raw-int rendering is gone.
+        assert!(!rendered.contains("Bits: 16"));
+        assert!(!rendered.contains("Unknown"));
+    }
+
+    #[test]
+    fn human_output_decodes_perf_multiple_reasons() {
+        nvoc_cli_common::color::init(true);
+        // limits bits = 3 = POWER_LIMIT(1) | THERMAL_LIMIT(2), decoded in bit
+        // order. The raw-int form (pynvoc path) is also accepted.
+        let rendered_obj = format_human_output(
+            "get-status",
+            &json!({ "perf": { "unknown": 1, "limits": { "bits": 3 } } }),
+        )
+        .join("\n");
+        assert!(rendered_obj.contains("Limits: Power, Temperature"));
+        assert!(rendered_obj.contains("Load Level: Load"));
+
+        let rendered_raw = format_human_output(
+            "get-status",
+            &json!({ "perf": { "unknown": 1, "limits": 3 } }),
+        )
+        .join("\n");
+        assert!(rendered_raw.contains("Limits: Power, Temperature"));
+    }
+
+    #[test]
+    fn human_output_decodes_performance_decrease() {
+        nvoc_cli_common::color::init(true);
+        // bits = 3 = THERMAL_PROTECTION(1) | POWER_CONTROL(2), decoded in bit
+        // order to friendly text on a single line.
+        let output = json!({
+            "performance_decrease": { "bits": 3 }
+        });
+        let rendered = format_human_output("get-status", &output).join("\n");
+        assert!(rendered.contains("Performance Decrease: Thermal Protection, Power Control"));
+
+        // bits = 0 (idle GPU) -> None.
+        let rendered_none =
+            format_human_output("get-status", &json!({ "performance_decrease": { "bits": 0 } }))
+                .join("\n");
+        assert!(rendered_none.contains("Performance Decrease: None"));
     }
 
     #[test]

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1034,6 +1034,8 @@ fn format_with_unit(key: &str, rendered: &str) -> String {
         format!("{rendered}%")
     } else if key.ends_with("_c") || key == "celsius" {
         format!("{rendered} C")
+    } else if key.ends_with("_mibps") {
+        format!("{rendered} MiB/s")
     } else if key == "voltage" {
         // Core voltage is reported in microvolts.
         format!("{rendered} uV")
@@ -1170,6 +1172,8 @@ mod tests {
         let output = json!({
             "voltage": 940000,
             "pcie_lanes": 8,
+            "pcie_tx_mibps": 1234.5,
+            "pcie_rx_mibps": 7.8,
             "memory": {
                 "dedicated": 8384512,
                 "dedicated_available": 8146944,
@@ -1198,6 +1202,8 @@ mod tests {
         assert!(rendered.contains("Voltage: 940000 uV"));
         // PCIe link width gets an `x` prefix.
         assert!(rendered.contains("Pcie Lanes: x8"));
+        assert!(rendered.contains("Pcie Tx Mibps: 1234.5 MiB/s"));
+        assert!(rendered.contains("Pcie Rx Mibps: 7.8 MiB/s"));
         // Memory size fields are KiB -> MB; the eviction *count* has no unit.
         assert!(rendered.contains("Dedicated: 8188 MB"));
         assert!(rendered.contains("Shared: 32573.785 MB"));

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1293,9 +1293,11 @@ mod tests {
         assert!(rendered.contains("Performance Decrease: Thermal Protection, Power Control"));
 
         // bits = 0 (idle GPU) -> None.
-        let rendered_none =
-            format_human_output("get-status", &json!({ "performance_decrease": { "bits": 0 } }))
-                .join("\n");
+        let rendered_none = format_human_output(
+            "get-status",
+            &json!({ "performance_decrease": { "bits": 0 } }),
+        )
+        .join("\n");
         assert!(rendered_none.contains("Performance Decrease: None"));
     }
 

--- a/core/src/nvml.rs
+++ b/core/src/nvml.rs
@@ -2,7 +2,7 @@ use super::conv::{nvml_pstate_to_index, nvml_pstate_to_str};
 use super::error::Error;
 use super::target::GpuId;
 use nvml_wrapper::Nvml;
-use nvml_wrapper::enum_wrappers::device::{Api, PerformanceState};
+use nvml_wrapper::enum_wrappers::device::{Api, PcieUtilCounter, PerformanceState};
 use nvml_wrapper::enums::device::FanControlPolicy;
 
 pub type NvmlPStateClockRange = (PerformanceState, u32, u32, u32, u32);
@@ -62,6 +62,43 @@ pub fn query_nvml_power_watts(nvml: &Nvml, gpu_id: u32) -> Option<(f32, f32, f32
         current_mw as f32 / 1000.0,
         max_mw as f32 / 1000.0,
     ))
+}
+
+/// Read-only PCIe link telemetry available through NVML.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct NvmlPcieTelemetry {
+    /// GPU-to-host throughput, averaged by NVML over its sampling interval.
+    pub tx_mibps: Option<f32>,
+    /// Host-to-GPU throughput, averaged by NVML over its sampling interval.
+    pub rx_mibps: Option<f32>,
+    /// Cumulative transaction replay count since the driver was loaded.
+    pub replay_counter: Option<u32>,
+    /// Currently negotiated PCIe generation.
+    pub current_generation: Option<u32>,
+    /// Maximum PCIe generation exposed by this NVML API.
+    pub max_generation: Option<u32>,
+}
+
+/// Query PCIe throughput, replay count, and link generation without waking or
+/// modifying the GPU. Unsupported counters are returned as `None` individually.
+pub fn query_nvml_pcie_telemetry(nvml: &Nvml, gpu_id: u32) -> NvmlPcieTelemetry {
+    let Some(device) = find_nvml_device(nvml, gpu_id) else {
+        return NvmlPcieTelemetry::default();
+    };
+
+    NvmlPcieTelemetry {
+        tx_mibps: device
+            .pcie_throughput(PcieUtilCounter::Send)
+            .ok()
+            .map(|kbps| kbps as f32 / 1024.0),
+        rx_mibps: device
+            .pcie_throughput(PcieUtilCounter::Receive)
+            .ok()
+            .map(|kbps| kbps as f32 / 1024.0),
+        replay_counter: device.pcie_replay_counter().ok(),
+        current_generation: device.current_pcie_link_gen().ok(),
+        max_generation: device.max_pcie_link_gen().ok(),
+    }
 }
 
 pub fn set_nvml_auto_boost(nvml: &Nvml, gpu_id: u32, enabled: bool) -> Result<(), Error> {

--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -554,3 +554,23 @@ fn nvapi_thermal_channels_have_core_first_and_unique_indices() {
     channels.dedup();
     assert_eq!(channels.len(), status.sensors.len());
 }
+
+#[test]
+#[ignore]
+fn nvapi_effective_clocks_are_positive_when_available() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    if !target.has_nvapi() {
+        return;
+    }
+
+    let status = run(&target, QueryGpuStatus)
+        .expect("GPU status should read effective clocks best-effort")
+        .output;
+    if let Some(clocks) = status.effective_clocks {
+        for frequency in clocks.values() {
+            assert!(frequency.0 > 0);
+            assert!(frequency.0 < 20_000_000);
+        }
+    }
+}

--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -219,6 +219,28 @@ fn nvml_power_ok() {
 
 #[test]
 #[ignore]
+fn nvml_pcie_telemetry_ok() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    let telemetry = nvoc_core::nvml::query_nvml_pcie_telemetry(nvml(&inv), target.id.0);
+
+    for throughput in [telemetry.tx_mibps, telemetry.rx_mibps]
+        .into_iter()
+        .flatten()
+    {
+        assert!(throughput.is_finite());
+        assert!(throughput >= 0.0);
+    }
+    for generation in [telemetry.current_generation, telemetry.max_generation]
+        .into_iter()
+        .flatten()
+    {
+        assert!((1..=7).contains(&generation));
+    }
+}
+
+#[test]
+#[ignore]
 fn nvml_power_bad_gpu() {
     let bad_target = GpuTarget::without_backends(GpuId(INVALID_GPU_ID), 0);
     assert!(run(&bad_target, QueryPowerLimits).is_err());

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -562,6 +562,25 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         map.insert("pcie_lanes".into(), u64_value(lanes as u64));
     }
 
+    if let Ok(nvml) = target.nvml() {
+        let pcie = nvoc_core::nvml::query_nvml_pcie_telemetry(nvml, target.id.0);
+        if let Some(tx) = pcie.tx_mibps {
+            map.insert("pcie_tx_mibps".into(), f64_value(tx as f64));
+        }
+        if let Some(rx) = pcie.rx_mibps {
+            map.insert("pcie_rx_mibps".into(), f64_value(rx as f64));
+        }
+        if let Some(replay) = pcie.replay_counter {
+            map.insert("pcie_replay_counter".into(), u64_value(replay as u64));
+        }
+        if let Some(generation) = pcie.current_generation {
+            map.insert("pcie_link_gen".into(), u64_value(generation as u64));
+        }
+        if let Some(generation) = pcie.max_generation {
+            map.insert("pcie_max_link_gen".into(), u64_value(generation as u64));
+        }
+    }
+
     // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle
     // reasons). `limits_decoded` is the same mask rendered as reason names so
     // consumers (TUI/CLI) don't each have to re-decode the bits.

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -271,6 +271,37 @@ fn bool_value(value: bool) -> Value {
     Value::Bool(value)
 }
 
+/// NVAPI PerfFlags bit -> reason name. Bit semantics mirror nvapi-rs
+/// (`sys/src/gpu/power.rs`, NV_GPU_PERF_FLAGS + its display table). Ascending
+/// bit order so the decoded list reads consistently regardless of active set.
+const PERF_LIMIT_BITS: &[(u32, &str)] = &[
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+];
+
+/// Decode a PerfFlags bitmask into reason names; an empty mask yields `["None"]`.
+fn decode_perf_flags(bits: u32) -> Vec<&'static str> {
+    let reasons: Vec<&'static str> = PERF_LIMIT_BITS
+        .iter()
+        .filter(|(bit, _)| bits & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    if reasons.is_empty() {
+        vec!["None"]
+    } else {
+        reasons
+    }
+}
+
+/// Build a JSON array of strings from the given reason names.
+fn text_array_value(items: Vec<&str>) -> Value {
+    Value::Array(items.into_iter().map(text).collect())
+}
+
 fn percent_value(value: Percentage) -> Value {
     u64_value(value.0 as u64)
 }
@@ -531,12 +562,19 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         map.insert("pcie_lanes".into(), u64_value(lanes as u64));
     }
 
-    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle reasons).
+    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle
+    // reasons). `limits_decoded` is the same mask rendered as reason names so
+    // consumers (TUI/CLI) don't each have to re-decode the bits.
+    let perf_limits_bits = status.perf.limits.bits() as u32;
     map.insert(
         "perf".into(),
         value_object([
             ("unknown", u64_value(status.perf.unknown as u64)),
-            ("limits", u64_value(status.perf.limits.bits() as u64)),
+            ("limits", u64_value(perf_limits_bits as u64)),
+            (
+                "limits_decoded",
+                text_array_value(decode_perf_flags(perf_limits_bits)),
+            ),
         ]),
     );
 

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -507,6 +507,25 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
             _ => {}
         }
     }
+    if let Some(effective) = &status.effective_clocks {
+        for (clock, frequency) in effective {
+            match *clock {
+                ClockDomain::Graphics => {
+                    map.insert(
+                        "eff_gpu_clock_mhz".into(),
+                        f64_value(frequency.0 as f64 / 1000.0),
+                    );
+                }
+                ClockDomain::Memory => {
+                    map.insert(
+                        "eff_mem_clock_mhz".into(),
+                        f64_value(frequency.0 as f64 / 1000.0),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
     if let Some((_sensor, temp)) = status.sensors.first() {
         map.insert("temperature_c".into(), f64_value(*temp as f64));
     }

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -14,6 +14,33 @@ def _temp_c_str(value) -> str:
         return "---"
 
 
+# NVAPI PerfFlags bit -> reason name. Bit semantics mirror nvapi-rs
+# (`sys/src/gpu/power.rs`, NV_GPU_PERF_FLAGS + its display table). Ascending
+# bit order so the decoded list reads consistently regardless of active set.
+_PERF_LIMIT_BITS = [
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+]
+
+
+def _perf_limits_text(perf) -> str:
+    """Decode the NVAPI perf-policy limit bitmask (``perf.limits``) to a
+    comma-separated reason list. ``0`` -> ``none``; missing/non-numeric -> ``---``.
+    """
+    if not isinstance(perf, dict):
+        return "---"
+    limits = perf.get("limits")
+    if not isinstance(limits, (int, float)):
+        return "---"
+    bits = int(limits)
+    reasons = [name for bit, name in _PERF_LIMIT_BITS if bits & bit]
+    return ", ".join(reasons) if reasons else "none"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -79,10 +106,7 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
 
     perf = status.get("perf") or {}
-    perf_limits = perf.get("limits") if isinstance(perf, dict) else None
-    perf_text = (
-        f"0x{int(perf_limits):x}" if isinstance(perf_limits, (int, float)) else "---"
-    )
+    perf_text = _perf_limits_text(perf)
 
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
@@ -96,6 +120,6 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
         f"FAN: {fan_text}",
         f"PCIE: {pcie_text}",
         f"PSTATE: {status.get('pstate', '---')}",
-        f"PERF: {perf_text}",
+        f"PERF LIMIT: {perf_text}",
         f"ARCH: {architecture}",
     ]

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -41,6 +41,15 @@ def _perf_limits_text(perf) -> str:
     return ", ".join(reasons) if reasons else "none"
 
 
+def _format_mibps(value: float) -> str:
+    """Format PCIe throughput using MiB/s or GiB/s."""
+    if value >= 1024.0:
+        return f"{value / 1024.0:.1f} GiB/s"
+    if value >= 10.0:
+        return f"{value:.0f} MiB/s"
+    return f"{value:.1f} MiB/s"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -104,6 +113,32 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
 
     lanes = status.get("pcie_lanes")
     pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
+
+    current_gen = status.get("pcie_link_gen")
+    max_gen = status.get("pcie_max_link_gen")
+    if isinstance(current_gen, (int, float)) and isinstance(max_gen, (int, float)):
+        generation = f"Gen{int(current_gen)}/{int(max_gen)}"
+    elif isinstance(max_gen, (int, float)):
+        generation = f"Gen?/{int(max_gen)}"
+    else:
+        generation = ""
+
+    tx = status.get("pcie_tx_mibps")
+    rx = status.get("pcie_rx_mibps")
+    bandwidth = []
+    if isinstance(tx, (int, float)):
+        bandwidth.append(f"↑{_format_mibps(float(tx))}")
+    if isinstance(rx, (int, float)):
+        bandwidth.append(f"↓{_format_mibps(float(rx))}")
+
+    parts = [
+        part for part in (generation, pcie_text if pcie_text != "---" else "") if part
+    ]
+    parts.extend(bandwidth)
+    replay = status.get("pcie_replay_counter")
+    if isinstance(replay, (int, float)) and replay > 0:
+        parts.append(f"⚠replay {int(replay)}")
+    pcie_text = " ".join(parts) if parts else "---"
 
     perf = status.get("perf") or {}
     perf_text = _perf_limits_text(perf)

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -50,6 +50,18 @@ def _format_mibps(value: float) -> str:
     return f"{value:.1f} MiB/s"
 
 
+def _effective_clocks_text(status: dict) -> str:
+    """Format effective, actually-running clocks when the driver exposes them."""
+    gpu = status.get("eff_gpu_clock_mhz")
+    memory = status.get("eff_mem_clock_mhz")
+    parts = []
+    if isinstance(gpu, (int, float)):
+        parts.append(f"GPU {round(float(gpu))}")
+    if isinstance(memory, (int, float)):
+        parts.append(f"MEM {round(float(memory))}")
+    return " | ".join(parts) + " MHz" if parts else "---"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -146,6 +158,7 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
         f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
+        f"ECLK: {_effective_clocks_text(status)}",
         f"VOLT: {status.get('voltage_mv', '---')} mV",
         f"VFP LOCK: {vfp_lock_text}",
         f"TEMP: {_temp_c_str(status.get('temperature_c'))} C",

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -79,6 +79,17 @@ def test_format_metric_lines_pcie_telemetry_without_lanes() -> None:
     assert "replay" not in text
 
 
+def test_format_metric_lines_effective_clocks() -> None:
+    status = {"eff_gpu_clock_mhz": 1897.5, "eff_mem_clock_mhz": 7500}
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "ECLK: GPU 1898 | MEM 7500 MHz" in text
+
+
+def test_format_metric_lines_effective_clocks_are_optional() -> None:
+    text = "\n".join(_format_metric_lines({"gpu_clock_mhz": 1800}, "Ada"))
+    assert "ECLK: ---" in text
+
+
 def test_format_metric_lines_perf_zero_is_none() -> None:
     # No active limit reason -> "none" (not "0x0").
     text = "\n".join(_format_metric_lines({"perf": {"unknown": 0, "limits": 0}}, "---"))

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -26,6 +26,11 @@ def test_format_metric_lines_full() -> None:
             "Cooler1": {"current_level": 45, "current_tach": 1234, "active": True},
         },
         "pcie_lanes": 16,
+        "pcie_link_gen": 4,
+        "pcie_max_link_gen": 4,
+        "pcie_tx_mibps": 1234.5,
+        "pcie_rx_mibps": 7.8,
+        "pcie_replay_counter": 2,
         "perf": {"unknown": 0, "limits": 32},
     }
 
@@ -40,7 +45,7 @@ def test_format_metric_lines_full() -> None:
     assert "LOAD: GPU 100% | MC 0% | VEN 12% | BUS 2%" in text
     assert "VRAM: 2.0 / 8.0 GB" in text
     assert "FAN: 1234 RPM @ 45%" in text
-    assert "PCIE: x16" in text
+    assert "PCIE: Gen4/4 x16 ↑1.2 GiB/s ↓7.8 MiB/s ⚠replay 2" in text
     # limits = 32 = UNKNOWN_32 bit -> decoded reason name, not raw hex.
     assert "PERF LIMIT: Unknown32" in text
     assert "ARCH: Ada" in text
@@ -52,6 +57,26 @@ def test_format_metric_lines_perf_decodes_multiple_reasons() -> None:
         _format_metric_lines({"perf": {"unknown": 0, "limits": 18}}, "---")
     )
     assert "PERF LIMIT: Temperature, No Load" in text
+
+
+def test_format_metric_lines_pcie_telemetry_is_optional() -> None:
+    text = "\n".join(_format_metric_lines({"pcie_lanes": 8}, "Ada"))
+    assert "PCIE: x8" in text
+    assert "Gen" not in text
+    assert "↑" not in text
+    assert "replay" not in text
+
+
+def test_format_metric_lines_pcie_telemetry_without_lanes() -> None:
+    status = {
+        "pcie_max_link_gen": 5,
+        "pcie_tx_mibps": 0.5,
+        "pcie_rx_mibps": 0.3,
+        "pcie_replay_counter": 0,
+    }
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "PCIE: Gen?/5 ↑0.5 MiB/s ↓0.3 MiB/s" in text
+    assert "replay" not in text
 
 
 def test_format_metric_lines_perf_zero_is_none() -> None:

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -26,7 +26,7 @@ def test_format_metric_lines_full() -> None:
             "Cooler1": {"current_level": 45, "current_tach": 1234, "active": True},
         },
         "pcie_lanes": 16,
-        "perf": {"unknown": 0, "limits": 64},
+        "perf": {"unknown": 0, "limits": 32},
     }
 
     text = "\n".join(_format_metric_lines(status, "Ada"))
@@ -41,8 +41,23 @@ def test_format_metric_lines_full() -> None:
     assert "VRAM: 2.0 / 8.0 GB" in text
     assert "FAN: 1234 RPM @ 45%" in text
     assert "PCIE: x16" in text
-    assert "PERF: 0x40" in text
+    # limits = 32 = UNKNOWN_32 bit -> decoded reason name, not raw hex.
+    assert "PERF LIMIT: Unknown32" in text
     assert "ARCH: Ada" in text
+
+
+def test_format_metric_lines_perf_decodes_multiple_reasons() -> None:
+    # limits = 18 = THERMAL_LIMIT(2) | NO_LOAD_LIMIT(16), decoded in bit order.
+    text = "\n".join(
+        _format_metric_lines({"perf": {"unknown": 0, "limits": 18}}, "---")
+    )
+    assert "PERF LIMIT: Temperature, No Load" in text
+
+
+def test_format_metric_lines_perf_zero_is_none() -> None:
+    # No active limit reason -> "none" (not "0x0").
+    text = "\n".join(_format_metric_lines({"perf": {"unknown": 0, "limits": 0}}, "---"))
+    assert "PERF LIMIT: none" in text
 
 
 def test_format_metric_lines_missing_fields_render_dashes() -> None:
@@ -53,7 +68,7 @@ def test_format_metric_lines_missing_fields_render_dashes() -> None:
     assert "FAN: ---" in text
     assert "PCIE: ---" in text
     assert "PSTATE: ---" in text
-    assert "PERF: ---" in text
+    assert "PERF LIMIT: ---" in text
 
 
 def test_format_metric_lines_multi_cooler_labels() -> None:


### PR DESCRIPTION
Replacement for #279, which was merged into its intermediate base branch rather than into `main`.\n\nExtracted from #267 as a focused read-only PCIe telemetry PR.\n\nDepends on #284 (`split/perf-limit-reasons-v2`).\n\nAdds one best-effort NVML telemetry query for current/max PCIe generation, TX/RX throughput, and the cumulative replay counter. CLI and Python status omit unsupported fields; the TUI renders available values on the existing PCIe row and warns only when the replay counter is nonzero. Effective clocks, private PCIe counters, and all GPU writes remain excluded.\n\nValidation after rebuilding on current `main`:\n- `cargo fmt --all -- --check`\n- `cargo build --workspace --exclude cli-stressor-cuda-rs`\n- `cargo test --package nvoc-core --all-targets`\n- covered by the stack-tip TUI suite (`54 passed`)\n- the hardware-gated read-only PCIe test passed before the rebuild and passed on the rebuilt head\n\nNo GPU writes were executed.