### PR TITLE
fix(gui): recover from GPU hot-add and removal

### DIFF
--- a/gui/src/app.py
+++ b/gui/src/app.py
@@ -44,6 +44,22 @@ from src.tabs.vfcurve import VFCurveTab
 
 import shutil
 
+
+def _is_discovery_offline_error(output: str) -> bool:
+    """Return whether discovery failed because the NVIDIA GPU disappeared."""
+    if not output:
+        return False
+    lowered = output.lower()
+    return (
+        "not_initialized" in lowered
+        or "api_not_initialized" in lowered
+        or "noimplementation" in lowered
+        or "nvidia_device_not_found" in lowered
+        or "novidevicefound" in lowered
+        or "gpu is lost" in lowered
+    )
+
+
 if TYPE_CHECKING:
     from src.single_instance import SingleInstanceGuard
 
@@ -151,6 +167,9 @@ class App(ctk.CTk):
 
         # Guard to suppress _on_gpu_changed during programmatic gpu_var.set() calls
         self._programmatic_gpu_set: bool = False
+        # When no NVIDIA GPU is visible, periodically re-run discovery so an
+        # eGPU or a re-enabled laptop dGPU appears without restarting the GUI.
+        self._gpu_reprobe_after_id: Optional[str] = None
 
         # Initial GPU list
         self.after(500, self._refresh_gpu_list)
@@ -457,15 +476,41 @@ class App(ctk.CTk):
 
         self.run_background("gpu-list", _worker)
 
+    def _start_gpu_reprobe(self) -> None:
+        """Schedule discovery retries until an NVIDIA GPU becomes available."""
+        if self._exiting or self._gpu_reprobe_after_id is not None:
+            return
+        self._gpu_reprobe_after_id = self.after(5000, self._gpu_reprobe_tick)
+
+    def _gpu_reprobe_tick(self) -> None:
+        self._gpu_reprobe_after_id = None
+        if self._exiting:
+            return
+        if self.selected_gpu_target() is None:
+            self._refresh_gpu_list()
+
+    def _stop_gpu_reprobe(self) -> None:
+        if self._gpu_reprobe_after_id is None:
+            return
+        try:
+            self.after_cancel(self._gpu_reprobe_after_id)
+        except Exception:
+            pass
+        self._gpu_reprobe_after_id = None
+
     def _apply_gpu_list(
         self, retcode: int, output: str, items: List[Dict[str, Any]]
     ) -> None:
         """Apply native GPU discovery results to the dropdown."""
-        self.console.append(output if output.endswith("\n") else f"{output}\n")
+        offline_error = retcode != 0 and _is_discovery_offline_error(output)
+        if output and not offline_error:
+            self.console.append(output if output.endswith("\n") else f"{output}\n")
         if retcode != 0:
-            self.console.append("[GUI] Failed to detect GPUs.\n")
+            if not offline_error:
+                self.console.append("[GUI] Failed to detect GPUs.\n")
             self.gpu_dropdown.configure(values=["(detection failed)"])
             self.gpu_var.set("(detection failed)")
+            self._start_gpu_reprobe()
             return
 
         short_labels: Dict[int, str] = {}
@@ -499,6 +544,7 @@ class App(ctk.CTk):
                 self.gpu_var.set("(no GPUs found)")
             finally:
                 self._programmatic_gpu_set = False
+            self._start_gpu_reprobe()
             return
 
         self.gpu_map = {}
@@ -525,6 +571,7 @@ class App(ctk.CTk):
         finally:
             self._programmatic_gpu_set = False
         self.console.append(f"[GUI] Found {len(ordered_indices)} GPU(s).\n")
+        self._stop_gpu_reprobe()
         self._query_gpu_info()
 
     def _parse_gpu_list(self, retcode: int, output: str):
@@ -1372,6 +1419,8 @@ class App(ctk.CTk):
 
         if hasattr(self, "tab_dashboard") and self.tab_dashboard is not None:
             self.tab_dashboard._stop_polling()
+
+        self._stop_gpu_reprobe()
 
         if hasattr(self, "tab_overclock") and self.tab_overclock is not None:
             if hasattr(self.tab_overclock, "_stop_auto_refresh"):

