### PR TITLE
feat(monitoring): show effective GPU clocks

### DIFF
--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -554,3 +554,23 @@ fn nvapi_thermal_channels_have_core_first_and_unique_indices() {
     channels.dedup();
     assert_eq!(channels.len(), status.sensors.len());
 }
+
+#[test]
+#[ignore]
+fn nvapi_effective_clocks_are_positive_when_available() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    if !target.has_nvapi() {
+        return;
+    }
+
+    let status = run(&target, QueryGpuStatus)
+        .expect("GPU status should read effective clocks best-effort")
+        .output;
+    if let Some(clocks) = status.effective_clocks {
+        for frequency in clocks.values() {
+            assert!(frequency.0 > 0);
+            assert!(frequency.0 < 20_000_000);
+        }
+    }
+}

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -507,6 +507,25 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
             _ => {}
         }
     }
+    if let Some(effective) = &status.effective_clocks {
+        for (clock, frequency) in effective {
+            match *clock {
+                ClockDomain::Graphics => {
+                    map.insert(
+                        "eff_gpu_clock_mhz".into(),
+                        f64_value(frequency.0 as f64 / 1000.0),
+                    );
+                }
+                ClockDomain::Memory => {
+                    map.insert(
+                        "eff_mem_clock_mhz".into(),
+                        f64_value(frequency.0 as f64 / 1000.0),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
     if let Some((_sensor, temp)) = status.sensors.first() {
         map.insert("temperature_c".into(), f64_value(*temp as f64));
     }

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -50,6 +50,18 @@ def _format_mibps(value: float) -> str:
     return f"{value:.1f} MiB/s"
 
 
+def _effective_clocks_text(status: dict) -> str:
+    """Format effective, actually-running clocks when the driver exposes them."""
+    gpu = status.get("eff_gpu_clock_mhz")
+    memory = status.get("eff_mem_clock_mhz")
+    parts = []
+    if isinstance(gpu, (int, float)):
+        parts.append(f"GPU {round(float(gpu))}")
+    if isinstance(memory, (int, float)):
+        parts.append(f"MEM {round(float(memory))}")
+    return " | ".join(parts) + " MHz" if parts else "---"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -146,6 +158,7 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
         f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
+        f"ECLK: {_effective_clocks_text(status)}",
         f"VOLT: {status.get('voltage_mv', '---')} mV",
         f"VFP LOCK: {vfp_lock_text}",
         f"TEMP: {_temp_c_str(status.get('temperature_c'))} C",

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -79,6 +79,17 @@ def test_format_metric_lines_pcie_telemetry_without_lanes() -> None:
     assert "replay" not in text
 
 
+def test_format_metric_lines_effective_clocks() -> None:
+    status = {"eff_gpu_clock_mhz": 1897.5, "eff_mem_clock_mhz": 7500}
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "ECLK: GPU 1898 | MEM 7500 MHz" in text
+
+
+def test_format_metric_lines_effective_clocks_are_optional() -> None:
+    text = "\n".join(_format_metric_lines({"gpu_clock_mhz": 1800}, "Ada"))
+    assert "ECLK: ---" in text
+
+
 def test_format_metric_lines_perf_zero_is_none() -> None:
     # No active limit reason -> "none" (not "0x0").
     text = "\n".join(_format_metric_lines({"perf": {"unknown": 0, "limits": 0}}, "---"))


### PR DESCRIPTION
Replacement for #281, which was merged into its intermediate base branch rather than into `main`.\n\nExtracted from #267 as a focused effective-clock monitoring PR.\n\nDepends on #286 (`split/pcie-telemetry-v2`) and Skyworks-Neo/nvapi-rs#2. The dependency delta beyond the thermal bindings is clock-only; the source branch experimental PowerMonitor code remains excluded.\n\nReads V2 `NvAPI_GPU_GetAllClocks` effective frequencies, exposes graphics and memory values through Python status, and adds an optional `ECLK` row to the TUI. Existing configured/current clock rows remain unchanged, and unsupported drivers render dashes.\n\nValidation after rebuilding on current `main`:\n- `cargo fmt --all -- --check`\n- `cargo build --workspace --exclude cli-stressor-cuda-rs`\n- `cargo test --package nvoc-core --all-targets`\n- `cd tui && uv run pytest` (`54 passed`)\n- the hardware-gated read-only effective-clock test passed before the rebuild and passed on the rebuilt head\n\nNo GPU writes were executed.