### PR TITLE
feat(monitoring): decode performance-limit reasons

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1303,9 +1303,11 @@ mod tests {
         assert!(rendered.contains("Performance Decrease: Thermal Protection, Power Control"));
 
         // bits = 0 (idle GPU) -> None.
-        let rendered_none =
-            format_human_output("get-status", &json!({ "performance_decrease": { "bits": 0 } }))
-                .join("\n");
+        let rendered_none = format_human_output(
+            "get-status",
+            &json!({ "performance_decrease": { "bits": 0 } }),
+        )
+        .join("\n");
         assert!(rendered_none.contains("Performance Decrease: None"));
     }
 

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -288,6 +288,24 @@ fn format_value_block_with_context(value: &Value, indent: usize, context: &str) 
                         ));
                         lines.extend(format_utilization_entries(indent + 1, child));
                     }
+                    // `perf` carries two raw NVAPI words from PerfPoliciesGetStatus:
+                    // `limits` (a PerfFlags bitmask of throttling reasons) and
+                    // `unknown` (a driver load-level indicator, not an error).
+                    // Both are unreadable as raw ints, so decode them here.
+                    Value::Object(child) if key == "perf" && child.contains_key("limits") => {
+                        lines.push(format!(
+                            "{}{}",
+                            indent_spaces(indent),
+                            nvoc_cli_common::color::stylize_title(&format_label(key))
+                        ));
+                        lines.extend(format_perf_block(indent + 1, child));
+                    }
+                    // `performance_decrease` is the serde form of nvapi-rs's
+                    // `PerformanceDecreaseReason` bitflags struct (`{"bits": N}`);
+                    // decode the bitmask to friendly reason text.
+                    Value::Object(_) if key == "performance_decrease" => {
+                        lines.extend(format_performance_decrease(indent, value));
+                    }
                     Value::Object(child) if key == "memory" && child.contains_key("dedicated") => {
                         lines.push(format!(
                             "{}{}",
@@ -704,6 +722,111 @@ fn format_utilization_entries(
             )
         })
         .collect()
+}
+
+/// NVAPI PerfFlags bit → friendly reason name. Bit semantics mirror
+/// `nvapi-rs/sys/src/gpu/power.rs` (`NV_GPU_PERF_FLAGS` + its display table):
+/// 1 Power, 2 Temperature, 4 Reliability Voltage, 8 Operating Voltage,
+/// 16 No Load, 32 Unknown32. Kept in ascending bit order so the decoded
+/// list reads consistently regardless of which reasons are active.
+const PERF_LIMIT_BITS: &[(u64, &str)] = &[
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+];
+
+/// Extract a bitmask from a JSON value that may be either a raw integer
+/// (`N`, as emitted by pynvoc) or a bitflags object (`{"bits": N}`, as serde
+/// renders nvapi-rs `nvbits!` structs on the CLI's native get-status path).
+fn bitmask_from_value(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(n) => n.as_u64(),
+        Value::Object(obj) => obj.get("bits").and_then(Value::as_u64),
+        _ => None,
+    }
+}
+
+/// Decode the NVAPI perf-policy status (`perf` object from PerfPoliciesGetStatus).
+/// `limits` is a PerfFlags bitmask of active throttling reasons; `unknown` is the
+/// driver's load-status level (1 = on load, 3 = low clocks, 7 = idle — see
+/// `nvapi-rs/sys/src/gpu/power.rs` field comment), not an error/unknown value.
+fn format_perf_block(indent: usize, object: &serde_json::Map<String, Value>) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    let limits_raw = object
+        .get("limits")
+        .and_then(bitmask_from_value)
+        .unwrap_or(0);
+    let reasons: Vec<&str> = PERF_LIMIT_BITS
+        .iter()
+        .filter(|(bit, _)| limits_raw & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    let limits_text = if reasons.is_empty() {
+        "None".to_string()
+    } else {
+        reasons.join(", ")
+    };
+    lines.push(format!(
+        "{}{}: {}",
+        indent_spaces(indent),
+        nvoc_cli_common::color::stylize_title("Limits"),
+        nvoc_cli_common::color::stylize(&limits_text, false)
+    ));
+
+    if let Some(unknown) = object.get("unknown").and_then(Value::as_u64) {
+        let load_text = match unknown {
+            1 => "Load".to_string(),
+            3 => "Low Clock".to_string(),
+            7 => "Idle".to_string(),
+            other => format!("{other} (raw)"),
+        };
+        lines.push(format!(
+            "{}{}: {}",
+            indent_spaces(indent),
+            nvoc_cli_common::color::stylize_title("Load Level"),
+            nvoc_cli_common::color::stylize(&load_text, false)
+        ));
+    }
+
+    lines
+}
+
+/// PerformanceDecreaseReason bits (NVAPI_GPU_PERF_DECREASE, `nvapi-rs/sys/src/
+/// gpu/mod.rs`): 1 Thermal Protection, 2 Power Control, 4 AC-Battery,
+/// 8 API Triggered, 16 Insufficient Power. 0 = none.
+const PERF_DECREASE_BITS: &[(u64, &str)] = &[
+    (1, "Thermal Protection"),
+    (2, "Power Control"),
+    (4, "AC-Battery"),
+    (8, "API Triggered"),
+    (16, "Insufficient Power"),
+];
+
+/// Decode the `performance_decrease` value. On the CLI's native get-status path
+/// serde renders the nvapi-rs `PerformanceDecreaseReason` bitflags struct as
+/// `{"bits": N}`; decode the bitmask into reason names (0 -> "None").
+fn format_performance_decrease(indent: usize, value: &Value) -> Vec<String> {
+    let bits = bitmask_from_value(value).unwrap_or(0);
+    let reasons: Vec<&str> = PERF_DECREASE_BITS
+        .iter()
+        .filter(|(bit, _)| bits & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    let text = if reasons.is_empty() {
+        "None".to_string()
+    } else {
+        reasons.join(", ")
+    };
+    vec![format!(
+        "{}{}: {}",
+        indent_spaces(indent),
+        nvoc_cli_common::color::stylize_title("Performance Decrease"),
+        nvoc_cli_common::color::stylize(&text, false)
+    )]
 }
 
 /// Render the VRAM info map. Size fields are kibibytes -> shown in MB;
@@ -1126,6 +1249,64 @@ mod tests {
         assert!(!rendered.contains("Range"));
         assert!(!rendered.contains("Target"));
         assert!(!rendered.contains("Name:"));
+    }
+
+    #[test]
+    fn human_output_decodes_perf_bitset() {
+        nvoc_cli_common::color::init(true);
+        // On the native get-status path serde renders PerfFlags as `{"bits": N}`;
+        // perf.unknown is a load-level indicator (7 = idle). Both must be decoded,
+        // not shown as raw ints.
+        let output = json!({
+            "perf": { "unknown": 7, "limits": { "bits": 16 } }
+        });
+
+        let rendered = format_human_output("get-status", &output).join("\n");
+
+        assert!(rendered.contains("Limits: No Load"));
+        assert!(rendered.contains("Load Level: Idle"));
+        // Raw-int rendering is gone.
+        assert!(!rendered.contains("Bits: 16"));
+        assert!(!rendered.contains("Unknown"));
+    }
+
+    #[test]
+    fn human_output_decodes_perf_multiple_reasons() {
+        nvoc_cli_common::color::init(true);
+        // limits bits = 3 = POWER_LIMIT(1) | THERMAL_LIMIT(2), decoded in bit
+        // order. The raw-int form (pynvoc path) is also accepted.
+        let rendered_obj = format_human_output(
+            "get-status",
+            &json!({ "perf": { "unknown": 1, "limits": { "bits": 3 } } }),
+        )
+        .join("\n");
+        assert!(rendered_obj.contains("Limits: Power, Temperature"));
+        assert!(rendered_obj.contains("Load Level: Load"));
+
+        let rendered_raw = format_human_output(
+            "get-status",
+            &json!({ "perf": { "unknown": 1, "limits": 3 } }),
+        )
+        .join("\n");
+        assert!(rendered_raw.contains("Limits: Power, Temperature"));
+    }
+
+    #[test]
+    fn human_output_decodes_performance_decrease() {
+        nvoc_cli_common::color::init(true);
+        // bits = 3 = THERMAL_PROTECTION(1) | POWER_CONTROL(2), decoded in bit
+        // order to friendly text on a single line.
+        let output = json!({
+            "performance_decrease": { "bits": 3 }
+        });
+        let rendered = format_human_output("get-status", &output).join("\n");
+        assert!(rendered.contains("Performance Decrease: Thermal Protection, Power Control"));
+
+        // bits = 0 (idle GPU) -> None.
+        let rendered_none =
+            format_human_output("get-status", &json!({ "performance_decrease": { "bits": 0 } }))
+                .join("\n");
+        assert!(rendered_none.contains("Performance Decrease: None"));
     }
 
     #[test]

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -271,6 +271,37 @@ fn bool_value(value: bool) -> Value {
     Value::Bool(value)
 }
 
+/// NVAPI PerfFlags bit -> reason name. Bit semantics mirror nvapi-rs
+/// (`sys/src/gpu/power.rs`, NV_GPU_PERF_FLAGS + its display table). Ascending
+/// bit order so the decoded list reads consistently regardless of active set.
+const PERF_LIMIT_BITS: &[(u32, &str)] = &[
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+];
+
+/// Decode a PerfFlags bitmask into reason names; an empty mask yields `["None"]`.
+fn decode_perf_flags(bits: u32) -> Vec<&'static str> {
+    let reasons: Vec<&'static str> = PERF_LIMIT_BITS
+        .iter()
+        .filter(|(bit, _)| bits & bit != 0)
+        .map(|(_, name)| *name)
+        .collect();
+    if reasons.is_empty() {
+        vec!["None"]
+    } else {
+        reasons
+    }
+}
+
+/// Build a JSON array of strings from the given reason names.
+fn text_array_value(items: Vec<&str>) -> Value {
+    Value::Array(items.into_iter().map(text).collect())
+}
+
 fn percent_value(value: Percentage) -> Value {
     u64_value(value.0 as u64)
 }
