### PR TITLE
perf(gui): cap BLAS thread pools during startup

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -8,6 +8,12 @@ import os
 import sys
 from typing import Any, Callable, Optional
 
+# Cap BLAS/OpenMP thread pools BEFORE numpy/matplotlib load: the GUI does no
+# matrix math, and the default per-core OpenBLAS arenas commit ~650MB of
+# pagefile for nothing (measured: full-stack commit 681MB -> 70MB).
+for _var in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_var, "1")
+
 # Ensure the project root is in path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 

--- a/gui/tests/test_main.py
+++ b/gui/tests/test_main.py
@@ -1,10 +1,41 @@
 from __future__ import annotations
 
+import importlib
+import os
 from typing import Any
 
 import pytest
 
 import main
+
+
+BLAS_THREAD_ENV_VARS = (
+    "OPENBLAS_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+)
+
+
+def test_main_caps_unconfigured_blas_thread_pools(monkeypatch) -> None:
+    for name in BLAS_THREAD_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    importlib.reload(main)
+
+    assert {name: os.environ[name] for name in BLAS_THREAD_ENV_VARS} == {
+        name: "1" for name in BLAS_THREAD_ENV_VARS
+    }
+
+
+def test_main_preserves_explicit_blas_thread_configuration(monkeypatch) -> None:
+    for name in BLAS_THREAD_ENV_VARS:
+        monkeypatch.setenv(name, "4")
+
+    importlib.reload(main)
+
+    assert {name: os.environ[name] for name in BLAS_THREAD_ENV_VARS} == {
+        name: "4" for name in BLAS_THREAD_ENV_VARS
+    }
 
 
 def test_require_gui_runtime_reports_missing_tkinter() -> None:


### PR DESCRIPTION
## Summary

- default OpenBLAS, OpenMP, and MKL worker counts to one before GUI code can import NumPy/Matplotlib
- preserve any explicit user-provided thread configuration via `setdefault`
- add regression coverage for both the default cap and explicit overrides

This isolates the startup-memory fix from the larger GUI rewrite retained in umbrella #267. The source branch measured the full GUI import stack dropping from roughly 681 MB to 70 MB of committed memory.

## Validation

- `cd gui && uv sync && uv run pytest` (37 passed)
- `uvx --from ruff==0.16.2 ruff format . --preview --check --output-format=github`
- `uvx --from ruff==0.16.2 ruff check . --output-format=github`