### PR TITLE
fix(gui): deduplicate global scrollwheel handlers

### DIFF
--- a/gui/src/widgets/lightweight_controls.py
+++ b/gui/src/widgets/lightweight_controls.py
@@ -7,6 +7,9 @@ from typing import List, Optional, Tuple
 
 import customtkinter as ctk
 
+# Mouse-wheel scroll multiplier: canvas "units" per wheel notch.
+_WHEEL_STEP_UNITS = 6
+
 
 def _is_descendant_widget(widget: tk.Misc, ancestor: tk.Misc) -> bool:
     """Return True when *widget* is *ancestor* or one of its descendants."""
@@ -31,34 +34,40 @@ def install_mousewheel_support(scroll_frame: ctk.CTkScrollableFrame) -> None:
     ``<Button-4>/<Button-5>`` or ``<MouseWheel>`` with tiny deltas. We bind all
     variants and normalize them into canvas unit scrolling.
     """
-    if getattr(scroll_frame, "_nvoc_mousewheel_installed", False):
+    # ``bind_all(..., add="+")`` installs handlers on the toplevel. Guarding
+    # each frame separately stacks three more global callbacks for every tab.
+    # Keep one toplevel dispatcher and register the frames it may target.
+    toplevel = scroll_frame.winfo_toplevel()
+    frames = getattr(toplevel, "_nvoc_mousewheel_frames", None)
+    if frames is None:
+        frames = []
+        setattr(toplevel, "_nvoc_mousewheel_frames", frames)
+    if scroll_frame not in frames:
+        frames.append(scroll_frame)
+    if getattr(toplevel, "_nvoc_mousewheel_installed", False):
         return
-    setattr(scroll_frame, "_nvoc_mousewheel_installed", True)
+    setattr(toplevel, "_nvoc_mousewheel_installed", True)
 
-    def _resolve_canvas() -> Optional[tk.Misc]:
-        canvas = getattr(scroll_frame, "_parent_canvas", None)
-        if canvas is None:
-            return None
-        return canvas
-
-    def _pointer_inside_frame() -> bool:
-        if not scroll_frame.winfo_exists():
-            return False
+    def _frame_at_pointer():
         try:
-            pointer_x = scroll_frame.winfo_pointerx()
-            pointer_y = scroll_frame.winfo_pointery()
-            hovered = scroll_frame.winfo_containing(pointer_x, pointer_y)
+            pointer_x = toplevel.winfo_pointerx()
+            pointer_y = toplevel.winfo_pointery()
+            hovered = toplevel.winfo_containing(pointer_x, pointer_y)
         except tk.TclError:
-            return False
+            return None
         if hovered is None:
-            return False
-        return _is_descendant_widget(hovered, scroll_frame)
+            return None
+        for frame in frames:
+            if frame.winfo_exists() and _is_descendant_widget(hovered, frame):
+                return frame
+        return None
 
     def _on_mousewheel(event) -> Optional[str]:
-        if not _pointer_inside_frame():
+        frame = _frame_at_pointer()
+        if frame is None:
             return None
 
-        canvas = _resolve_canvas()
+        canvas = getattr(frame, "_parent_canvas", None)
         if canvas is None:
             return None
 
@@ -81,12 +90,11 @@ def install_mousewheel_support(scroll_frame: ctk.CTkScrollableFrame) -> None:
             return "break"
 
         try:
-            canvas.yview_scroll(steps, "units")
+            canvas.yview_scroll(steps * _WHEEL_STEP_UNITS, "units")
         except Exception:
             return None
         return "break"
 
-    toplevel = scroll_frame.winfo_toplevel()
     toplevel.bind_all("<MouseWheel>", _on_mousewheel, add="+")
     toplevel.bind_all("<Button-4>", _on_mousewheel, add="+")
     toplevel.bind_all("<Button-5>", _on_mousewheel, add="+")

--- a/gui/tests/test_lightweight_controls.py
+++ b/gui/tests/test_lightweight_controls.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.widgets import lightweight_controls
+
+
+class FakeCanvas:
+    def __init__(self) -> None:
+        self.scrolls: list[tuple[int, str]] = []
+
+    def yview_scroll(self, steps: int, unit: str) -> None:
+        self.scrolls.append((steps, unit))
+
+
+class FakeTopLevel:
+    def __init__(self) -> None:
+        self.hovered = None
+        self.bindings: dict[str, object] = {}
+
+    def winfo_pointerx(self) -> int:
+        return 1
+
+    def winfo_pointery(self) -> int:
+        return 1
+
+    def winfo_containing(self, _x: int, _y: int):
+        return self.hovered
+
+    def bind_all(self, event: str, callback, *, add: str) -> None:
+        assert add == "+"
+        self.bindings[event] = callback
+
+
+class FakeFrame:
+    def __init__(self, toplevel: FakeTopLevel) -> None:
+        self.toplevel = toplevel
+        self._parent_canvas = FakeCanvas()
+
+    def winfo_toplevel(self) -> FakeTopLevel:
+        return self.toplevel
+
+    def winfo_exists(self) -> bool:
+        return True
+
+
+def test_mousewheel_uses_one_toplevel_dispatcher_for_multiple_frames(
+    monkeypatch,
+) -> None:
+    toplevel = FakeTopLevel()
+    first = FakeFrame(toplevel)
+    second = FakeFrame(toplevel)
+    monkeypatch.setattr(
+        lightweight_controls,
+        "_is_descendant_widget",
+        lambda hovered, frame: hovered is frame,
+    )
+
+    lightweight_controls.install_mousewheel_support(first)
+    lightweight_controls.install_mousewheel_support(second)
+
+    assert set(toplevel.bindings) == {"<MouseWheel>", "<Button-4>", "<Button-5>"}
+    assert toplevel._nvoc_mousewheel_frames == [first, second]
+
+    toplevel.hovered = second
+    result = toplevel.bindings["<MouseWheel>"](SimpleNamespace(num=None, delta=-120))
+
+    assert result == "break"
+    assert first._parent_canvas.scrolls == []
+    assert second._parent_canvas.scrolls == [(6, "units")]
+
+
+def test_linux_wheel_event_uses_same_scroll_multiplier(monkeypatch) -> None:
+    toplevel = FakeTopLevel()
+    frame = FakeFrame(toplevel)
+    toplevel.hovered = frame
+    monkeypatch.setattr(
+        lightweight_controls,
+        "_is_descendant_widget",
+        lambda hovered, candidate: hovered is candidate,
+    )
+    lightweight_controls.install_mousewheel_support(frame)
+
+    result = toplevel.bindings["<Button-4>"](SimpleNamespace(num=4, delta=0))
+
+    assert result == "break"
+    assert frame._parent_canvas.scrolls == [(-6, "units")]


### PR DESCRIPTION
Child of #267.

## Scope

- Install one mousewheel dispatcher per toplevel instead of stacking three global callbacks per scrollable tab.
- Route wheel events to the scrollable frame currently under the pointer.
- Use six canvas units per wheel notch for responsive scrolling on Tk/CTk panels.

## Tests

- `cd gui && ruff check .`
- `cd gui && uv run pytest` — 44 passed

No GPU tests were required.