### PR TITLE
fix(tui): recover from GPU hot-add and removal

### DIFF
--- a/tui/nvoc_tui/app.py
+++ b/tui/nvoc_tui/app.py
@@ -34,6 +34,21 @@ from .panes.overclock import compose_overclock
 from .panes.vfcurve import compose_vfcurve
 
 
+def _is_offline_error(output: str) -> bool:
+    """Return whether a query failed because the NVIDIA GPU disappeared."""
+    if not output:
+        return False
+    lowered = output.lower()
+    return (
+        "not_initialized" in lowered
+        or "api_not_initialized" in lowered
+        or "noimplementation" in lowered
+        or "nvidia_device_not_found" in lowered
+        or "novidevicefound" in lowered
+        or "gpu is lost" in lowered
+    )
+
+
 class NVOCApp(App[None]):
     TITLE = "NVOC-TUI"
     MIN_WIDTH = 55
@@ -92,6 +107,7 @@ class NVOCApp(App[None]):
         self.native_service = NativeService(self.root_dir)
         self.gpus: list[GpuDescriptor] = []
         self.cache = GpuCache()
+        self._gpu_reprobe_timer = None
 
         self.header_controller = HeaderController(self)
         self.dashboard_controller = DashboardController(self)
@@ -202,6 +218,9 @@ class NVOCApp(App[None]):
             return
 
         def finish_query(code: int, output: str, parsed: dict) -> None:
+            if code != 0 and _is_offline_error(output):
+                callback(code, output, parsed)
+                return
             if output and (log_output or code != 0):
                 self.write_log(output)
             callback(code, output, parsed)
@@ -211,6 +230,22 @@ class NVOCApp(App[None]):
             self.call_from_thread(finish_query, code, output, parsed)
 
         self.native_service.submit_query(worker)
+
+    def start_gpu_reprobe(self) -> None:
+        """Retry discovery until an NVIDIA GPU becomes available."""
+        if self._gpu_reprobe_timer is None:
+            self._gpu_reprobe_timer = self.set_interval(5.0, self._gpu_reprobe_tick)
+
+    def _gpu_reprobe_tick(self) -> None:
+        if not self.gpus:
+            self.refresh_gpu_list()
+        else:
+            self._stop_gpu_reprobe()
+
+    def _stop_gpu_reprobe(self) -> None:
+        if self._gpu_reprobe_timer is not None:
+            self._gpu_reprobe_timer.stop()
+            self._gpu_reprobe_timer = None
 
     def refresh_gpu_list(self) -> None:
         def worker() -> None:

--- a/tui/nvoc_tui/controllers/dashboard.py
+++ b/tui/nvoc_tui/controllers/dashboard.py
@@ -9,24 +9,85 @@ from .base import PaneController
 
 
 class DashboardController(PaneController):
+    _OFFLINE_FAIL_THRESHOLD = 3
+    _OFFLINE_BACKOFF_S = 5.0
+    _OFFLINE_BACKOFF_CAP_S = 15.0
+
     def __init__(self, app) -> None:
         super().__init__(app)
         self.poll_timer = None
         self._timer_paused = False
+        self._user_interval = 1.0
+        self._consecutive_offline = 0
+        self._in_offline_backoff = False
+        self._offline_hint_logged = False
 
     def set_poll_timer(self, interval: float) -> None:
         interval = max(0.2, min(interval, 60.0))
+        self._user_interval = interval
         self.app.config_data.dashboard.refresh_interval = interval
         self.app.save_config()
         if self.poll_timer is not None:
             self.poll_timer.stop()
         self._timer_paused = False
-        self.poll_timer = self.app.set_interval(interval, self.tick, pause=False)
+        self.poll_timer = self.app.set_interval(
+            self._effective_interval(), self.tick, pause=False
+        )
+
+    def _effective_interval(self) -> float:
+        if not self._in_offline_backoff:
+            return self._user_interval
+        step = max(1, self._consecutive_offline - self._OFFLINE_FAIL_THRESHOLD + 1)
+        return min(self._OFFLINE_BACKOFF_S * step, self._OFFLINE_BACKOFF_CAP_S)
 
     def tick(self) -> None:
         if self.app.native_service.action_state.running:
             return
+        if self._in_offline_backoff:
+            self.app.refresh_gpu_list()
+            return
         self.app.run_query("status", self.on_status_loaded, log_output=False)
