### PR TITLE
perf(gui): debounce config writes

### DIFF
--- a/gui/src/app.py
+++ b/gui/src/app.py
@@ -1421,6 +1421,7 @@ class App(ctk.CTk):
         self.runner.shutdown()
         self.backend.shutdown()
         self.tasks.shutdown(wait=True)
+        self.config.close()
 
         # 4. Destroy window synchronously
         self.destroy()

--- a/gui/src/config.py
+++ b/gui/src/config.py
@@ -4,6 +4,7 @@ Configuration management - persists user settings to JSON.
 
 import json
 import os
+import threading
 from typing import Any, Dict, List, Optional, Union
 
 JSONPrimitive = Optional[Union[str, int, float, bool]]
@@ -25,12 +26,26 @@ CONFIG_FILE = "nvoc_gui_config.json"
 
 
 class Config:
-    """Simple JSON-based config store."""
+    """JSON config store with coalesced background writes."""
+
+    _FLUSH_DELAY_S = 0.5
 
     def __init__(self, config_dir: str) -> None:
         self.path = os.path.join(config_dir, CONFIG_FILE)
         self.data: Dict[str, JSONValue] = {}
+        self._dirty = False
+        self._closed = False
+        self._lock = threading.Lock()
+        self._write_lock = threading.Lock()
+        self._flush_requested = threading.Event()
+        self._stop_requested = threading.Event()
         self.load()
+        self._flusher = threading.Thread(
+            target=self._flush_loop,
+            name="nvoc-gui-config-flush",
+            daemon=True,
+        )
+        self._flusher.start()
 
     def load(self) -> None:
         if os.path.exists(self.path):
@@ -43,6 +58,17 @@ class Config:
         self._merge_defaults(self.data, DEFAULT_CONFIG)
 
     def save(self) -> None:
+        """Synchronously persist the current config."""
+        with self._lock:
+            snapshot = json.loads(json.dumps(self.data))
+            self._dirty = False
+            self._write_lock.acquire()
+        try:
+            self._write_snapshot(snapshot)
+        finally:
+            self._write_lock.release()
+
+    def _write_snapshot(self, snapshot: Dict[str, JSONValue]) -> None:
         import sys
         import tempfile
 
@@ -51,7 +77,7 @@ class Config:
             fd, tmp = tempfile.mkstemp(dir=dir_, prefix=".nvoc_cfg-", suffix=".tmp")
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    json.dump(self.data, f, indent=2, ensure_ascii=False)
+                    json.dump(snapshot, f, indent=2, ensure_ascii=False)
                 # Restrict config to owner-only before it lands at the final path.
                 # Windows uses ACLs; os.chmod is a no-op there for 0o600, skip it
                 # to avoid triggering antivirus hooks on the temp file.
@@ -71,8 +97,63 @@ class Config:
         return self.data.get(key, default)
 
     def set(self, key: str, value: JSONValue) -> None:
-        self.data[key] = value
-        self.save()
+        with self._lock:
+            if self._closed:
+                return
+            self.data[key] = value
+            self._dirty = True
+        self._flush_requested.set()
+
+    def _flush_loop(self) -> None:
+        while True:
+            self._flush_requested.wait()
+            self._flush_requested.clear()
+            if self._stop_requested.wait(self._FLUSH_DELAY_S):
+                return
+            with self._lock:
+                if self._closed:
+                    return
+                if not self._dirty:
+                    continue
+                snapshot = json.loads(json.dumps(self.data))
+                self._dirty = False
+                self._write_lock.acquire()
+            try:
+                self._write_snapshot(snapshot)
+            finally:
+                self._write_lock.release()
+
+    def flush(self) -> None:
+        """Synchronously persist pending changes without closing the store."""
+        with self._lock:
+            if self._closed or not self._dirty:
+                return
+            snapshot = json.loads(json.dumps(self.data))
+            self._dirty = False
+            self._write_lock.acquire()
+        try:
+            self._write_snapshot(snapshot)
+        finally:
+            self._write_lock.release()
+
+    def close(self) -> None:
+        """Persist the last update and wait for the flusher to stop."""
+        with self._lock:
+            if self._closed:
+                return
+            snapshot = json.loads(json.dumps(self.data)) if self._dirty else None
+            self._dirty = False
+            self._closed = True
+            if snapshot is not None:
+                self._write_lock.acquire()
+        if snapshot is not None:
+            try:
+                self._write_snapshot(snapshot)
+            finally:
+                self._write_lock.release()
+        self._stop_requested.set()
+        self._flush_requested.set()
+        self._flusher.join()
 
     def _merge_defaults(self, target: Dict[str, Any], defaults: Dict[str, Any]) -> None:
         for k, v in defaults.items():

