### PR TITLE
perf(gui): batch console output updates

### DIFF
--- a/gui/src/app.py
+++ b/gui/src/app.py
@@ -76,6 +76,10 @@ class App(ctk.CTk):
     def __init__(self, single_instance_guard: Optional["SingleInstanceGuard"] = None):
         super().__init__()
 
+        self._cli_output_buffer: List[str] = []
+        self._cli_output_flush_id: Optional[str] = None
+        self._cli_output_lock = threading.Lock()
+
         # Global resize session state (used to coalesce expensive per-tab redraw work)
         self._is_resizing = False
         self._resize_settle_after_id = None  # type: Optional[str]
@@ -386,8 +390,19 @@ class App(ctk.CTk):
             self._refresh_gpu_list()
 
     def _on_cli_output(self, text: str):
-        """Thread-safe callback: schedule append on the main thread."""
-        self.after(0, lambda: self.console.append(text))
+        """Buffer worker output and schedule one batched UI update."""
+        with self._cli_output_lock:
+            self._cli_output_buffer.append(text)
+            if self._cli_output_flush_id is None:
+                self._cli_output_flush_id = self.after(100, self._flush_cli_output)
+
+    def _flush_cli_output(self) -> None:
+        with self._cli_output_lock:
+            self._cli_output_flush_id = None
+            if not self._cli_output_buffer:
+                return
+            buffered, self._cli_output_buffer = self._cli_output_buffer, []
+        self.console.append_batch(buffered)
 
     def run_background(self, name: str, task: Callable[[], Any]) -> Any:
         """Submit non-UI work to the central GUI task runner."""
@@ -1421,6 +1436,7 @@ class App(ctk.CTk):
         self.runner.shutdown()
         self.backend.shutdown()
         self.tasks.shutdown(wait=True)
+        self._flush_cli_output()
         self.config.close()
 
         # 4. Destroy window synchronously

--- a/gui/src/widgets/output_console.py
+++ b/gui/src/widgets/output_console.py
@@ -72,30 +72,40 @@ class OutputConsole(ctk.CTkFrame):
 
     def append(self, text: str) -> None:
         """Append text to the console (thread-safe) and keep only the last 100 lines."""
+        self.append_batch([text])
+
+    def append_batch(self, texts: list[str]) -> None:
+        """Append multiple chunks with one text-widget update."""
+        if not texts:
+            return
         with self._lock:
             self.textbox.configure(state="normal")
 
             start_index = self.textbox.index("end-1c")
-            self.textbox.insert("end", text)
-            end_index = self.textbox.index("end-1c")
+            for text in texts:
+                self.textbox.insert("end", text)
+                end_index = self.textbox.index("end-1c")
 
-            # Check if it has a return code
-            if "code 0" in text.lower() or "successfully" in text.lower():
-                self.textbox.tag_add("lime", start_index, end_index)
-            elif (
-                "return code" in text.lower()
-                or "code " in text.lower()
-                or "failed" in text.lower()
-            ):
-                # If it's a message with a return code that isn't 0
-                self.textbox.tag_add("red", start_index, end_index)
+                # Check if it has a return code
+                if "code 0" in text.lower() or "successfully" in text.lower():
+                    self.textbox.tag_add("lime", start_index, end_index)
+                elif (
+                    "return code" in text.lower()
+                    or "code " in text.lower()
+                    or "failed" in text.lower()
+                ):
+                    # If it's a message with a return code that isn't 0
+                    self.textbox.tag_add("red", start_index, end_index)
+
+                start_index = end_index
 
             # Keep only the last 100 lines
             line_count = int(float(self.textbox.index("end-1c")))
             if line_count > self._MAX_LINES:
                 self.textbox.delete("1.0", f"{line_count - self._MAX_LINES}.0")
 
-            self.textbox.see("end")
+            if self._expanded:
+                self.textbox.see("end")
             self.textbox.configure(state="disabled")
 
     def clear(self) -> None:

--- a/gui/tests/test_console_batching.py
+++ b/gui/tests/test_console_batching.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+import threading
+from unittest.mock import Mock, call
+
+os.environ.setdefault("PYSTRAY_BACKEND", "dummy")
+
+from src.app import App
+from src.widgets.output_console import OutputConsole
+
+
+def test_output_console_appends_batch_with_one_widget_update() -> None:
+    console = OutputConsole.__new__(OutputConsole)
+    console._lock = threading.Lock()
+    console._expanded = True
+    console.textbox = Mock()
+    console.textbox.index.side_effect = ["1.0", "2.0", "3.0", "3.0"]
+
+    console.append_batch(["Successfully applied\n", "Command failed\n"])
+
+    assert console.textbox.configure.call_args_list == [
+        call(state="normal"),
+        call(state="disabled"),
+    ]
+    assert console.textbox.insert.call_args_list == [
+        call("end", "Successfully applied\n"),
+        call("end", "Command failed\n"),
+    ]
+    assert console.textbox.tag_add.call_args_list == [
+        call("lime", "1.0", "2.0"),
+        call("red", "2.0", "3.0"),
+    ]
+    console.textbox.see.assert_called_once_with("end")
+
+
+def test_app_coalesces_cli_output_into_one_scheduled_flush() -> None:
+    app = Mock()
+    app._cli_output_buffer = []
+    app._cli_output_flush_id = None
+    app._cli_output_lock = threading.Lock()
+    scheduled = []
+
+    def after(delay_ms: int, callback) -> str:
+        scheduled.append((delay_ms, callback))
+        return "flush-1"
+
+    app.after.side_effect = after
+    app._flush_cli_output = lambda: App._flush_cli_output(app)
+
+    App._on_cli_output(app, "first\n")
+    App._on_cli_output(app, "second\n")
+
+    assert len(scheduled) == 1
+    assert scheduled[0][0] == 100
+    app.console.append_batch.assert_not_called()
+
+    scheduled[0][1]()
+
+    app.console.append_batch.assert_called_once_with(["first\n", "second\n"])
+    assert app._cli_output_buffer == []
+    assert app._cli_output_flush_id is None


### PR DESCRIPTION
## Summary

- coalesce streaming CLI output into one UI update per 100 ms
- append console chunks with one text-widget state/trim/scroll cycle
- flush the final buffered output during GUI shutdown

Split from the draft umbrella #267.

## Tests

- `cd gui && pytest` (60 passed)
- scoped Ruff check and format validation