### PR TITLE
perf(tui): keep V/F refresh data in memory

### DIFF
--- a/tui/nvoc_tui/controllers/dashboard.py
+++ b/tui/nvoc_tui/controllers/dashboard.py
@@ -40,7 +40,7 @@ class DashboardController(PaneController):
             return
         self.app.cache.status = parsed
         self.update_metrics()
-        if self.app.cache.vf_curve_path:
+        if self.app.cache.vf_curve_points:
             self.app.vfcurve_controller.render_plot()
 
     def on_get_loaded(self, code: int, output: str, parsed: dict) -> None:

--- a/tui/nvoc_tui/controllers/vfcurve.py
+++ b/tui/nvoc_tui/controllers/vfcurve.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import threading
-from pathlib import Path
 
 from rich.text import Text
 from textual.widgets import Button, Checkbox, Input, Select
@@ -10,8 +9,8 @@ from textual_plotext import PlotextPlot
 from ..parsing import (
     compute_vf_plot_bounds,
     find_curve_point_for_voltage,
-    load_vf_curve,
     load_vf_curve_deltas,
+    vf_curve_points_to_series,
     write_vf_curve_points,
 )
 from ..widgets import mnemonic_text
@@ -84,15 +83,6 @@ class VFCurveController(PaneController):
         with self._refresh_lock:
             self.refresh_inflight = False
 