@@ -577,12 +608,19 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         map.insert("pcie_lanes".into(), u64_value(lanes as u64));
     }
 
-    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle reasons).
+    // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle
+    // reasons). `limits_decoded` is the same mask rendered as reason names so
+    // consumers (TUI/CLI) don't each have to re-decode the bits.
+    let perf_limits_bits = status.perf.limits.bits() as u32;
     map.insert(
         "perf".into(),
         value_object([
             ("unknown", u64_value(status.perf.unknown as u64)),
-            ("limits", u64_value(status.perf.limits.bits() as u64)),
+            ("limits", u64_value(perf_limits_bits as u64)),
+            (
+                "limits_decoded",
+                text_array_value(decode_perf_flags(perf_limits_bits)),
+            ),
         ]),
     );
 

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -26,6 +26,33 @@ def _effective_clocks_text(status: dict) -> str:
     return " | ".join(parts) + " MHz" if parts else "---"
 
 
+# NVAPI PerfFlags bit -> reason name. Bit semantics mirror nvapi-rs
+# (`sys/src/gpu/power.rs`, NV_GPU_PERF_FLAGS + its display table). Ascending
+# bit order so the decoded list reads consistently regardless of active set.
+_PERF_LIMIT_BITS = [
+    (1, "Power"),
+    (2, "Temperature"),
+    (4, "Reliability Voltage"),
+    (8, "Operating Voltage"),
+    (16, "No Load"),
+    (32, "Unknown32"),
+]
+
+
+def _perf_limits_text(perf) -> str:
+    """Decode the NVAPI perf-policy limit bitmask (``perf.limits``) to a
+    comma-separated reason list. ``0`` -> ``none``; missing/non-numeric -> ``---``.
+    """
+    if not isinstance(perf, dict):
+        return "---"
+    limits = perf.get("limits")
+    if not isinstance(limits, (int, float)):
+        return "---"
+    bits = int(limits)
+    reasons = [name for bit, name in _PERF_LIMIT_BITS if bits & bit]
+    return ", ".join(reasons) if reasons else "none"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -91,10 +118,7 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
 
     perf = status.get("perf") or {}
