### PR TITLE
fix(monitoring): source live GPU power draw from NVML

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1390,6 +1390,7 @@ fn list_gpus_execution(
 fn discovery_backend_set(command: Command, adapter: BackendAdapter) -> BackendSet {
     match (command, adapter) {
         (Command::GetInfo, BackendAdapter::Nvapi) => BackendSet::Both,
+        (Command::GetStatus, BackendAdapter::Nvapi) => BackendSet::Both,
         (Command::GetUuid, BackendAdapter::Nvapi) => BackendSet::Both,
         (Command::SetPstateLock, BackendAdapter::Nvapi) => BackendSet::Both,
         (_, BackendAdapter::Nvapi) => BackendSet::Nvapi,
@@ -1456,6 +1457,11 @@ fn execute_target(
             if let Ok(nvml) = target.nvml()
                 && let Some(map) = value.as_object_mut()
             {
+                if let Some(draw_w) =
+                    nvoc_core::nvml::query_nvml_power_draw_watts(nvml, target.id.0)
+                {
+                    map.insert("power_draw_w".to_string(), json!(draw_w));
+                }
                 let pcie = nvoc_core::nvml::query_nvml_pcie_telemetry(nvml, target.id.0);
                 if let Some(tx) = pcie.tx_mibps {
                     map.insert("pcie_tx_mibps".to_string(), json!(tx));

--- a/core/src/nvml.rs
+++ b/core/src/nvml.rs
@@ -101,6 +101,24 @@ pub fn query_nvml_pcie_telemetry(nvml: &Nvml, gpu_id: u32) -> NvmlPcieTelemetry 
     }
 }
 
+/// Query the live (instantaneous) GPU power draw in watts via NVML.
+///
+/// Wraps `nvmlDeviceGetPowerUsage` (`Device::power_usage`), which reports the
+/// current board power draw in milliwatts — the same reading `nvidia-smi`
+/// shows. This is the only reliable live-draw source on laptop GPUs: the
+/// NVAPI power-topology path (`NvAPI_GPU_ClientPowerTopologyGetStatus`) returns
+/// a dimensionless percentage and is typically empty on mobile parts, while
+/// [`query_nvml_power_watts`] reads the configurable power *limit*, not the
+/// actual draw (and laptops usually have no user-configurable limit, so it
+/// returns `None`).
+///
+/// `gpu_id` uses the NVAPI encoding: `PCI_Bus_Number × 256`.
+pub fn query_nvml_power_draw_watts(nvml: &Nvml, gpu_id: u32) -> Option<f32> {
+    let device = find_nvml_device(nvml, gpu_id)?;
+    let mw = device.power_usage().ok()?;
+    Some(mw as f32 / 1000.0)
+}
+
 pub fn set_nvml_auto_boost(nvml: &Nvml, gpu_id: u32, enabled: bool) -> Result<(), Error> {
     let mut device = find_nvml_device_err(nvml, gpu_id)?;
     device

--- a/core/tests/gpu_readonly.rs
+++ b/core/tests/gpu_readonly.rs
@@ -219,6 +219,18 @@ fn nvml_power_ok() {
 
 #[test]
 #[ignore]
+fn nvml_live_power_draw_ok() {
+    let inv = inventory();
+    let target = first_target(&inv);
+    let draw = nvoc_core::nvml::query_nvml_power_draw_watts(nvml(&inv), target.id.0)
+        .expect("live NVML power draw should be readable");
+    assert!(draw.is_finite());
+    assert!(draw >= 0.0);
+    assert!(nvoc_core::nvml::query_nvml_power_draw_watts(nvml(&inv), INVALID_GPU_ID).is_none());
+}
+
+#[test]
+#[ignore]
 fn nvml_pcie_telemetry_ok() {
     let inv = inventory();
     let target = first_target(&inv);

--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -556,7 +556,21 @@ fn normalize_status(target: &GpuTarget<'_>) -> PyResultValue {
             }
         }
     }
-    if let Some((_channel, power)) = status.power.iter().next()
+    // Live board power draw (watts). Prefer the NVML reading
+    // (`nvmlDeviceGetPowerUsage`, same source as nvidia-smi): on laptop GPUs the
+    // NVAPI power-topology path returns a dimensionless percentage (or nothing),
+    // so it is neither accurate nor usually present. Fall back to the NVAPI
+    // value only when NVML is unavailable.
+    let mut power_w_set = false;
+    if target.has_nvml()
+        && let Ok(device) = target_nvml_device(target)
+        && let Ok(mw) = device.power_usage()
+    {
+        map.insert("power_w".into(), f64_value(mw as f64 / 1000.0));
+        power_w_set = true;
+    }
+    if !power_w_set
+        && let Some((_channel, power)) = status.power.iter().next()
         && let Some(watts) = first_number_in_display(power)
     {
         map.insert("power_w".into(), f64_value(watts));


### PR DESCRIPTION
## Summary

- source instantaneous board-power draw from NVML `power_usage()` instead of treating NVAPI topology percentages as watts
- expose the same live reading in CLI JSON and `pynvoc`, retaining the existing NVAPI fallback when NVML is unavailable
- add a hardware-gated read-only regression for valid and invalid GPU IDs

Umbrella: #267

## Validation

- `cargo fmt --all -- --check`
- `cargo test --package nvoc-core --all-targets`
- `cargo test --package nvoc-cli --all-targets`
- `cargo check --package pynvoc`
- `cargo test --package nvoc-core --test gpu_readonly nvml_live_power_draw_ok -- --ignored --exact --nocapture` (local NVIDIA GPU, read-only)

`cargo test --package pynvoc --all-targets` could not link the local test binary because this environment does not expose Python C symbols to the Rust linker; `cargo check --package pynvoc` passes.