### PR TITLE
perf(pynvoc): release the GIL during read-only queries

### DIFF
--- a/nvoc-python/src/lib.rs
+++ b/nvoc-python/src/lib.rs
@@ -1085,40 +1085,55 @@ fn target_inventory(backends: BackendSet) -> PyResult<nvoc_core::TargetInventory
 
 #[pyfunction]
 fn discover_gpus(py: Python<'_>, backends: Option<&str>) -> PyResult<Py<PyAny>> {
-    let inventory = target_inventory(parse_backends(backends.unwrap_or("both"))?)?;
-    let mut items = Vec::new();
-    for target in inventory.targets() {
-        let mut item = Map::new();
-        item.insert("index".into(), u64_value(target.index as u64));
-        item.insert("gpu_id".into(), u64_value(target.id.0 as u64));
-        item.insert("gpu_id_hex".into(), text(format!("0x{:04X}", target.id.0)));
-        item.insert("backend_nvapi".into(), bool_value(target.has_nvapi()));
-        item.insert("backend_nvml".into(), bool_value(target.has_nvml()));
-        if let Ok(info) = run(&target, QueryGpuInfo).map(|report| report.output) {
-            item.insert("name".into(), text(info.name));
-            item.insert("codename".into(), text(info.codename));
-            item.insert("arch".into(), text(info.arch));
+    let backends = backends.unwrap_or("both").to_string();
+    // Release the GIL: discovery loads nvapi64 + inits NVAPI (hundreds of
+    // ms) and the GUI calls it at tick zero to overlap UI construction —
+    // holding the GIL would stall the main thread's Python widget build.
+    let items = py.detach(|| -> PyResult<Vec<Value>> {
+        let inventory = target_inventory(parse_backends(&backends)?)?;
+        let mut items = Vec::new();
+        for target in inventory.targets() {
+            let mut item = Map::new();
+            item.insert("index".into(), u64_value(target.index as u64));
+            item.insert("gpu_id".into(), u64_value(target.id.0 as u64));
+            item.insert("gpu_id_hex".into(), text(format!("0x{:04X}", target.id.0)));
+            item.insert("backend_nvapi".into(), bool_value(target.has_nvapi()));
+            item.insert("backend_nvml".into(), bool_value(target.has_nvml()));
+            if let Ok(info) = run(&target, QueryGpuInfo).map(|report| report.output) {
+                item.insert("name".into(), text(info.name));
+                item.insert("codename".into(), text(info.codename));
+                item.insert("arch".into(), text(info.arch));
+            }
+            items.push(Value::Object(item));
         }
-        items.push(Value::Object(item));
-    }
+        Ok(items)
+    })?;
     py_value(py, &Value::Array(items))
 }
 
 #[pyfunction]
 fn query_info(py: Python<'_>, gpu: &str, backends: Option<&str>) -> PyResult<Py<PyAny>> {
-    let value = with_target(gpu, backends.unwrap_or("both"), normalize_info)?;
+    let gpu = gpu.to_string();
+    let backends = backends.unwrap_or("both").to_string();
+    let value = py.detach(|| with_target(&gpu, &backends, normalize_info))?;
     py_value(py, &value)
 }
 
 #[pyfunction]
 fn query_status(py: Python<'_>, gpu: &str, backends: Option<&str>) -> PyResult<Py<PyAny>> {
-    let value = with_target(gpu, backends.unwrap_or("both"), normalize_status)?;
+    // GIL released: the 1 Hz dashboard poll runs this sweep while the GUI
+    // main thread handles events — holding the GIL stalls drag/click streams.
+    let gpu = gpu.to_string();
+    let backends = backends.unwrap_or("both").to_string();
+    let value = py.detach(|| with_target(&gpu, &backends, normalize_status))?;
     py_value(py, &value)
 }
 
 #[pyfunction]
 fn query_settings(py: Python<'_>, gpu: &str, backends: Option<&str>) -> PyResult<Py<PyAny>> {
-    let value = with_target(gpu, backends.unwrap_or("both"), normalize_settings)?;
+    let gpu = gpu.to_string();
+    let backends = backends.unwrap_or("both").to_string();
+    let value = py.detach(|| with_target(&gpu, &backends, normalize_settings))?;
     py_value(py, &value)
 }
 
@@ -1251,8 +1266,13 @@ fn query_domain_vfp_points(
     infer_missing_default: bool,
 ) -> PyResult<Py<PyAny>> {
     let domain = parse_domain(domain.unwrap_or("graphics"))?;
-    let value = with_target(gpu, "nvapi", |target| {
-        normalize_domain_vfp_points(target, domain, infer_missing_default)
+    let gpu = gpu.to_string();
+    // GIL released: the VFP table RM escape is the heaviest read (curve
+    // refresh / auto-refresh) and must not stall the GUI event stream.
+    let value = py.detach(|| {
+        with_target(&gpu, "nvapi", |target| {
+            normalize_domain_vfp_points(target, domain, infer_missing_default)
+        })
     })?;
     py_value(py, &value)
 }


### PR DESCRIPTION
## Summary

- release the Python GIL while GPU discovery and the main read-only query wrappers wait on driver calls
- copy borrowed Python strings before detaching, then convert the completed JSON value back under the GIL
- keep the change limited to existing query paths; no inventory cache, capability expansion, or setter behavior is included

Umbrella: #267

## Validation

- `cargo fmt --all -- --check`
- `cargo check --package pynvoc`
- `cargo test --package nvoc-core --all-targets`
- `cd gui && uv sync && uv run pytest` (35 passed)
- `cd tui && uv sync && uv run pytest` (56 passed)