-    perf_limits = perf.get("limits") if isinstance(perf, dict) else None
-    perf_text = (
-        f"0x{int(perf_limits):x}" if isinstance(perf_limits, (int, float)) else "---"
-    )
+    perf_text = _perf_limits_text(perf)
 
     # Thermal sensors: core (GPU_AVG) is always shown; hot spot (GPU_MAX) and
     # memory/VRAM are appended only when the GPU exposes them, so the line
@@ -119,6 +143,6 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
         f"FAN: {fan_text}",
         f"PCIE: {pcie_text}",
         f"PSTATE: {status.get('pstate', '---')}",
-        f"PERF: {perf_text}",
+        f"PERF LIMIT: {perf_text}",
         f"ARCH: {architecture}",
     ]

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -26,7 +26,7 @@ def test_format_metric_lines_full() -> None:
             "Cooler1": {"current_level": 45, "current_tach": 1234, "active": True},
         },
         "pcie_lanes": 16,
-        "perf": {"unknown": 0, "limits": 64},
+        "perf": {"unknown": 0, "limits": 32},
     }
 
     text = "\n".join(_format_metric_lines(status, "Ada"))
@@ -41,7 +41,8 @@ def test_format_metric_lines_full() -> None:
     assert "VRAM: 2.0 / 8.0 GB" in text
     assert "FAN: 1234 RPM @ 45%" in text
     assert "PCIE: x16" in text