+
+    @staticmethod
+    def _looks_like_offline_error(output: str) -> bool:
+        if not output:
+            return False
+        lowered = output.lower()
+        return (
+            "not_initialized" in lowered
+            or "api_not_initialized" in lowered
+            or "noimplementation" in lowered
+            or "nvidia_device_not_found" in lowered
+            or "novidevicefound" in lowered
+            or "gpu is lost" in lowered
+        )
+
+    def _record_offline_failure(self) -> None:
+        self._consecutive_offline += 1
+        if (
+            not self._in_offline_backoff
+            and self._consecutive_offline >= self._OFFLINE_FAIL_THRESHOLD
+        ):
+            self._enter_offline_backoff()
+
+    def _enter_offline_backoff(self) -> None:
+        self._in_offline_backoff = True
+        if not self._offline_hint_logged:
+            self._offline_hint_logged = True
+            self.app.write_log(
+                "dGPU probably offline — polling paused, re-probing for the "
+                "GPU to come back."
+            )
+        self.set_poll_timer(self._user_interval)
+        self.app.refresh_gpu_list()
+
+    def _exit_offline_backoff(self) -> None:
+        if self._in_offline_backoff:
+            self._in_offline_backoff = False
+            self.app.write_log("dGPU back online — resuming polling.")
+            self.set_poll_timer(self._user_interval)
+        self._consecutive_offline = 0
+        self._offline_hint_logged = False
 
     def on_info_loaded(self, code: int, output: str, parsed: dict) -> None:
         if code != 0 and not parsed:
@@ -36,6 +97,11 @@ class DashboardController(PaneController):
         self.app.overclock_controller.prime_inputs()
 
     def on_status_loaded(self, code: int, output: str, parsed: dict) -> None:
+        if code == 0:
+            self._exit_offline_backoff()
+        elif self._looks_like_offline_error(output):
+            self._record_offline_failure()
+            return
         if code != 0 and not parsed:
             return
         self.app.cache.status = parsed

--- a/tui/nvoc_tui/controllers/header.py
+++ b/tui/nvoc_tui/controllers/header.py
@@ -6,6 +6,21 @@ from ..models import GpuDescriptor
 from .base import PaneController
 
 
+def _is_discovery_offline_error(output: str) -> bool:
+    """Return whether discovery failed because the NVIDIA GPU disappeared."""
+    if not output:
+        return False
+    lowered = output.lower()
+    return (
+        "not_initialized" in lowered
+        or "api_not_initialized" in lowered
+        or "noimplementation" in lowered
+        or "nvidia_device_not_found" in lowered
+        or "novidevicefound" in lowered
+        or "gpu is lost" in lowered
+    )
+
+
 class HeaderController(PaneController):
     def selected_gpu_idx(self) -> int | None:
         try:
@@ -39,13 +54,16 @@ class HeaderController(PaneController):
     def on_gpu_list_loaded(
         self, code: int, output: str, gpus: list[GpuDescriptor]
     ) -> None:
-        self.app.write_log(output or "GPU detection finished.")
+        if code == 0 or not _is_discovery_offline_error(output):
+            self.app.write_log(output or "GPU detection finished.")
         self.app.gpus = gpus
         select = self.app.query_one("#gpu-select", Select)
         if not gpus:
             select.set_options([("(no GPUs found)", "-1")])
             select.value = "-1"
+            self.app.start_gpu_reprobe()
             return
+        self.app._stop_gpu_reprobe()
         select.set_options([(gpu.long_label, str(gpu.index)) for gpu in gpus])
         target = self.app.config_data.last_gpu_idx
         if target is None or all(gpu.index != target for gpu in gpus):

--- a/tui/tests/test_controllers.py
+++ b/tui/tests/test_controllers.py
@@ -4,12 +4,13 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from nvoc_tui.app import NVOCApp
+from nvoc_tui.app import NVOCApp, _is_offline_error
 from nvoc_tui.controllers.console import ConsoleController
 from nvoc_tui.controllers.dashboard import DashboardController
+from nvoc_tui.controllers.header import HeaderController
 from nvoc_tui.controllers.overclock import OverclockController
 from nvoc_tui.controllers.vfcurve import VFCurveController
-from nvoc_tui.models import AppConfig, GpuCache
+from nvoc_tui.models import AppConfig, GpuCache, GpuDescriptor
 
 
 class FakeApp:
@@ -27,6 +28,13 @@ class FakeApp:
             action_state=SimpleNamespace(running=False)
         )
         self.classes: set[str] = set()
+        self.gpus = []
+        self.refreshes = 0
+        self.reprobe_starts = 0
+        self.reprobe_stops = 0
+        self.timers: list[FakeTimer] = []
+        self.dashboard_focuses = 0
+        self.full_refreshes = 0
 
     def query_one(self, selector: str, _widget_type=None):
         return self.widgets[selector]
@@ -72,6 +80,43 @@ class FakeApp:
 
     def write_log(self, text: str) -> None:
         self.logs.append(text)
+
+    def set_interval(self, interval: float, callback, *, pause: bool = False):
+        timer = FakeTimer(interval, callback, pause)
+        self.timers.append(timer)
+        return timer
+
+    def refresh_gpu_list(self) -> None:
+        self.refreshes += 1
+
+    def start_gpu_reprobe(self) -> None:
+        self.reprobe_starts += 1
+
+    def _stop_gpu_reprobe(self) -> None:
+        self.reprobe_stops += 1
+
+    def focus_dashboard_tab_switcher(self) -> None:
+        self.dashboard_focuses += 1
+
+    def refresh_all_state(self) -> None:
+        self.full_refreshes += 1
+
+
+class FakeTimer:
+    def __init__(self, interval: float, callback, pause: bool = False) -> None:
+        self.interval = interval
+        self.callback = callback
+        self.paused = pause
+        self.stopped = False
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def pause(self) -> None:
+        self.paused = True
+
+    def resume(self) -> None:
+        self.paused = False
 
 
 class FakePanel:
@@ -162,6 +207,82 @@ def test_dashboard_tick_suppresses_status_json_output() -> None:
     assert command_name == "status"
     assert callback.__name__ == "on_status_loaded"
     assert log_output is False
+
+
+def test_offline_error_classification_excludes_unsupported_features() -> None:
+    assert _is_offline_error("NvAPI: API_NOT_INITIALIZED")
+    assert DashboardController._looks_like_offline_error("GPU is lost")
+    assert not _is_offline_error("NVAPI_NOT_SUPPORTED")
+    assert not DashboardController._looks_like_offline_error("function not supported")
+
+
+def test_dashboard_enters_backoff_after_three_offline_failures() -> None:
+    app = FakeApp()
+    controller = DashboardController(app)
+    controller.set_poll_timer(1.0)
+
+    for _ in range(3):
+        controller.on_status_loaded(-1, "API_NOT_INITIALIZED", {})
+
+    assert controller._in_offline_backoff is True
+    assert controller._effective_interval() == 5.0
+    assert app.refreshes == 1
+    assert app.logs == [
+        "dGPU probably offline — polling paused, re-probing for the GPU to come back."
+    ]
+    assert app.timers[-1].interval == 5.0
+
+
+def test_dashboard_backoff_tick_reprobes_instead_of_querying() -> None:
+    app = FakeApp()
+    controller = DashboardController(app)
+    controller._in_offline_backoff = True
+
+    controller.tick()
+
+    assert app.refreshes == 1
+    assert app.query_calls == []
+
+
+def test_dashboard_success_restores_user_poll_interval() -> None:
+    app = FakeApp()
+    app.widgets["#metrics"] = SimpleNamespace(update=lambda _value: None)
+    controller = DashboardController(app)
+    controller._user_interval = 2.5
+    controller._in_offline_backoff = True
+    controller._consecutive_offline = 4
+    controller._offline_hint_logged = True
+
+    controller.on_status_loaded(0, "", {})
+
+    assert controller._in_offline_backoff is False
+    assert controller._consecutive_offline == 0
+    assert app.logs == ["dGPU back online — resuming polling."]
+    assert app.timers[-1].interval == 2.5
+
+
+def test_header_reprobes_empty_gpu_list_and_stops_after_gpu_returns() -> None:
+    app = FakeApp()
+    select = SimpleNamespace(options=[], value=None)
+    select.set_options = lambda options: setattr(select, "options", options)
+    app.widgets["#gpu-select"] = select
+    controller = HeaderController(app)
+
+    controller.on_gpu_list_loaded(-1, "API_NOT_INITIALIZED", [])
+
+    assert app.logs == []
+    assert app.reprobe_starts == 1
+    assert select.value == "-1"
+
+    controller.on_gpu_list_loaded(
+        0, "", [GpuDescriptor(index=2, name="RTX", gpu_id_hex="0x2")]
+    )
+
+    assert app.reprobe_stops == 1
+    assert select.options == [("GPU 2: RTX [0x2]", "2")]
+    assert select.value == "2"
+    assert app.dashboard_focuses == 1
+    assert app.full_refreshes == 1
 
 
 def test_console_maximize_toggle_updates_app_class_and_label() -> None:
@@ -433,7 +554,7 @@ def test_vfcurve_refresh_suppresses_overlapping_workers(tmp_path: Path) -> None:
     assert controller.is_refresh_inflight() is True
 
 
-def test_vfcurve_refresh_keeps_points_in_memory(tmp_path: Path, monkeypatch) -> None:
+def test_vfcurve_refresh_keeps_points_in_memory(tmp_path: Path) -> None:
     app = FakeApp()
     app.root_dir = tmp_path
     points = [
@@ -445,16 +566,7 @@ def test_vfcurve_refresh_keeps_points_in_memory(tmp_path: Path, monkeypatch) -> 
     ]
     app.native_service.query_domain_vfp_points = lambda _gpu: points
 
-    class ImmediateThread:
-        def __init__(self, *, target, daemon, name) -> None:
-            self.target = target
-
-        def start(self) -> None:
-            self.target()
-
-    monkeypatch.setattr(
-        "nvoc_tui.controllers.vfcurve.threading.Thread", ImmediateThread
-    )
+    app.native_service.submit_query = lambda job: job()
     controller = VFCurveController(app)
     rendered: list[bool] = []
     controller.render_plot = lambda: rendered.append(True)


### PR DESCRIPTION
Child of #267.

## Scope

- Retry GPU discovery when no NVIDIA GPU is visible at startup or after removal.
- Back off status polling after repeated offline errors.
- Suppress repeated offline discovery noise and resume the configured cadence when the GPU returns.

## Tests

- `cd tui && uv run ruff check . --output-format=github`
- `cd tui && uv run pytest` — 65 passed

No GPU-mutating tests were run.