### PR TITLE
fix(gui): cancel CLI processes off the UI thread

### DIFF
--- a/gui/src/cli_runner.py
+++ b/gui/src/cli_runner.py
@@ -32,10 +32,13 @@ class CLIRunner:
         self.on_finished = on_finished
         self._submit = submit
         self._fallback_executor = None  # type: Optional[ThreadPoolExecutor]
+        self._cancel_executor = None  # type: Optional[ThreadPoolExecutor]
         self._process = None  # type: Optional[subprocess.Popen]
         self._thread = None  # type: Optional[object]
         self._cancelled = False
         self._busy = False
+        self._cancel_inflight = False
+        self._cancel_target = None  # type: Optional[subprocess.Popen]
         self._current_on_finished = None  # type: Optional[Callable[[int], None]]
         self._lock = Lock()
 
@@ -176,14 +179,22 @@ class CLIRunner:
         except Exception as e:
             return -1, str(e)
 
-    def cancel(self) -> None:
-        """Cancel the currently running process."""
+    def cancel(self, wait: bool = False) -> None:
+        """Cancel the active process without blocking the caller by default.
+
+        A process holding driver handles may take the full timeout to exit.
+        The GUI cancel button therefore schedules terminate/wait/kill on a
+        worker; shutdown passes ``wait=True`` for deterministic teardown.
+        """
         callback = None  # type: Optional[Callable[[int], None]]
         cancelled_pending = False
         with self._lock:
             self._cancelled = True
             process = self._process
             thread = self._thread
+            already_cancelling = (
+                self._cancel_inflight and self._cancel_target is process
+            )
             if process is None and thread is not None:
                 cancel = getattr(thread, "cancel", None)
                 if callable(cancel) and cancel():
@@ -199,7 +210,14 @@ class CLIRunner:
                 callback(-1)
             return
 
-        if process is not None:
+        if process is None or already_cancelling:
+            return
+
+        with self._lock:
+            self._cancel_inflight = True
+            self._cancel_target = process
+
+        def _terminate_job() -> None:
             try:
                 process.terminate()
             except OSError:
@@ -212,10 +230,35 @@ class CLIRunner:
                 except OSError:
                     # Best-effort cancellation: process may have already exited.
                     pass
+            finally:
+                with self._lock:
+                    if self._cancel_target is process:
+                        self._cancel_inflight = False
+                        self._cancel_target = None
+
+        if wait:
+            _terminate_job()
+            return
+
+        if self._submit is not None:
+            try:
+                self._submit("cli-cancel", _terminate_job)
+                return
+            except Exception:
+                pass
+
+        if self._cancel_executor is None:
+            self._cancel_executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="nvoc-gui-cli-cancel"
+            )
+        self._cancel_executor.submit(_terminate_job)
 
     def shutdown(self) -> None:
         """Stop any active process and release fallback worker threads."""
-        self.cancel()
+        self.cancel(wait=True)
         if self._fallback_executor is not None:
             self._fallback_executor.shutdown(wait=True, cancel_futures=True)
             self._fallback_executor = None
+        if self._cancel_executor is not None:
+            self._cancel_executor.shutdown(wait=True, cancel_futures=True)
+            self._cancel_executor = None

--- a/gui/tests/test_cli_runner.py
+++ b/gui/tests/test_cli_runner.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+
 from src import cli_runner
 from src.cli_runner import CLIRunner
 
@@ -95,3 +97,111 @@ def test_cli_runner_captures_per_run_callback(monkeypatch) -> None:
 
     assert finished == ["first:7"]
     assert not runner.is_running
+
+
+def test_cli_runner_cancel_schedules_process_wait_off_caller_thread() -> None:
+    queued: list[QueuedJob] = []
+
+    def submit(_name, task):
+        job = QueuedJob(task)
+        queued.append(job)
+        return job
+
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.terminated = 0
+            self.waited = 0
+
+        def terminate(self) -> None:
+            self.terminated += 1
+
+        def wait(self, timeout: int) -> int:
+            assert timeout == 3
+            self.waited += 1
+            return 0
+
+    process = FakeProcess()
+    runner = CLIRunner("nvoc-autooptimizer", lambda _text: None, submit=submit)
+    runner._process = process
+    runner._busy = True
+
+    runner.cancel()
+
+    assert process.terminated == 0
+    assert process.waited == 0
+    assert len(queued) == 1
+    assert runner._cancel_inflight is True
+
+    queued[0].task()
+
+    assert process.terminated == 1
+    assert process.waited == 1
+    assert runner._cancel_inflight is False
+
+
+def test_cli_runner_reuses_one_cancel_job_per_process() -> None:
+    queued: list[QueuedJob] = []
+
+    def submit(_name, task):
+        job = QueuedJob(task)
+        queued.append(job)
+        return job
+
+    process = type(
+        "FakeProcess",
+        (),
+        {"terminate": lambda self: None, "wait": lambda self, timeout: 0},
+    )()
+    runner = CLIRunner("nvoc-autooptimizer", lambda _text: None, submit=submit)
+    runner._process = process
+    runner._busy = True
+
+    runner.cancel()
+    runner.cancel()
+
+    assert len(queued) == 1
+
+
+def test_cli_runner_shutdown_cancels_synchronously(monkeypatch) -> None:
+    process = type(
+        "FakeProcess",
+        (),
+        {"terminate": lambda self: None, "wait": lambda self, timeout: 0},
+    )()
+    runner = CLIRunner("nvoc-autooptimizer", lambda _text: None)
+    runner._process = process
+    waits: list[bool] = []
+    original_cancel = runner.cancel
+
+    def record_cancel(wait: bool = False) -> None:
+        waits.append(wait)
+        original_cancel(wait=wait)
+
+    monkeypatch.setattr(runner, "cancel", record_cancel)
+
+    runner.shutdown()
+
+    assert waits == [True]
+
+
+def test_cli_runner_cancel_kills_process_after_timeout() -> None:
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.killed = False
+
+        def terminate(self) -> None:
+            return
+
+        def wait(self, timeout: int) -> int:
+            raise subprocess.TimeoutExpired("nvoc", timeout)
+
+        def kill(self) -> None:
+            self.killed = True
+
+    process = FakeProcess()
+    runner = CLIRunner("nvoc-autooptimizer", lambda _text: None)
+    runner._process = process
+
+    runner.cancel(wait=True)
+
+    assert process.killed is True


### PR DESCRIPTION
Child of #267.

## Scope

- Move terminate/wait/kill out of the GUI caller thread.
- Deduplicate concurrent cancel requests for the same process.
- Use a dedicated fallback cancel executor so cancellation cannot queue behind the process reader.
- Keep shutdown cancellation synchronous for deterministic cleanup.

## Tests

- `cd gui && ruff check .`
- `cd gui && uv run pytest` — 50 passed

No GPU tests were required.