-    assert "PERF: 0x40" in text
+    # limits = 32 = UNKNOWN_32 bit -> decoded reason name, not raw hex.
+    assert "PERF LIMIT: Unknown32" in text
     assert "ARCH: Ada" in text
 
 
@@ -77,6 +78,20 @@ def test_format_metric_lines_effective_clocks_are_optional() -> None:
     assert "ECLK: ---" in text
 
 
+def test_format_metric_lines_perf_decodes_multiple_reasons() -> None:
+    # limits = 18 = THERMAL_LIMIT(2) | NO_LOAD_LIMIT(16), decoded in bit order.
+    text = "\n".join(
+        _format_metric_lines({"perf": {"unknown": 0, "limits": 18}}, "---")
+    )
+    assert "PERF LIMIT: Temperature, No Load" in text
+
+
+def test_format_metric_lines_perf_zero_is_none() -> None:
+    # No active limit reason -> "none" (not "0x0").
+    text = "\n".join(_format_metric_lines({"perf": {"unknown": 0, "limits": 0}}, "---"))
+    assert "PERF LIMIT: none" in text
+
+
 def test_format_metric_lines_missing_fields_render_dashes() -> None:
     text = "\n".join(_format_metric_lines({}, "---"))
 
@@ -85,7 +100,7 @@ def test_format_metric_lines_missing_fields_render_dashes() -> None:
     assert "FAN: ---" in text
     assert "PCIE: ---" in text
     assert "PSTATE: ---" in text
-    assert "PERF: ---" in text
+    assert "PERF LIMIT: ---" in text
 
 
 def test_format_metric_lines_multi_cooler_labels() -> None:


### PR DESCRIPTION
Replacement for #284 (and original #278), which was merged into an already-landed intermediate branch rather than into `main`.

This version targets current `main` directly and is independent of the other remaining monitoring PRs.

Decodes NVAPI performance-policy limit bits into stable reason names in Python status output, CLI human output, and the TUI `PERF LIMIT` row. It handles raw integer and `{ "bits": N }` shapes, distinguishes load level from limit reasons, and decodes the separate performance-decrease bitset. PCIe telemetry, effective clocks, PowerMonitor rails, and GPU writes are excluded.

Validation:
- `cargo fmt --all -- --check`
- `cargo build --workspace --exclude cli-stressor-cuda-rs`
- `cd tui && uv run pytest` (`52 passed`)

No GPU writes were executed.