### PR TITLE
fix(tui): serialize read-only query workers

### DIFF
--- a/tui/nvoc_tui/app.py
+++ b/tui/nvoc_tui/app.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import threading
-
 from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -212,9 +210,7 @@ class NVOCApp(App[None]):
             code, output, parsed = self.native_service.run_query(gpu, command_name)
             self.call_from_thread(finish_query, code, output, parsed)
 
-        threading.Thread(
-            target=worker, daemon=True, name=f"query-{command_name}"
-        ).start()
+        self.native_service.submit_query(worker)
 
     def refresh_gpu_list(self) -> None:
         def worker() -> None:
@@ -223,7 +219,7 @@ class NVOCApp(App[None]):
                 self.header_controller.on_gpu_list_loaded, code, output, gpus
             )
 
-        threading.Thread(target=worker, daemon=True, name="gpu-list").start()
+        self.native_service.submit_query(worker)
 
     def focus_dashboard_tab_switcher(self) -> None:
         self.switch_to_tab("dashboard")

--- a/tui/nvoc_tui/controllers/vfcurve.py
+++ b/tui/nvoc_tui/controllers/vfcurve.py
@@ -131,8 +131,7 @@ class VFCurveController(PaneController):
                 raise
 
         try:
-            thread = threading.Thread(target=worker, daemon=True, name="vf-refresh")
-            thread.start()
+            self.app.native_service.submit_query(worker)
         except Exception:
             self._end_refresh()
             raise

--- a/tui/nvoc_tui/native.py
+++ b/tui/nvoc_tui/native.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import queue
 import threading
 from pathlib import Path
 from typing import Any, Callable
@@ -20,6 +21,31 @@ class NativeService:
         self._native: Any | None = None
         self._lock = threading.Lock()
         self.action_state = ActionState()
+        self._query_queue: queue.Queue[Callable[[], None] | None] = queue.Queue()
+        self._query_worker = threading.Thread(
+            target=self._query_loop,
+            daemon=True,
+            name="nvoc-tui-query",
+        )
+        self._query_worker.start()
+
+    def _query_loop(self) -> None:
+        while True:
+            job = self._query_queue.get()
+            try:
+                if job is None:
+                    return
+                job()
+            except Exception:
+                # Query jobs marshal their own errors to the UI. Keep the
+                # shared worker alive if a callback itself unexpectedly fails.
+                pass
+            finally:
+                self._query_queue.task_done()
+
+    def submit_query(self, job: Callable[[], None]) -> None:
+        """Run a read-only frontend query on the shared serial worker."""
+        self._query_queue.put(job)
 
     def _pynvoc(self) -> Any:
         if self._native is None:

--- a/tui/tests/test_controllers.py
+++ b/tui/tests/test_controllers.py
@@ -418,23 +418,12 @@ def test_vfcurve_export_action_writes_static_curve(tmp_path: Path) -> None:
     ]
 
 
-def test_vfcurve_refresh_suppresses_overlapping_workers(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_vfcurve_refresh_suppresses_overlapping_workers(tmp_path: Path) -> None:
     app = FakeApp()
     app.root_dir = tmp_path
     scheduled: list[object] = []
 
-    class FakeThread:
-        def __init__(self, *, target, daemon, name) -> None:
-            self.target = target
-            self.daemon = daemon
-            self.name = name
-
-        def start(self) -> None:
-            scheduled.append(self)
-
-    monkeypatch.setattr("nvoc_tui.controllers.vfcurve.threading.Thread", FakeThread)
+    app.native_service.submit_query = scheduled.append
     controller = VFCurveController(app)
 
     controller.refresh_curve()
@@ -463,21 +452,15 @@ def test_vfcurve_refresh_clears_inflight_when_cache_path_fails() -> None:
 
 
 def test_vfcurve_refresh_clears_inflight_when_thread_start_fails(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path,
 ) -> None:
     app = FakeApp()
     app.root_dir = tmp_path
 
-    class FakeThread:
-        def __init__(self, *, target, daemon, name) -> None:
-            self.target = target
-            self.daemon = daemon
-            self.name = name
+    def fail_submit(_job) -> None:
+        raise RuntimeError("query queue unavailable")
 
-        def start(self) -> None:
-            raise RuntimeError("thread unavailable")
-
-    monkeypatch.setattr("nvoc_tui.controllers.vfcurve.threading.Thread", FakeThread)
+    app.native_service.submit_query = fail_submit
     controller = VFCurveController(app)
 
     with pytest.raises(RuntimeError):

--- a/tui/tests/test_native.py
+++ b/tui/tests/test_native.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from threading import Event
 
 from nvoc_tui.native import NativeService
 
@@ -26,3 +27,37 @@ def test_run_query_returns_loggable_native_output() -> None:
     assert parsed == {"gpu": "0x1234", "name": "Test GPU"}
     assert output.startswith("> native info --gpu=0x1234\n")
     assert '"name": "Test GPU"' in output
+
+
+def test_submit_query_serializes_jobs_and_survives_failures() -> None:
+    service = NativeService(Path.cwd())
+    first_started = Event()
+    release_first = Event()
+    second_finished = Event()
+    calls: list[str] = []
+
+    def first() -> None:
+        calls.append("first-start")
+        first_started.set()
+        assert release_first.wait(timeout=1)
+        calls.append("first-end")
+
+    def second() -> None:
+        calls.append("second")
+        second_finished.set()
+
+    service.submit_query(first)
+    assert first_started.wait(timeout=1)
+    service.submit_query(second)
+    assert not second_finished.wait(timeout=0.05)
+    release_first.set()
+    assert second_finished.wait(timeout=1)
+    assert calls == ["first-start", "first-end", "second"]
+
+    def fail() -> None:
+        raise RuntimeError("query failed")
+
+    recovered = Event()
+    service.submit_query(fail)
+    service.submit_query(recovered.set)
+    assert recovered.wait(timeout=1)


### PR DESCRIPTION
## Summary

- replace per-poll threads with one shared daemon worker for dashboard, GPU discovery, and V/F refresh queries
- serialize frontend reads so overlapping timers cannot concurrently enter backend discovery and driver calls
- keep the worker alive after an unexpected job/callback exception
- exclude the source branch's mobile/private-control additions

Umbrella: #267

## Validation

- `cd tui && uv sync && uv run pytest` (57 passed)
- `cd tui && uv run ruff format . --preview --check --output-format=github`
- `cd tui && uv run ruff check . --output-format=github`