### PR TITLE
perf(tui): cap BLAS thread pools during startup

### DIFF
--- a/tui/nvoc_tui/__main__.py
+++ b/tui/nvoc_tui/__main__.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+# Cap BLAS/OpenMP thread pools before numpy loads through textual-plotext. The
+# TUI does no matrix math, so per-core worker pools only reserve excess memory.
+for _var in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_var, "1")
+
 if __package__:
     from .app import NVOCApp
 else:

--- a/tui/tests/test_main.py
+++ b/tui/tests/test_main.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+import os
+
+from nvoc_tui import __main__
+
+
+BLAS_THREAD_ENV_VARS = (
+    "OPENBLAS_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+)
+
+
+def test_main_caps_unconfigured_blas_thread_pools(monkeypatch) -> None:
+    for name in BLAS_THREAD_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    importlib.reload(__main__)
+
+    assert {name: os.environ[name] for name in BLAS_THREAD_ENV_VARS} == {
+        name: "1" for name in BLAS_THREAD_ENV_VARS
+    }
+
+
+def test_main_preserves_explicit_blas_thread_configuration(monkeypatch) -> None:
+    for name in BLAS_THREAD_ENV_VARS:
+        monkeypatch.setenv(name, "4")
+
+    importlib.reload(__main__)
+
+    assert {name: os.environ[name] for name in BLAS_THREAD_ENV_VARS} == {
+        name: "4" for name in BLAS_THREAD_ENV_VARS
+    }


### PR DESCRIPTION
## Summary

- default OpenBLAS, OpenMP, and MKL worker counts to one before `textual-plotext` can import NumPy
- preserve explicit user-provided thread settings via `setdefault`
- add regression coverage for both the default cap and explicit overrides

This is the TUI-only counterpart to #293 and deliberately excludes the source branch's GC6/no-wake changes, which depend on private wake plumbing not present in `main`. Umbrella: #267.

## Validation

- `cd tui && uv sync && uv run pytest` (58 passed)
- `cd tui && uv run ruff format . --preview --check --output-format=github`
- `cd tui && uv run ruff check . --output-format=github`