### PR TITLE
feat(monitoring): add read-only PCIe telemetry

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1451,7 +1451,30 @@ fn execute_target(
             let info = run(target, QueryGpuInfo)?.output;
             Ok(Value::String(info.uuid.unwrap_or_default()))
         }
-        Command::GetStatus => Ok(serde_json::to_value(run(target, QueryGpuStatus)?.output)?),
+        Command::GetStatus => {
+            let mut value = serde_json::to_value(run(target, QueryGpuStatus)?.output)?;
+            if let Ok(nvml) = target.nvml()
+                && let Some(map) = value.as_object_mut()
+            {
+                let pcie = nvoc_core::nvml::query_nvml_pcie_telemetry(nvml, target.id.0);
+                if let Some(tx) = pcie.tx_mibps {
+                    map.insert("pcie_tx_mibps".to_string(), json!(tx));
+                }
+                if let Some(rx) = pcie.rx_mibps {
+                    map.insert("pcie_rx_mibps".to_string(), json!(rx));
+                }
+                if let Some(replay) = pcie.replay_counter {
+                    map.insert("pcie_replay_counter".to_string(), json!(replay));
+                }
+                if let Some(generation) = pcie.current_generation {
+                    map.insert("pcie_link_gen".to_string(), json!(generation));
+                }
+                if let Some(generation) = pcie.max_generation {
+                    map.insert("pcie_max_link_gen".to_string(), json!(generation));
+                }
+            }
+            Ok(value)
+        }
         Command::GetSettings => Ok(serde_json::to_value(run(target, QueryGpuSettings)?.output)?),
         Command::GetVfp => get_vfp(target, invocation),
         Command::GetVfpPointVoltageMv => {

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -1044,6 +1044,8 @@ fn format_with_unit(key: &str, rendered: &str) -> String {
         format!("{rendered}%")
     } else if key.ends_with("_c") || key == "celsius" {
         format!("{rendered} C")
+    } else if key.ends_with("_mibps") {
+        format!("{rendered} MiB/s")
     } else if key == "voltage" {
         // Core voltage is reported in microvolts.
         format!("{rendered} uV")
@@ -1180,6 +1182,8 @@ mod tests {
         let output = json!({
             "voltage": 940000,
             "pcie_lanes": 8,
+            "pcie_tx_mibps": 1234.5,
+            "pcie_rx_mibps": 7.8,
             "memory": {
                 "dedicated": 8384512,
                 "dedicated_available": 8146944,
@@ -1208,6 +1212,8 @@ mod tests {
         assert!(rendered.contains("Voltage: 940000 uV"));
         // PCIe link width gets an `x` prefix.
         assert!(rendered.contains("Pcie Lanes: x8"));
+        assert!(rendered.contains("Pcie Tx Mibps: 1234.5 MiB/s"));
+        assert!(rendered.contains("Pcie Rx Mibps: 7.8 MiB/s"));
         // Memory size fields are KiB -> MB; the eviction *count* has no unit.
         assert!(rendered.contains("Dedicated: 8188 MB"));
         assert!(rendered.contains("Shared: 32573.785 MB"));

--- a/core/src/nvml.rs
+++ b/core/src/nvml.rs
@@ -2,7 +2,7 @@ use super::conv::{nvml_pstate_to_index, nvml_pstate_to_str};
 use super::error::Error;
 use super::target::GpuId;
 use nvml_wrapper::Nvml;
-use nvml_wrapper::enum_wrappers::device::{Api, PerformanceState};
+use nvml_wrapper::enum_wrappers::device::{Api, PcieUtilCounter, PerformanceState};
 use nvml_wrapper::enums::device::FanControlPolicy;
 
 pub type NvmlPStateClockRange = (PerformanceState, u32, u32, u32, u32);
@@ -62,6 +62,43 @@ pub fn query_nvml_power_watts(nvml: &Nvml, gpu_id: u32) -> Option<(f32, f32, f32
         current_mw as f32 / 1000.0,
         max_mw as f32 / 1000.0,
     ))
+}
+
+/// Read-only PCIe link telemetry available through NVML.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct NvmlPcieTelemetry {
+    /// GPU-to-host throughput, averaged by NVML over its sampling interval.
+    pub tx_mibps: Option<f32>,
+    /// Host-to-GPU throughput, averaged by NVML over its sampling interval.
+    pub rx_mibps: Option<f32>,
+    /// Cumulative transaction replay count since the driver was loaded.
+    pub replay_counter: Option<u32>,
+    /// Currently negotiated PCIe generation.
+    pub current_generation: Option<u32>,
+    /// Maximum PCIe generation exposed by this NVML API.
+    pub max_generation: Option<u32>,
+}
+
+/// Query PCIe throughput, replay count, and link generation without waking or
+/// modifying the GPU. Unsupported counters are returned as `None` individually.
+pub fn query_nvml_pcie_telemetry(nvml: &Nvml, gpu_id: u32) -> NvmlPcieTelemetry {
+    let Some(device) = find_nvml_device(nvml, gpu_id) else {
+        return NvmlPcieTelemetry::default();
+    };
+
+    NvmlPcieTelemetry {
+        tx_mibps: device
+            .pcie_throughput(PcieUtilCounter::Send)
+            .ok()
+            .map(|kbps| kbps as f32 / 1024.0),
+        rx_mibps: device
+            .pcie_throughput(PcieUtilCounter::Receive)
+            .ok()
+            .map(|kbps| kbps as f32 / 1024.0),
+        replay_counter: device.pcie_replay_counter().ok(),
+        current_generation: device.current_pcie_link_gen().ok(),
+        max_generation: device.max_pcie_link_gen().ok(),
+    }
 }
 
 pub fn set_nvml_auto_boost(nvml: &Nvml, gpu_id: u32, enabled: bool) -> Result<(), Error> {

--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -219,6 +219,28 @@ fn nvml_power_ok() {
 
 #[test]
 #[ignore]
+fn nvml_pcie_telemetry_ok() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    let telemetry = nvoc_core::nvml::query_nvml_pcie_telemetry(nvml(&inv), target.id.0);
+
+    for throughput in [telemetry.tx_mibps, telemetry.rx_mibps]
+        .into_iter()
+        .flatten()
+    {
+        assert!(throughput.is_finite());
+        assert!(throughput >= 0.0);
+    }
+    for generation in [telemetry.current_generation, telemetry.max_generation]
+        .into_iter()
+        .flatten()
+    {
+        assert!((1..=7).contains(&generation));
+    }
+}
+
+#[test]
+#[ignore]
 fn nvml_power_bad_gpu() {
     let bad_target = GpuTarget::without_backends(GpuId(INVALID_GPU_ID), 0);
     assert!(run(&bad_target, QueryPowerLimits).is_err());

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -608,6 +608,25 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
         map.insert("pcie_lanes".into(), u64_value(lanes as u64));
     }
 
+    if let Ok(nvml) = target.nvml() {
+        let pcie = nvoc_core::nvml::query_nvml_pcie_telemetry(nvml, target.id.0);
+        if let Some(tx) = pcie.tx_mibps {
+            map.insert("pcie_tx_mibps".into(), f64_value(tx as f64));
+        }
+        if let Some(rx) = pcie.rx_mibps {
+            map.insert("pcie_rx_mibps".into(), f64_value(rx as f64));
+        }
+        if let Some(replay) = pcie.replay_counter {
+            map.insert("pcie_replay_counter".into(), u64_value(replay as u64));
+        }
+        if let Some(generation) = pcie.current_generation {
+            map.insert("pcie_link_gen".into(), u64_value(generation as u64));
+        }
+        if let Some(generation) = pcie.max_generation {
+            map.insert("pcie_max_link_gen".into(), u64_value(generation as u64));
+        }
+    }
+
     // NVAPI perf / throttle-limit flags (raw bitset; overlaps NVML throttle
     // reasons). `limits_decoded` is the same mask rendered as reason names so
     // consumers (TUI/CLI) don't each have to re-decode the bits.

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -53,6 +53,15 @@ def _perf_limits_text(perf) -> str:
     return ", ".join(reasons) if reasons else "none"
 
 
+def _format_mibps(value: float) -> str:
+    """Format PCIe throughput using MiB/s or GiB/s."""
+    if value >= 1024.0:
+        return f"{value / 1024.0:.1f} GiB/s"
+    if value >= 10.0:
+        return f"{value:.0f} MiB/s"
+    return f"{value:.1f} MiB/s"
+
+
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
     """Build the dashboard metric lines from a normalized status dict.
 
@@ -116,6 +125,32 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
 
     lanes = status.get("pcie_lanes")
     pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
+
+    current_gen = status.get("pcie_link_gen")
+    max_gen = status.get("pcie_max_link_gen")
+    if isinstance(current_gen, (int, float)) and isinstance(max_gen, (int, float)):
+        generation = f"Gen{int(current_gen)}/{int(max_gen)}"
+    elif isinstance(max_gen, (int, float)):
+        generation = f"Gen?/{int(max_gen)}"
+    else:
+        generation = ""
+
+    tx = status.get("pcie_tx_mibps")
+    rx = status.get("pcie_rx_mibps")
+    bandwidth = []
+    if isinstance(tx, (int, float)):
+        bandwidth.append(f"↑{_format_mibps(float(tx))}")
+    if isinstance(rx, (int, float)):
+        bandwidth.append(f"↓{_format_mibps(float(rx))}")
+
+    parts = [
+        part for part in (generation, pcie_text if pcie_text != "---" else "") if part
+    ]
+    parts.extend(bandwidth)
+    replay = status.get("pcie_replay_counter")
+    if isinstance(replay, (int, float)) and replay > 0:
+        parts.append(f"⚠replay {int(replay)}")
+    pcie_text = " ".join(parts) if parts else "---"
 
     perf = status.get("perf") or {}
     perf_text = _perf_limits_text(perf)

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -26,6 +26,11 @@ def test_format_metric_lines_full() -> None:
             "Cooler1": {"current_level": 45, "current_tach": 1234, "active": True},
         },
         "pcie_lanes": 16,
+        "pcie_link_gen": 4,
+        "pcie_max_link_gen": 4,
+        "pcie_tx_mibps": 1234.5,
+        "pcie_rx_mibps": 7.8,
+        "pcie_replay_counter": 2,
         "perf": {"unknown": 0, "limits": 32},
     }
 
@@ -40,7 +45,7 @@ def test_format_metric_lines_full() -> None:
     assert "LOAD: GPU 100% | MC 0% | VEN 12% | BUS 2%" in text
     assert "VRAM: 2.0 / 8.0 GB" in text
     assert "FAN: 1234 RPM @ 45%" in text
-    assert "PCIE: x16" in text
+    assert "PCIE: Gen4/4 x16 ↑1.2 GiB/s ↓7.8 MiB/s ⚠replay 2" in text
     # limits = 32 = UNKNOWN_32 bit -> decoded reason name, not raw hex.
     assert "PERF LIMIT: Unknown32" in text
     assert "ARCH: Ada" in text
@@ -90,6 +95,26 @@ def test_format_metric_lines_perf_zero_is_none() -> None:
     # No active limit reason -> "none" (not "0x0").
     text = "\n".join(_format_metric_lines({"perf": {"unknown": 0, "limits": 0}}, "---"))
     assert "PERF LIMIT: none" in text
+
+
+def test_format_metric_lines_pcie_telemetry_is_optional() -> None:
+    text = "\n".join(_format_metric_lines({"pcie_lanes": 8}, "Ada"))
+    assert "PCIE: x8" in text
+    assert "Gen" not in text
+    assert "↑" not in text
+    assert "replay" not in text
+
+
+def test_format_metric_lines_pcie_telemetry_without_lanes() -> None:
+    status = {
+        "pcie_max_link_gen": 5,
+        "pcie_tx_mibps": 0.5,
+        "pcie_rx_mibps": 0.3,
+        "pcie_replay_counter": 0,
+    }
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "PCIE: Gen?/5 ↑0.5 MiB/s ↓0.3 MiB/s" in text
+    assert "replay" not in text
 
 
 def test_format_metric_lines_missing_fields_render_dashes() -> None:


### PR DESCRIPTION
Replacement for #286 (and original #279), which was merged into an already-landed intermediate branch rather than into `main`.

This version targets current `main` directly and is independent of the other remaining monitoring PRs.

Adds one best-effort NVML telemetry query for current/max PCIe generation, TX/RX throughput, and the cumulative replay counter. CLI and Python status omit unsupported fields; the TUI renders available values on the existing PCIe row and warns only when the replay counter is nonzero. Performance-limit decoding, effective clocks, private counters, and GPU writes are excluded.

Validation:
- `cargo fmt --all -- --check`
- `cargo build --workspace --exclude cli-stressor-cuda-rs`
- `cargo test --package nvoc-core --all-targets`
- `cd tui && uv run pytest` (`52 passed`)
- elevated read-only `nvml_pcie_telemetry_ok`: passed on the rebuilt head

No GPU writes were executed.