### PR TITLE
feat(monitoring): show effective GPU clocks

### DIFF
--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -552,3 +552,23 @@ fn nvapi_legacy_thermal_settings_have_valid_ranges() {
         assert!(sensor.current_c <= sensor.max_c);
     }
 }
+
+#[test]
+#[ignore]
+fn nvapi_effective_clocks_are_positive_when_available() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    if !target.has_nvapi() {
+        return;
+    }
+
+    let status = run(&target, QueryGpuStatus)
+        .expect("GPU status should read effective clocks best-effort")
+        .output;
+    if let Some(clocks) = status.effective_clocks {
+        for frequency in clocks.values() {
+            assert!(frequency.0 > 0);
+            assert!(frequency.0 < 20_000_000);
+        }
+    }
+}

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -476,6 +476,25 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
             _ => {}
         }
     }
+    if let Some(effective) = &status.effective_clocks {
+        for (clock, frequency) in effective {
+            match *clock {
+                ClockDomain::Graphics => {
+                    map.insert(
+                        "eff_gpu_clock_mhz".into(),
+                        f64_value(frequency.0 as f64 / 1000.0),
+                    );
+                }
+                ClockDomain::Memory => {
+                    map.insert(
+                        "eff_mem_clock_mhz".into(),
+                        f64_value(frequency.0 as f64 / 1000.0),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
     if let Some((_sensor, temp)) = status.sensors.first() {
         map.insert("temperature_c".into(), f64_value(*temp as f64));
     }

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -14,6 +14,18 @@ def _temp_c_str(value) -> str:
         return "---"
 
 
+def _effective_clocks_text(status: dict) -> str:
+    """Format effective, actually-running clocks when the driver exposes them."""
+    gpu = status.get("eff_gpu_clock_mhz")
+    memory = status.get("eff_mem_clock_mhz")
+    parts = []
+    if isinstance(gpu, (int, float)):
+        parts.append(f"GPU {round(float(gpu))}")
+    if isinstance(memory, (int, float)):
+        parts.append(f"MEM {round(float(memory))}")
+    return " | ".join(parts) + " MHz" if parts else "---"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -97,6 +109,7 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
         f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
+        f"ECLK: {_effective_clocks_text(status)}",
         f"VOLT: {status.get('voltage_mv', '---')} mV",
         f"VFP LOCK: {vfp_lock_text}",
         f"TEMP: {temp_text}",

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -66,6 +66,17 @@ def test_format_metric_lines_core_only_when_no_extra_temps() -> None:
     assert "MEM 47 C" not in text
 
 
+def test_format_metric_lines_effective_clocks() -> None:
+    status = {"eff_gpu_clock_mhz": 1897.5, "eff_mem_clock_mhz": 7500}
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "ECLK: GPU 1898 | MEM 7500 MHz" in text
+
+
+def test_format_metric_lines_effective_clocks_are_optional() -> None:
+    text = "\n".join(_format_metric_lines({"gpu_clock_mhz": 1800}, "Ada"))
+    assert "ECLK: ---" in text
+
+
 def test_format_metric_lines_missing_fields_render_dashes() -> None:
     text = "\n".join(_format_metric_lines({}, "---"))
 


### PR DESCRIPTION
Replacement for #287 (and original #281), which was merged into an already-landed intermediate branch rather than into `main`.

This version targets current `main` directly and is independent of the other remaining NVOC monitoring PRs. Its only remaining prerequisite is Skyworks-Neo/nvapi-rs#2; the dependency delta beyond the already-landed thermal bindings is clock-only.

Reads V2 `NvAPI_GPU_GetAllClocks` effective frequencies, exposes graphics and memory values through Python status, and adds an optional `ECLK` row to the TUI. Existing configured/current clock rows remain unchanged. PCIe telemetry, performance-limit decoding, PowerMonitor bindings, and GPU writes are excluded.

Validation:
- `cargo fmt --all -- --check`
- `cargo build --workspace --exclude cli-stressor-cuda-rs`
- `cargo test --package nvoc-core --all-targets`
- `cd tui && uv run pytest` (`52 passed`)
- elevated read-only `nvapi_effective_clocks_are_positive_when_available`: passed on the rebuilt head

No GPU writes were executed.