### PR TITLE
perf(gui): pause dashboard polling while in tray

### DIFF
--- a/gui/src/tabs/dashboard.py
+++ b/gui/src/tabs/dashboard.py
@@ -422,6 +422,14 @@ class DashboardTab:
     def _poll_tick(self) -> None:
         if not self._polling:
             return
+        # The dashboard is not visible while the app lives in the system tray;
+        # avoid a full NVAPI/NVML sweep every second until the window returns.
+        try:
+            if self.app.state() == "withdrawn":
+                self._schedule_next()
+                return
+        except Exception:
+            pass
         if self._in_offline_backoff:
             self.app._refresh_gpu_list()
             self._schedule_next()

--- a/gui/tests/test_dashboard_visibility.py
+++ b/gui/tests/test_dashboard_visibility.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from src.tabs.dashboard import DashboardTab
+
+
+class FakeApp:
+    def __init__(self, state: str) -> None:
+        self._state = state
+        self.scheduled: list[int] = []
+
+    def state(self) -> str:
+        return self._state
+
+    def after(self, delay: int, _callback) -> str:
+        self.scheduled.append(delay)
+        return "poll-job"
+
+
+def make_dashboard(state: str) -> tuple[DashboardTab, FakeApp]:
+    app = FakeApp(state)
+    dashboard = DashboardTab.__new__(DashboardTab)
+    dashboard.app = app
+    dashboard._polling = True
+    dashboard._poll_job = None
+    dashboard._interval_ms = 1000
+    dashboard._consecutive_offline = 0
+    dashboard._in_offline_backoff = False
+    return dashboard, app
+
+
+def test_poll_tick_defers_query_while_window_is_withdrawn() -> None:
+    dashboard, app = make_dashboard("withdrawn")
+    fetches: list[bool] = []
+    dashboard._fetch_once = lambda: fetches.append(True)
+
+    dashboard._poll_tick()
+
+    assert fetches == []
+    assert app.scheduled == [1000]
+
+
+def test_poll_tick_queries_when_window_is_visible() -> None:
+    dashboard, app = make_dashboard("normal")
+    fetches: list[bool] = []
+    dashboard._fetch_once = lambda: fetches.append(True)
+
+    dashboard._poll_tick()
+
+    assert fetches == [True]
+    assert app.scheduled == []


### PR DESCRIPTION
Child of #267.

## Scope

- Skip the periodic NVAPI/NVML dashboard query while the GUI window is withdrawn to the system tray.
- Keep the timer armed so normal polling resumes when the window becomes visible.
- Leave manual pause, offline backoff, and visible dashboard behavior unchanged.

## Tests

- `cd gui && ruff check .`
- `cd gui && uv run pytest` — 44 passed

No GPU-mutating tests were run.