### PR TITLE
fix(gui): avoid callback reentry during layout

### DIFF
--- a/gui/src/app.py
+++ b/gui/src/app.py
@@ -281,8 +281,9 @@ class App(ctk.CTk):
         #     def clear(self): pass
         # self.console = MockConsole()
 
-        # Show the window layout immediately before rendering heavy tabs
-        self.update()
+        # Flush layout and paint work without dispatching arbitrary callbacks
+        # against the still-partially-built tab state.
+        self.update_idletasks()
 
         # Placeholders for tabs
         self.tab_dashboard = None

--- a/gui/tests/test_initial_layout_flush.py
+++ b/gui/tests/test_initial_layout_flush.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import inspect
+import os
+
+os.environ.setdefault("PYSTRAY_BACKEND", "dummy")
+
+from src.app import App
+
+
+def test_initial_layout_flush_does_not_dispatch_full_event_loop() -> None:
+    source = inspect.getsource(App._build_ui)
+
+    assert "self.update_idletasks()" in source
+    assert "self.update()" not in source


### PR DESCRIPTION
## Summary

- flush initial Tk layout with update_idletasks() only
- avoid dispatching arbitrary callbacks against partially built tab state

Split from the draft umbrella #267.

## Tests

- `cd gui && pytest` (66 passed)
- scoped Ruff check and format validation