--- a/gui/src/tabs/dashboard.py
+++ b/gui/src/tabs/dashboard.py
@@ -239,6 +239,9 @@ class DashboardTab:
     """Dashboard tab with real-time GPU metric bars."""
 
     _DEFAULT_INTERVAL_MS = 1000
+    _OFFLINE_FAIL_THRESHOLD = 3
+    _OFFLINE_BACKOFF_MS = 5000
+    _OFFLINE_BACKOFF_CAP_MS = 15000
 
     def __init__(self, parent: ctk.CTkFrame, app: "App") -> None:
         self.app = app
@@ -250,6 +253,9 @@ class DashboardTab:
         self._interval_ms = self._DEFAULT_INTERVAL_MS
         self._is_resize_active = False
         self._pending_done_payload: Optional[Tuple[int, str]] = None
+        self._consecutive_offline = 0
+        self._in_offline_backoff = False
+        self._offline_hint_logged = False
 
         self._build_ui()
         self._sync_lock_state_from_cache()
@@ -386,11 +392,41 @@ class DashboardTab:
 
     def _schedule_next(self) -> None:
         if self._polling:
-            self._poll_job = self.app.after(self._interval_ms, self._poll_tick)
+            self._poll_job = self.app.after(
+                self._current_poll_interval_ms(), self._poll_tick
+            )
+
+    def _current_poll_interval_ms(self) -> int:
+        if not self._in_offline_backoff:
+            return self._interval_ms
+        step = max(1, self._consecutive_offline - self._OFFLINE_FAIL_THRESHOLD + 1)
+        return min(
+            self._OFFLINE_BACKOFF_MS * step,
+            self._OFFLINE_BACKOFF_CAP_MS,
+        )
+
+    @staticmethod
+    def _looks_like_offline_error(output: str) -> bool:
+        if not output:
+            return False
+        lowered = output.lower()
+        return (
+            "not_initialized" in lowered
+            or "api_not_initialized" in lowered
+            or "noimplementation" in lowered
+            or "nvidia_device_not_found" in lowered
+            or "novidevicefound" in lowered
+            or "gpu is lost" in lowered
+        )
 
     def _poll_tick(self) -> None:
-        if self._polling:
-            self._fetch_once()
+        if not self._polling:
+            return
+        if self._in_offline_backoff:
+            self.app._refresh_gpu_list()
+            self._schedule_next()
+            return
+        self._fetch_once()
 
     def _fetch_once(self) -> None:
         # Sync lock state from cache at the start of every fetch
@@ -412,6 +448,9 @@ class DashboardTab:
     def _on_done(self, retcode: int, output: str) -> None:
         self._fetching = False
 
+        if retcode == 0:
+            self._exit_offline_backoff()
+
         if self._is_resize_active:
             # Keep only latest sample while resize is active, then flush once.
             self._pending_done_payload = (retcode, output)
@@ -419,8 +458,41 @@ class DashboardTab:
             self._schedule_next()
             return
 
+        if retcode != 0 and self._looks_like_offline_error(output):
+            self._record_offline_failure()
+            self._status_lbl.configure(text="⚠ dGPU offline")
+            for row in self._rows.values():
+                row.set_error()
+            self._schedule_next()
+            return
+
         self._apply_done_payload(retcode, output)
         self._schedule_next()
+
+    def _record_offline_failure(self) -> None:
+        self._consecutive_offline += 1
+        if (
+            not self._in_offline_backoff
+            and self._consecutive_offline >= self._OFFLINE_FAIL_THRESHOLD
+        ):
+            self._enter_offline_backoff()
+
+    def _enter_offline_backoff(self) -> None:
+        self._in_offline_backoff = True
+        if not self._offline_hint_logged:
+            self._offline_hint_logged = True
+            self.app.console.append(
+                "[GUI] dGPU probably offline — polling paused, "
+                "re-probing for the GPU to come back.\n"
+            )
+        self.app._refresh_gpu_list()
+
+    def _exit_offline_backoff(self) -> None:
+        if self._in_offline_backoff:
+            self._in_offline_backoff = False
+            self.app.console.append("[GUI] dGPU back online — resuming polling.\n")
+        self._consecutive_offline = 0
+        self._offline_hint_logged = False
 
     def _apply_done_payload(self, retcode: int, output: str) -> None:
         """Apply a status poll result to the UI in one batched update."""

