### PR TITLE
fix(gui): use portable paths and native fixed fonts

### DIFF
--- a/gui/src/config.py
+++ b/gui/src/config.py
@@ -15,8 +15,8 @@ DEFAULT_CONFIG: Dict[str, JSONValue] = {
     "last_gpu_idx": "",
     "autoscan": {
         "mode": "standard",  # standard / ultrafast / legacy
-        "output_csv": r".\ws\vfp-tem.csv",
-        "init_csv": r".\ws\vfp-init.csv",
+        "output_csv": "./ws/vfp-tem.csv",
+        "init_csv": "./ws/vfp-init.csv",
         "bsod_recovery": "",
     },
 }

--- a/gui/src/tabs/autoscan.py
+++ b/gui/src/tabs/autoscan.py
@@ -64,7 +64,7 @@ class AutoscanTab:
         ctk.CTkLabel(params_grid, text="Output CSV:").grid(
             row=row, column=0, sticky="w", padx=5, pady=3
         )
-        self.output_csv_var = ctk.StringVar(value=r".\ws\vfp-tem.csv")
+        self.output_csv_var = ctk.StringVar(value="./ws/vfp-tem.csv")
         out_row = ctk.CTkFrame(params_grid, fg_color="transparent")
         out_row.grid(row=row, column=1, sticky="ew", padx=5, pady=3)
         out_entry = LiteEntry(
@@ -87,7 +87,7 @@ class AutoscanTab:
         ctk.CTkLabel(params_grid, text="Init CSV:").grid(
             row=row, column=0, sticky="w", padx=5, pady=3
         )
-        self.init_csv_var = ctk.StringVar(value=r".\ws\vfp-init.csv")
+        self.init_csv_var = ctk.StringVar(value="./ws/vfp-init.csv")
         init_row = ctk.CTkFrame(params_grid, fg_color="transparent")
         init_row.grid(row=row, column=1, sticky="ew", padx=5, pady=3)
         init_entry = LiteEntry(
@@ -294,8 +294,8 @@ class AutoscanTab:
 
     def _import_final(self) -> None:
         gpu_args = self.app.get_gpu_args()
-        self.app.run_cli_display(gpu_args + ["import-vfp", r".\ws\vfp.csv"])
+        self.app.run_cli_display(gpu_args + ["import-vfp", "./ws/vfp.csv"])
 
     def _export_final(self) -> None:
         gpu_args = self.app.get_gpu_args()
-        self.app.run_cli_display(gpu_args + ["export-vfp", r".\ws\vfp-final.csv"])
+        self.app.run_cli_display(gpu_args + ["export-vfp", "./ws/vfp-final.csv"])

--- a/gui/src/widgets/output_console.py
+++ b/gui/src/widgets/output_console.py
@@ -3,6 +3,8 @@ Output Console Widget - A read-only scrollable text area for CLI output.
 """
 
 import threading
+import sys
+import tkinter.font as tk_font
 
 import customtkinter as ctk
 
@@ -39,11 +41,19 @@ class OutputConsole(ctk.CTkFrame):
         self.clear_button.pack(side="right")
 
         self.textbox = ctk.CTkTextbox(
-            self, state="disabled", font=("Consolas", 12), wrap="none", height=200
+            self, state="disabled", font=self._mono_font(), wrap="none", height=200
         )
         self.textbox.tag_config("lime", foreground="lime")
         self.textbox.tag_config("red", foreground="red")
         self._set_expanded(False)
+
+    @staticmethod
+    def _mono_font() -> tuple[str, int]:
+        """Use Consolas on Windows and Tk's native fixed font elsewhere."""
+        if sys.platform == "win32":
+            return ("Consolas", 12)
+        fixed = tk_font.nametofont("TkFixedFont")
+        return (str(fixed.cget("family")), max(10, int(fixed.cget("size"))))
 
     def toggle(self, _event: object = None) -> None:
         """Toggle the console body between folded and expanded."""

--- a/gui/tests/test_portable_gui_defaults.py
+++ b/gui/tests/test_portable_gui_defaults.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from src.config import DEFAULT_CONFIG
+from src.widgets.output_console import OutputConsole
+
+
+def test_autoscan_defaults_use_portable_path_separators() -> None:
+    autoscan = DEFAULT_CONFIG["autoscan"]
+
+    assert isinstance(autoscan, dict)
+    assert autoscan["output_csv"] == "./ws/vfp-tem.csv"
+    assert autoscan["init_csv"] == "./ws/vfp-init.csv"
+
+
+def test_console_uses_native_fixed_font_off_windows(monkeypatch) -> None:
+    class FakeFont:
+        def cget(self, key: str):
+            return {"family": "DejaVu Sans Mono", "size": 9}[key]
+
+    monkeypatch.setattr("src.widgets.output_console.sys.platform", "linux")
+    monkeypatch.setattr(
+        "src.widgets.output_console.tk_font.nametofont",
+        lambda name: FakeFont() if name == "TkFixedFont" else None,
+    )
+
+    assert OutputConsole._mono_font() == ("DejaVu Sans Mono", 10)
+
+
+def test_console_keeps_consolas_on_windows(monkeypatch) -> None:
+    monkeypatch.setattr("src.widgets.output_console.sys.platform", "win32")
+
+    assert OutputConsole._mono_font() == ("Consolas", 12)


### PR DESCRIPTION
Child of #267.

## Scope

- Replace Windows-only autoscan path literals with portable `./ws/...` paths.
- Use Tk's native fixed font outside Windows while preserving Consolas on Windows.
- Cover defaults and platform font selection with unit tests.

## Tests

- `cd gui && ruff check .`
- `cd gui && uv run pytest` — 49 passed

No GPU tests were required.