--- a/gui/tests/test_config.py
+++ b/gui/tests/test_config.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+from src.config import Config
+
+
+def test_set_defers_write_until_flush(tmp_path) -> None:
+    config = Config(str(tmp_path))
+    writes: list[dict] = []
+    config._write_snapshot = lambda snapshot: writes.append(snapshot)
+
+    config.set("first", 1)
+    config.set("second", 2)
+
+    assert writes == []
+
+    config.flush()
+
+    assert writes == [{**config.data, "first": 1, "second": 2}]
+    config.close()
+    assert not config._flusher.is_alive()
+
+
+def test_background_flusher_coalesces_burst(tmp_path) -> None:
+    original_delay = Config._FLUSH_DELAY_S
+    Config._FLUSH_DELAY_S = 0.01
+    try:
+        config = Config(str(tmp_path))
+        writes: list[dict] = []
+        config._write_snapshot = lambda snapshot: writes.append(snapshot)
+
+        config.set("value", 1)
+        config.set("value", 2)
+
+        deadline = time.monotonic() + 1.0
+        while not writes and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        assert len(writes) == 1
+        assert writes[0]["value"] == 2
+        config.close()
+    finally:
+        Config._FLUSH_DELAY_S = original_delay
+
+
+def test_close_persists_pending_update_and_stops_thread(tmp_path) -> None:
+    config = Config(str(tmp_path))
+    config.set("last_gpu_idx", 4)
+
+    config.close()
+
+    saved = json.loads((tmp_path / "nvoc_gui_config.json").read_text())
+    assert saved["last_gpu_idx"] == 4
+    assert not config._flusher.is_alive()
+
+
+def test_close_cannot_be_overwritten_by_older_background_snapshot(tmp_path) -> None:
+    original_delay = Config._FLUSH_DELAY_S
+    Config._FLUSH_DELAY_S = 0
+    try:
+        config = Config(str(tmp_path))
+        first_write_started = threading.Event()
+        release_first_write = threading.Event()
+        writes: list[int] = []
+
+        def write_snapshot(snapshot) -> None:
+            if not writes:
+                first_write_started.set()
+                assert release_first_write.wait(timeout=1)
+            writes.append(snapshot["value"])
+
+        config._write_snapshot = write_snapshot
+        config.set("value", 1)
+        assert first_write_started.wait(timeout=1)
+
+        config.set("value", 2)
+        close_thread = threading.Thread(target=config.close)
+        close_thread.start()
+        release_first_write.set()
+        close_thread.join(timeout=1)
+
+        assert not close_thread.is_alive()
+        assert writes == [1, 2]
+        assert not config._flusher.is_alive()
+    finally:
+        Config._FLUSH_DELAY_S = original_delay


### PR DESCRIPTION
## Summary

- coalesce rapid GUI config updates into background writes
- flush the newest pending config during shutdown
- serialize synchronous and background snapshots so stale writes cannot win

Split from the draft umbrella #267.

## Tests

- `cd gui && uv run pytest` (58 passed)
- `cd gui && uv run ruff check src/config.py src/app.py tests/test_config.py`
- `cd gui && uv run ruff format --check src/config.py src/app.py tests/test_config.py`