-    def cache_path(self) -> Path:
-        cache_dir = self.app.root_dir / "vfp_cache"
-        cache_dir.mkdir(exist_ok=True)
-        gpu = self.app.current_gpu()
-        if gpu and gpu.uuid:
-            return cache_dir / f"{gpu.uuid}.csv"
-        idx = self.app.selected_gpu_idx() or 0
-        return cache_dir / f"gpu_{idx}.csv"
-
     def sync_from_ui(self) -> None:
         self.app.config_data.vfcurve.default_path = self.app.query_one(
             "#vf-path", Input
@@ -103,7 +93,6 @@ class VFCurveController(PaneController):
         if not self._begin_refresh():
             return
         try:
-            cache_path = self.cache_path()
             gpu = self.app.selected_gpu_target()
         except Exception:
             self._end_refresh()
@@ -116,16 +105,14 @@ class VFCurveController(PaneController):
         def worker() -> None:
             output = ""
             code = 0
+            points: list[dict] | None = None
             try:
                 points = self.app.native_service.query_domain_vfp_points(gpu)
-                write_vf_curve_points(str(cache_path), points)
             except Exception as exc:
                 output = f"pynvoc VFP curve query failed: {exc}"
                 code = -1
             try:
-                self.app.call_from_thread(
-                    self.on_curve_loaded, output, str(cache_path), code
-                )
+                self.app.call_from_thread(self.on_curve_loaded, output, points, code)
             except Exception:
                 self._end_refresh()
                 raise
@@ -137,15 +124,17 @@ class VFCurveController(PaneController):
             self._end_refresh()
             raise
 
-    def on_curve_loaded(self, output: str, path: str, code: int) -> None:
+    def on_curve_loaded(
+        self, output: str, points: list[dict] | None, code: int
+    ) -> None:
         self._end_refresh()
         if output:
             self.app.write_log(output)
-        self.app.cache.vf_curve_path = path
+        self.app.cache.vf_curve_points = points if code == 0 else None
         if code == 0:
             self.render_plot()
         else:
-            self.clear_plot("VF curve export failed.")
+            self.clear_plot("VF curve query failed.")
 
     def clear_plot(self, title: str) -> None:
         widget = self.app.query_one("#vf-plot", PlotextPlot)
@@ -159,10 +148,11 @@ class VFCurveController(PaneController):
         widget.refresh()
 
     def render_plot(self) -> None:
-        if not self.app.cache.vf_curve_path:
-            self.clear_plot("No VF curve cache loaded.")
+        points = self.app.cache.vf_curve_points
+        if not points:
+            self.clear_plot("No VF curve loaded.")
             return
-        voltages, freqs, defaults = load_vf_curve(self.app.cache.vf_curve_path)
+        voltages, freqs, defaults = vf_curve_points_to_series(points)
         if not voltages:
             self.clear_plot("VF curve cache is empty.")
             return

--- a/tui/nvoc_tui/models.py
+++ b/tui/nvoc_tui/models.py
@@ -69,7 +69,7 @@ class GpuCache:
     info: dict[str, Any] = field(default_factory=dict)
     status: dict[str, Any] = field(default_factory=dict)
     settings: dict[str, Any] = field(default_factory=dict)
-    vf_curve_path: str = ""
+    vf_curve_points: list[dict[str, Any]] | None = None
 
 
 @dataclass(slots=True)

--- a/tui/nvoc_tui/parsing.py
+++ b/tui/nvoc_tui/parsing.py
@@ -291,6 +291,25 @@ def normalize_query_output(command: str, output: str) -> dict[str, Any]:
     return {}
 
 
+def vf_curve_points_to_series(
+    points: list[dict[str, Any]],
+) -> tuple[list[float], list[float], list[float]]:
+    """Convert in-memory V/F points from micro-units to plot units."""
+    voltages: list[float] = []
+    frequencies: list[float] = []
+    defaults: list[float] = []
+    for point in points:
+        voltage_uv = point.get("voltage_uv", 0)
+        frequency_khz = point.get("frequency_khz", 0)
+        default_khz = point.get("default_frequency_khz")
+        voltages.append(float(voltage_uv) / 1000.0)
+        frequencies.append(float(frequency_khz) / 1000.0)
+        defaults.append(
+            frequencies[-1] if default_khz is None else float(default_khz) / 1000.0
+        )
+    return voltages, frequencies, defaults
+
+
 def load_vf_curve(path: str) -> tuple[list[float], list[float], list[float]]:
     csv_path = Path(path)
     if not csv_path.is_file():

--- a/tui/tests/test_controllers.py
+++ b/tui/tests/test_controllers.py
@@ -444,21 +444,37 @@ def test_vfcurve_refresh_suppresses_overlapping_workers(
     assert controller.is_refresh_inflight() is True
 
 
-def test_vfcurve_refresh_clears_inflight_when_cache_path_fails() -> None:
+def test_vfcurve_refresh_keeps_points_in_memory(tmp_path: Path, monkeypatch) -> None:
     app = FakeApp()
+    app.root_dir = tmp_path
+    points = [
+        {
+            "voltage_uv": 800000,
+            "frequency_khz": 1800000,
+            "default_frequency_khz": 1750000,
+        }
+    ]
+    app.native_service.query_domain_vfp_points = lambda _gpu: points
+
+    class ImmediateThread:
+        def __init__(self, *, target, daemon, name) -> None:
+            self.target = target
+
+        def start(self) -> None:
+            self.target()
+
+    monkeypatch.setattr(
+        "nvoc_tui.controllers.vfcurve.threading.Thread", ImmediateThread
+    )
     controller = VFCurveController(app)
+    rendered: list[bool] = []
+    controller.render_plot = lambda: rendered.append(True)
 
-    def fail_cache_path() -> Path:
-        raise OSError("cache path unavailable")
+    controller.refresh_curve()
 
-    controller.cache_path = fail_cache_path
-
-    try:
-        controller.refresh_curve()
-    except OSError:
-        # Expected in this test: cache_path is forced to fail, we only verify inflight cleanup.
-        pass
-
+    assert app.cache.vf_curve_points == points
+    assert rendered == [True]
+    assert not (tmp_path / "vfp_cache").exists()
     assert controller.is_refresh_inflight() is False
 
 

--- a/tui/tests/test_parsing.py
+++ b/tui/tests/test_parsing.py
@@ -24,6 +24,7 @@ from nvoc_tui.parsing import (
     parse_info_output,
     parse_json_output,
     parse_status_output,
+    vf_curve_points_to_series,
 )
 
 
@@ -230,6 +231,21 @@ def test_load_vf_curve(tmp_path: Path) -> None:
     assert voltages == [800.0, 825.0, 850.0]
     assert freqs == [1800.0, 1840.0, 1900.0]
     assert defaults == [1750.0, 1775.0, 1800.0]
+
+
+def test_vf_curve_points_to_series_uses_frequency_as_missing_default() -> None:
+    voltages, frequencies, defaults = vf_curve_points_to_series([
+        {
+            "voltage_uv": 800000,
+            "frequency_khz": 1800000,
+            "default_frequency_khz": 1750000,
+        },
+        {"voltage_uv": 825000, "frequency_khz": 1840000},
+    ])
+
+    assert voltages == [800.0, 825.0]
+    assert frequencies == [1800.0, 1840.0]
+    assert defaults == [1750.0, 1840.0]
 
 
 def test_load_vf_curve_deltas_skips_invalid_rows(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- keep read-only V/F point responses in the TUI cache and convert them directly to plot series
- remove the automatic write-then-read round trip through `vfp_cache/*.csv` on every refresh
- retain CSV I/O only for explicit user import/export actions
- add conversion and controller regressions, including verification that refresh creates no cache directory

This PR is independent of #296; both target `main` directly. Umbrella: #267.

## Validation

- `cd tui && uv sync && uv run pytest` (57 passed)
- `cd tui && uv run ruff format . --preview --check --output-format=github`
- `cd tui && uv run ruff check . --output-format=github`