--- a/gui/tests/test_gpu_hotplug.py
+++ b/gui/tests/test_gpu_hotplug.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+
+
+os.environ.setdefault("PYSTRAY_BACKEND", "dummy")
+
+from src.app import App, _is_discovery_offline_error
+from src.tabs.dashboard import DashboardTab
+
+
+class FakeConsole:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def append(self, message: str) -> None:
+        self.messages.append(message)
+
+
+class FakeApp:
+    def __init__(self) -> None:
+        self.console = FakeConsole()
+        self.refreshes = 0
+        self.scheduled: list[int] = []
+
+    def _refresh_gpu_list(self) -> None:
+        self.refreshes += 1
+
+    def after(self, delay: int, _callback) -> str:
+        self.scheduled.append(delay)
+        return f"after-{len(self.scheduled)}"
+
+
+def make_dashboard() -> tuple[DashboardTab, FakeApp]:
+    app = FakeApp()
+    dashboard = DashboardTab.__new__(DashboardTab)
+    dashboard.app = app
+    dashboard._polling = True
+    dashboard._poll_job = None
+    dashboard._interval_ms = 1000
+    dashboard._consecutive_offline = 0
+    dashboard._in_offline_backoff = False
+    dashboard._offline_hint_logged = False
+    return dashboard, app
+
+
+def test_offline_error_classification_excludes_unsupported_features() -> None:
+    assert _is_discovery_offline_error("NvAPI: API_NOT_INITIALIZED")
+    assert _is_discovery_offline_error("NVIDIA_DEVICE_NOT_FOUND")
+    assert DashboardTab._looks_like_offline_error("GPU is lost")
+    assert not _is_discovery_offline_error("NVAPI_NOT_SUPPORTED")
+    assert not DashboardTab._looks_like_offline_error("function not supported")
+
+
+def test_dashboard_enters_bounded_backoff_after_three_failures() -> None:
+    dashboard, app = make_dashboard()
+
+    for _ in range(3):
+        dashboard._record_offline_failure()
+
+    assert dashboard._in_offline_backoff is True
+    assert app.refreshes == 1
+    assert app.console.messages == [
+        "[GUI] dGPU probably offline — polling paused, "
+        "re-probing for the GPU to come back.\n"
+    ]
+    assert dashboard._current_poll_interval_ms() == 5000
+
+    dashboard._consecutive_offline = 10
+    assert dashboard._current_poll_interval_ms() == 15000
+
+
+def test_dashboard_backoff_tick_reprobes_instead_of_querying() -> None:
+    dashboard, app = make_dashboard()
+    dashboard._in_offline_backoff = True
+    dashboard._consecutive_offline = 3
+
+    dashboard._poll_tick()
+
+    assert app.refreshes == 1
+    assert app.scheduled == [5000]
+
+
+def test_dashboard_success_restores_normal_polling_state() -> None:
+    dashboard, app = make_dashboard()
+    dashboard._in_offline_backoff = True
+    dashboard._consecutive_offline = 6
+    dashboard._offline_hint_logged = True
+
+    dashboard._exit_offline_backoff()
+
+    assert dashboard._in_offline_backoff is False
+    assert dashboard._consecutive_offline == 0
+    assert dashboard._offline_hint_logged is False
+    assert app.console.messages == ["[GUI] dGPU back online — resuming polling.\n"]
+
+
+def test_app_reprobe_is_single_shot_until_discovery_finishes() -> None:
+    app = App.__new__(App)
+    app._exiting = False
+    app._gpu_reprobe_after_id = None
+    scheduled: list[int] = []
+    app.after = lambda delay, _callback: scheduled.append(delay) or "after-1"
+
+    app._start_gpu_reprobe()
+    app._start_gpu_reprobe()
+
+    assert scheduled == [5000]
+    assert app._gpu_reprobe_after_id == "after-1"


### PR DESCRIPTION
Child of #267.

## Scope

- Retry GPU discovery when no NVIDIA GPU is visible at startup or after removal.
- Back off dashboard polling after repeated offline errors.
- Suppress repeated offline discovery noise and resume normal polling when the GPU returns.

## Tests

- `cd gui && uv run ruff check . --output-format=github`
- `cd gui && uv run pytest` — 42 passed

No GPU-mutating tests were run.