### PR TITLE
perf(gui): coalesce native refresh chains

### DIFF
--- a/gui/src/app.py
+++ b/gui/src/app.py
@@ -79,6 +79,7 @@ class App(ctk.CTk):
         self._cli_output_buffer: List[str] = []
         self._cli_output_flush_id: Optional[str] = None
         self._cli_output_lock = threading.Lock()
+        self._refresh_chain_after_id: Optional[str] = None
 
         # Global resize session state (used to coalesce expensive per-tab redraw work)
         self._is_resizing = False
@@ -1203,6 +1204,15 @@ class App(ctk.CTk):
             self.refresh_after_native_action()
 
     def refresh_after_native_action(self) -> None:
+        """Coalesce bursts into one deferred status refresh chain."""
+        if self._refresh_chain_after_id is not None:
+            self.after_cancel(self._refresh_chain_after_id)
+        self._refresh_chain_after_id = self.after(
+            300, self._refresh_after_native_action_now
+        )
+
+    def _refresh_after_native_action_now(self) -> None:
+        self._refresh_chain_after_id = None
         self._query_gpu_get()
         self._query_overclock_status()
         if self.tab_dashboard:
@@ -1412,6 +1422,10 @@ class App(ctk.CTk):
     def _do_shutdown(self):
         """Perform shutdown cleanup. Must run on the main Tk thread."""
         # 1. Stop all periodic timers
+        if self._refresh_chain_after_id is not None:
+            self.after_cancel(self._refresh_chain_after_id)
+            self._refresh_chain_after_id = None
+
         if hasattr(self, "tab_dashboard") and self.tab_dashboard is not None:
             self.tab_dashboard._stop_polling()
 

--- a/gui/tests/test_native_refresh_coalescing.py
+++ b/gui/tests/test_native_refresh_coalescing.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import Mock
+
+os.environ.setdefault("PYSTRAY_BACKEND", "dummy")
+
+from src.app import App
+
+
+class RefreshHarness:
+    refresh_after_native_action = App.refresh_after_native_action
+    _refresh_after_native_action_now = App._refresh_after_native_action_now
+
+    def __init__(self) -> None:
+        self._refresh_chain_after_id = None
+        self.scheduled: list[tuple[int, object, str]] = []
+        self.cancelled: list[str] = []
+        self._query_gpu_get = Mock()
+        self._query_overclock_status = Mock()
+        self.tab_dashboard = Mock()
+        self.tab_vfcurve = Mock()
+
+    def after(self, delay_ms: int, callback) -> str:
+        timer_id = f"refresh-{len(self.scheduled) + 1}"
+        self.scheduled.append((delay_ms, callback, timer_id))
+        return timer_id
+
+    def after_cancel(self, timer_id: str) -> None:
+        self.cancelled.append(timer_id)
+
+
+def test_native_refresh_burst_keeps_only_latest_timer() -> None:
+    app = RefreshHarness()
+
+    app.refresh_after_native_action()
+    app.refresh_after_native_action()
+
+    assert [delay for delay, _callback, _id in app.scheduled] == [300, 300]
+    assert app.cancelled == ["refresh-1"]
+    assert app._refresh_chain_after_id == "refresh-2"
+
+
+def test_deferred_native_refresh_runs_each_query_once() -> None:
+    app = RefreshHarness()
+    app.refresh_after_native_action()
+
+    app.scheduled[-1][1]()
+
+    assert app._refresh_chain_after_id is None
+    app._query_gpu_get.assert_called_once_with()
+    app._query_overclock_status.assert_called_once_with()
+    app.tab_dashboard._fetch_once.assert_called_once_with()
+    app.tab_vfcurve._refresh_curve.assert_called_once_with()


### PR DESCRIPTION
## Summary

- debounce post-native-action refresh requests for 300 ms
- collapse action bursts into one GPU/status/dashboard/VF refresh chain
- cancel a pending refresh timer during GUI shutdown

Split from the draft umbrella #267.

## Tests

- `cd gui && pytest` (65 passed)
- scoped Ruff check and format validation