### PR TITLE
perf(gui): pause hidden dashboard polling

### DIFF
--- a/gui/src/tabs/dashboard.py
+++ b/gui/src/tabs/dashboard.py
@@ -430,6 +430,14 @@ class DashboardTab:
                 return
         except Exception:
             pass
+        # Other tabs do not display dashboard metrics, so defer the expensive
+        # status sweep until the dashboard becomes visible again.
+        try:
+            if not str(self.app.tabview.get()).endswith("Dashboard"):
+                self._schedule_next()
+                return
+        except Exception:
+            pass
         if self._in_offline_backoff:
             self.app._refresh_gpu_list()
             self._schedule_next()

--- a/gui/tests/test_dashboard_visibility.py
+++ b/gui/tests/test_dashboard_visibility.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from src.tabs.dashboard import DashboardTab
 
 
 class FakeApp:
-    def __init__(self, state: str) -> None:
+    def __init__(self, state: str, tab: str = "📊 Dashboard") -> None:
         self._state = state
         self.scheduled: list[int] = []
+        self.tabview = SimpleNamespace(get=lambda: tab)
 
     def state(self) -> str:
         return self._state
@@ -16,8 +19,10 @@ class FakeApp:
         return "poll-job"
 
 
-def make_dashboard(state: str) -> tuple[DashboardTab, FakeApp]:
-    app = FakeApp(state)
+def make_dashboard(
+    state: str, tab: str = "📊 Dashboard"
+) -> tuple[DashboardTab, FakeApp]:
+    app = FakeApp(state, tab)
     dashboard = DashboardTab.__new__(DashboardTab)
     dashboard.app = app
     dashboard._polling = True
@@ -48,3 +53,14 @@ def test_poll_tick_queries_when_window_is_visible() -> None:
 
     assert fetches == [True]
     assert app.scheduled == []
+
+
+def test_poll_tick_defers_query_while_another_tab_is_visible() -> None:
+    dashboard, app = make_dashboard("normal", "⚡ Overclock")
+    fetches: list[bool] = []
+    dashboard._fetch_once = lambda: fetches.append(True)
+
+    dashboard._poll_tick()
+
+    assert fetches == []
+    assert app.scheduled == [1000]


### PR DESCRIPTION
## Summary

- defer dashboard status polling while another tab is visible
- keep the existing polling interval and resume naturally when the dashboard returns

Split from the draft umbrella #267.

## Tests

- `cd gui && pytest` (61 passed)
- scoped Ruff check and format validation