### PR TITLE
fix(gui): restore nested dashboard and VF curve structure

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -17,6 +17,13 @@ for _var in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
 # Ensure the project root is in path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+# Cap BLAS/OpenMP thread pools BEFORE numpy/matplotlib load (they arrive via
+# src imports in main()): the GUI does no matrix math, and the default
+# per-core OpenBLAS arenas commit ~650MB of pagefile for nothing (measured:
+# full-stack commit 681MB -> 70MB).
+for _var in ("OPENBLAS_NUM_THREADS", "OMP_NUM_THREADS", "MKL_NUM_THREADS"):
+    os.environ.setdefault(_var, "1")
+
 # Fix blurry/tiny rendering on Windows HiDPI displays (e.g. 150% scaling).
 if sys.platform == "win32":
     try:
@@ -38,12 +45,14 @@ def _tkinter_install_hint() -> str:
     if sys.platform == "win32":
         return (
             "Install Python from python.org with the Tcl/Tk option enabled, "
-            "then recreate or resync the virtual environment."
+            "then recreate or resync the virtual environment.\n"
+            'Verify the interpreter first: `python -c "import tkinter"`.'
         )
     if sys.platform == "darwin":
         return (
             "Install a Python build that includes Tcl/Tk support, then recreate "
-            "or resync the virtual environment."
+            "or resync the virtual environment.\n"
+            'Verify the interpreter first: `python -c "import tkinter"`.'
         )
     return (
         "Install Tk support for the Python interpreter, then recreate or resync "

--- a/gui/nvoc_gui.spec
+++ b/gui/nvoc_gui.spec
@@ -13,6 +13,9 @@ Optimizations:
 import os
 import importlib
 
+# NOTE: requires PyInstaller >= 6.22 for Tcl/Tk 9 (Python 3.14) embedded
+# data-archive support; older versions silently bundle zero tcl/tk files.
+
 # ── Locate customtkinter assets automatically ──
 ctk_path = os.path.dirname(importlib.import_module("customtkinter").__file__)
 

--- a/gui/src/app.py
+++ b/gui/src/app.py
@@ -8,6 +8,8 @@ import os
 import re
 import sys
 import threading
+import time
+import tkinter as tk
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import pystray
@@ -17,10 +19,8 @@ from src.backend import NativeBackend
 from src.cli_runner import CLIRunner
 from src.config import Config
 from src.parsing import (
-    analyze_vfp_offsets,
-    get_vfp_offset_state_from_csv,
+    get_vfp_offset_state_from_points,
     native_query_payload,
-    parse_gpu_list_output,
     parse_info_limits,
     parse_legacy_overvolt_bounds,
     parse_nvapi_power_current_from_get,
@@ -29,23 +29,28 @@ from src.parsing import (
     parse_status_current_values,
     parse_supported_pstates,
     parse_vfp_lock_bounds,
-    voltage_text_to_mv,
-    write_vfp_points,
 )
 from src.task_runner import GuiTaskRunner
 from src.widgets.output_console import OutputConsole
 from src.widgets.lightweight_controls import LiteButton
 from src.tabs.dashboard import DashboardTab
-from src.tabs.autoscan import AutoscanTab
-from src.tabs.overclock import OverclockTab
+from src.tabs.dashboard.sections import OverclockTab
 from src.tabs.vfcurve import VFCurveTab
+from src.tabs.vfcurve.sections import AutoscanTab
 
 
 import shutil
 
 
 def _is_discovery_offline_error(output: str) -> bool:
-    """Return whether discovery failed because the NVIDIA GPU disappeared."""
+    """True when a failed GPU discovery's error indicates the dGPU is gone.
+
+    Discovery re-runs on the offline-backoff cadence (after the user disabled
+    the dGPU), and `NvAPI_EnumPhysicalGPUs` returns ApiNotInitialized /
+    NoImplementation / NvidiaDeviceNotFound while the dGPU is off. Suppressing
+    these per-tick errors keeps the console quiet during backoff; the dashboard
+    already logged a single "dGPU probably offline" hint.
+    """
     if not output:
         return False
     lowered = output.lower()
@@ -70,25 +75,155 @@ def find_cli_exe() -> str:
     )
 
 
+class _ConsoleWindowProxy:
+    """Standalone console window.
+
+    Log lines buffer here until the window is first opened; afterwards they
+    stream to the live widget. Closing the window just withdraws it (the
+    widget and its history stay alive).
+    """
+
+    _MAX_LINES = 500
+
+    def __init__(self, app: "App") -> None:
+        self._app = app
+        self._widget = None  # type: Optional[OutputConsole]
+        self._window = None  # type: Optional[ctk.CTkToplevel]
+        self._buffer: List[str] = []
+        self._lock = threading.Lock()
+
+    # ── widget lifecycle ────────────────────────────────────────────────
+    def _ensure_window(self) -> "OutputConsole":
+        if self._widget is not None and self._widget.winfo_exists():
+            return self._widget
+        win = ctk.CTkToplevel(self._app)
+        win.title("NVOC Console")
+        win.geometry("640x360")
+        win.protocol("WM_DELETE_WINDOW", self.close)
+        widget = OutputConsole(win, height=380)
+        widget.pack(fill="both", expand=True, padx=6, pady=6)
+        with self._lock:
+            backlog, self._buffer = self._buffer[-self._MAX_LINES :], []
+        if backlog:
+            widget.append_batch(backlog)
+        self._window = win
+        self._widget = widget
+        return widget
+
+    def open(self) -> None:
+        self._ensure_window()
+        if self._window is not None:
+            self._window.deiconify()
+
+    def close(self) -> None:
+        if self._window is not None:
+            self._window.withdraw()
+
+    def toggle(self) -> None:
+        if self._window is not None and self._window.state() != "withdrawn":
+            self.close()
+        else:
+            self.open()
+
+    # ── OutputConsole API ───────────────────────────────────────────────
+    def append(self, text: str) -> None:
+        with self._lock:
+            self._buffer.append(text)
+            if len(self._buffer) > self._MAX_LINES:
+                del self._buffer[: len(self._buffer) - self._MAX_LINES]
+            live = self._widget
+        if live is not None and live.winfo_exists():
+            live.append(text)
+
+    def append_batch(self, texts: List[str]) -> None:
+        for text in texts:
+            self.append(text)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._buffer = []
+        if self._widget is not None and self._widget.winfo_exists():
+            self._widget.clear()
+
+
+def _warm_matplotlib(ready_event: "threading.Event") -> None:
+    """Import matplotlib and build the font cache off the UI thread.
+
+    The first matplotlib use triggers a full system-font scan ("Matplotlib is
+    building the font cache") that can take minutes on slow machines — running
+    it inside the Tk event loop freezes the whole GUI. Doing it here warms the
+    cache before the VF-curve chart is built.
+    """
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.font_manager as fm
+
+        fm.findfont("DejaVu Sans")
+    except Exception:
+        pass  # chart build falls back to importing on its own
+    finally:
+        ready_event.set()
+
+
+def _start_matplotlib_warmup() -> "threading.Event":
+    """Point MPLCONFIGDIR at a persistent dir and start the font-cache warm-up."""
+    if not os.environ.get("MPLCONFIGDIR"):
+        base = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~")
+        mpl_dir = os.path.join(base, "nvoc-gui", "mpl")
+        try:
+            os.makedirs(mpl_dir, exist_ok=True)
+            os.environ["MPLCONFIGDIR"] = mpl_dir
+        except OSError:
+            pass  # keep matplotlib's default config dir
+    ready = threading.Event()
+    threading.Thread(
+        target=_warm_matplotlib, args=(ready,), name="mpl-warmup", daemon=True
+    ).start()
+    return ready
+
+
 class App(ctk.CTk):
     """Main application window."""
 
     def __init__(self, single_instance_guard: Optional["SingleInstanceGuard"] = None):
         super().__init__()
 
+        # Warm matplotlib (font cache) on a background thread before any tab
+        # builds its chart — keeps the Tk event loop responsive.
+        self._mpl_ready = _start_matplotlib_warmup()
+        # CLI output batching (see _on_cli_output)
         self._cli_output_buffer: List[str] = []
         self._cli_output_flush_id: Optional[str] = None
         self._cli_output_lock = threading.Lock()
+        # Post-native-action refresh chain coalescing
         self._refresh_chain_after_id: Optional[str] = None
+        # Idle-time tab prebuild (see _prebuild_next_tab)
+        self._tab_prebuild_started = False
+        # 'get'-failure re-probe state (see _apply_gpu_get)
+        self._get_reprobe_pending = False
+        self._get_reprobe_count = 0
+        # Per-GPU capability cache: GPU whose P-States are already known
+        self._pstates_cached_for = None
+        self._last_pstates_logged = None
+        # Short-TTL query result cache (see run_gpu_query_async)
+        self._query_result_cache: Dict[str, Tuple[float, int, str]] = {}
+        self._query_cache_lock = threading.Lock()
 
         # Global resize session state (used to coalesce expensive per-tab redraw work)
         self._is_resizing = False
         self._resize_settle_after_id = None  # type: Optional[str]
         self._last_root_width = None  # type: Optional[int]
+        # Last root geometry (x, y, w, h) — any change (incl. a pure title-bar
+        # drag that moves the window without resizing) starts an interaction
+        # session that pauses polling, so DWM compositing doesn't contend
+        # with the NVAPI sweep and the drag doesn't stutter once per second.
+        self._last_root_geom: Optional[Tuple[int, int, int, int]] = None
         self._resize_targets = []  # type: List[Any]
 
         self.title("NVOC-GUI — NVIDIA GPU VF Curve Optimizer")
-        self.geometry("768x672")
+        self.geometry("768x712")
         self.minsize(768, 360)
         self._single_instance_guard = single_instance_guard
 
@@ -133,6 +268,13 @@ class App(ctk.CTk):
         self.tasks = GuiTaskRunner()
         self._build_ui()
 
+        # Prebuild the tray icon image off-thread so the first minimize-to-tray
+        # doesn't stall the UI thread on Image.open/LANCZOS/font loading.
+        self.after(
+            2000,
+            lambda: self.run_background("tray-icon-prebuild", self._get_tray_image),
+        )
+
         # Setup CLI runner (after console is created)
         self.runner = CLIRunner(
             exe_path,
@@ -154,6 +296,7 @@ class App(ctk.CTk):
         self.gpu_arches: Dict[
             int, str
         ] = {}  # gpu_index -> architecture string from 'info'
+        self._gpu_flags_by_idx: Dict[int, Dict[str, Any]] = {}  # probe-time caps
         self.gpu_uuid_map: Dict[int, str] = {}  # gpu_index -> UUID string
         self._gpu_short_label_by_idx: Dict[int, str] = {}
         self._gpu_long_label_by_idx: Dict[int, str] = {}
@@ -170,12 +313,16 @@ class App(ctk.CTk):
 
         # Guard to suppress _on_gpu_changed during programmatic gpu_var.set() calls
         self._programmatic_gpu_set: bool = False
-        # When no NVIDIA GPU is visible, periodically re-run discovery so an
-        # eGPU or a re-enabled laptop dGPU appears without restarting the GUI.
+        # Background GPU re-probe timer: when startup discovery finds no GPU
+        # (dGPU disabled at launch) or detection fails, this re-runs discovery
+        # periodically so the dGPU is auto-detected when the user re-enables it.
+        # Cancelled as soon as a non-empty GPU list lands (or on shutdown).
         self._gpu_reprobe_after_id: Optional[str] = None
 
-        # Initial GPU list
-        self.after(500, self._refresh_gpu_list)
+        # Initial GPU list — start immediately (no after() hop): discovery
+        # runs on a worker thread (pynvoc import + nvapi64 load + NVAPI init
+        # never touch Tk), so it overlaps UI construction from tick zero.
+        self._refresh_gpu_list()
 
         if self._single_instance_guard is not None:
             self.after(200, self._poll_single_instance_signal)
@@ -212,7 +359,22 @@ class App(ctk.CTk):
             pos = indices.index(cur_idx)
             delta = -1 if event.delta > 0 else 1
             nxt = indices[(pos + delta) % len(indices)]
-            self._on_gpu_changed(self._gpu_short_label_by_idx[nxt])
+            label = self._gpu_short_label_by_idx[nxt]
+            # Update the selection display immediately, but debounce the heavy
+            # info→status→settings query chain — one wheel gesture over many
+            # GPUs must not fire it per notch.
+            self._programmatic_gpu_set = True
+            try:
+                self.gpu_var.set(label)
+            finally:
+                self._programmatic_gpu_set = False
+            if self._gpu_wheel_after_id is not None:
+                self.after_cancel(self._gpu_wheel_after_id)
+            self._gpu_wheel_after_id = self.after(
+                250, lambda: self._on_gpu_wheel_settled(label)
+            )
+
+        self._gpu_wheel_after_id = None  # type: Optional[str]
 
         self.gpu_dropdown.bind("<MouseWheel>", _on_gpu_wheel)
 
@@ -265,24 +427,21 @@ class App(ctk.CTk):
         # We can try to reduce the impact by ensuring the main window doesn't update
         # too many internal state variables during the drag.
 
-        # Create tabs
+        # Create tabs. The Overclock page itself is gone — its sections are
+        # hosted on the Dashboard; the OverclockTab object still exists
+        # (parented to a hidden frame) to own the logic and widgets.
         _tab_dashboard = self.tabview.add("📊 Dashboard")
-        _tab_autoscan = self.tabview.add("🔍 Autoscan")
-        _tab_overclock = self.tabview.add("⚡ Overclock")
         _tab_vfcurve = self.tabview.add("📈 VF Curve")
+        self._oc_hidden_host = tk.Frame(self)
 
-        # === Bottom: Output Console ===
-        # (Created before tabs so the main frame structure is visible during load)
-        self.console = OutputConsole(self, height=200)
-        self.console.pack(fill="x", padx=10, pady=(0, 10))
+        # === Output Console lives in its own window now ===
+        # The bottom dock is gone; the dashboard gets a Console button.
+        # Logs buffer until the window is first opened.
+        self.console = _ConsoleWindowProxy(self)
 
-        # class MockConsole:
-        #     def append(self, text: str): pass
-        #     def clear(self): pass
-        # self.console = MockConsole()
-
-        # Flush layout and paint work without dispatching arbitrary callbacks
-        # against the still-partially-built tab state.
+        # Show the window layout immediately before rendering heavy tabs.
+        # update_idletasks (layout/paint only) — update() would pump the full
+        # event loop mid-build, re-entering callbacks against half-built tabs.
         self.update_idletasks()
 
         # Placeholders for tabs
@@ -292,11 +451,21 @@ class App(ctk.CTk):
         self.tab_vfcurve = None
 
         # Defer initialization of the default selected tab to avoid blocking startup
-        self.after(50, self._on_tab_changed)
+        # Build the default (Dashboard) tab at the first event-loop turn —
+        # the old after(50) was 50ms of pure scheduler latency before the
+        # first screen. after(0) keeps attribute-init order safe.
+        self.after(0, self._on_tab_changed)
 
     def _on_tab_changed(self):
         """Lazy load tabs when they are selected and handle visibility for performance."""
         current_tab = self.tabview.get()
+
+        # First entry into a tab constructs its whole widget page on the spot
+        # (~3.4 ms per CTk widget — a visible freeze on weak single-cores), so
+        # after startup we prebuild the remaining tabs one per idle slice.
+        if not self._tab_prebuild_started:
+            self._tab_prebuild_started = True
+            self.after(400, self._prebuild_next_tab)
 
         if current_tab.endswith("Dashboard") and self.tab_dashboard is None:
             self.tab_dashboard = DashboardTab(self.tabview.tab("📊 Dashboard"), self)
@@ -308,6 +477,14 @@ class App(ctk.CTk):
             self._query_gpu_get()
             self.tab_dashboard._fetch_once()
 
+        # Leaving VF Curve: stop its crosshair timer and hand polling back to
+        # the dashboard so the metric rows refresh again.
+        if not current_tab.endswith("VF Curve"):
+            if self.tab_vfcurve is not None:
+                self.tab_vfcurve.stop_live_poll()
+            if self.tab_dashboard is not None:
+                self.tab_dashboard._set_vfcurve_active(False)
+
         elif current_tab.endswith("VF Curve"):
             if self.tab_vfcurve is None:
                 self.tab_vfcurve = VFCurveTab(self.tabview.tab("📈 VF Curve"), self)
@@ -318,34 +495,112 @@ class App(ctk.CTk):
                     )
                 if hasattr(self, "_gpu_limits_cache") and self._gpu_limits_cache:
                     self.tab_vfcurve.sync_freq_locks_from_cache(self._gpu_limits_cache)
-            # Refresh frequency lock states from CLI on every tab entry.
-            self._query_gpu_get()
-            # Always refresh when entering VF Curve to keep the plot up to date.
-            self.tab_vfcurve._refresh_curve()
+            # Crosshair refresh is owned by vfcurve's own low-cadence timer so
+            # the dashboard poll's after(0) completion cannot interpose a blit
+            # ahead of a mouse-press on the curve.
+            self.tab_vfcurve.start_live_poll()
+            if self.tab_dashboard is not None:
+                self.tab_dashboard._set_vfcurve_active(True)
+            # P-States are a per-GPU capability: query once per GPU
+            # selection, not on every tab entry.
+            gpu = self.selected_gpu_target()
+            if gpu is None or self._pstates_cached_for != gpu:
+                self._query_gpu_get()
+            # Load only if the tab has no data yet: curve changes are
+            # covered by the action-triggered refresh chain.
+            if not self.tab_vfcurve._voltages:
+                self.tab_vfcurve._refresh_curve()
 
-        elif current_tab.endswith("Autoscan") and self.tab_autoscan is None:
-            self.tab_autoscan = AutoscanTab(self.tabview.tab("🔍 Autoscan"), self)
-            self.register_resize_target(self.tab_autoscan)
+    def _overclock_content_host(self):
+        """Dashboard frame hosting the overclock top panels (integration mode)."""
+        return getattr(self.tab_dashboard, "oc_panels_host", None)
 
-        elif current_tab.endswith("Overclock"):
-            if self.tab_overclock is None:
-                self.tab_overclock = OverclockTab(
-                    self.tabview.tab("⚡ Overclock"), self
-                )
-                self.register_resize_target(self.tab_overclock)
-                # Sync any cached info if available
-                if hasattr(self, "_gpu_limits_cache") and self._gpu_limits_cache:
-                    self.tab_overclock.check_capabilities(self._gpu_limits_cache)
-                    self.tab_overclock.update_limits(self._gpu_limits_cache)
-                elif self._gpu_pstates_cache:
-                    self.tab_overclock.set_supported_pstates(self._gpu_pstates_cache)
-                if self._vfp_offset_state_cache is not None:
-                    has_vfp_offset, uniform_offset = self._vfp_offset_state_cache
-                    self.tab_overclock.set_vfp_state(has_vfp_offset, uniform_offset)
-                if self.tab_vfcurve is None:
-                    self.refresh_vfp_offset_state(force=True)
-            # Always force-refresh status cache when entering Overclock.
-            self._query_overclock_status()
+    def _fan_content_host(self):
+        """Dashboard frame hosting the fan-control section."""
+        return getattr(self.tab_dashboard, "fan_panels_host", None)
+
+    def _prebuild_next_tab(self):
+        """Construct one not-yet-built tab per call, in idle slices.
+
+        Tk/Tcl is single-threaded — widget construction cannot be moved off
+        the main thread — but building hidden tab pages AFTER first paint
+        (instead of on first click) removes the per-tab entry freeze. One
+        tab per slice keeps the event loop responsive between builds.
+        """
+        builders = [
+            ("tab_overclock", "⚡ Overclock", OverclockTab),
+            ("tab_vfcurve", "📈 VF Curve", VFCurveTab),
+        ]
+        for attr, tab_name, cls in builders:
+            if getattr(self, attr, None) is not None:
+                continue
+            try:
+                if cls is OverclockTab:
+                    tab = cls(
+                        self._oc_hidden_host,
+                        self,
+                        content_parent=self._overclock_content_host(),
+                        fan_parent=self._fan_content_host(),
+                    )
+                else:
+                    tab = cls(self.tabview.tab(tab_name), self)
+                setattr(self, attr, tab)
+                self.register_resize_target(tab)
+                if attr == "tab_vfcurve":
+                    if hasattr(self, "_locked_voltage_mv_cache"):
+                        tab.sync_lock_from_voltage(self._locked_voltage_mv_cache)
+                    if hasattr(self, "_gpu_limits_cache") and self._gpu_limits_cache:
+                        tab.sync_freq_locks_from_cache(self._gpu_limits_cache)
+                    # Background preload: fetch the curve once the dashboard
+                    # is up so the first tab switch shows data instantly.
+                    self.after(600, tab._refresh_curve)
+                elif attr == "tab_overclock":
+                    if hasattr(self, "_gpu_limits_cache") and self._gpu_limits_cache:
+                        tab.check_capabilities(self._gpu_limits_cache)
+                        tab.update_limits(self._gpu_limits_cache)
+                    else:
+                        # First paint must already be the correct layout.
+                        # Priority: (1) probe-time capability flags from GPU
+                        # discovery (gpu_type.rs verdict — is_mobile etc.),
+                        # (2) LAST session's persisted limits from config
+                        # (also carries slider ranges). With either applied,
+                        # the later info query finds matching verdicts (mode
+                        # early-return, xbar no-op) and nothing re-packs.
+                        # A stale config cache (GPU swapped) self-corrects
+                        # with one layout switch — the pre-cache behavior.
+                        last_idx = self.get_current_gpu_index()
+                        flags = (
+                            self._gpu_flags_by_idx.get(last_idx)
+                            if last_idx is not None
+                            else None
+                        )
+                        try:
+                            if flags:
+                                tab.check_capabilities(dict(flags))
+                            else:
+                                cached = self.config.get("last_gpu_limits")
+                                if isinstance(cached, dict) and cached:
+                                    tab.check_capabilities(dict(cached))
+                                    tab.update_limits(dict(cached))
+                        except Exception:
+                            pass
+                    if self._gpu_pstates_cache:
+                        tab.set_supported_pstates(self._gpu_pstates_cache)
+                    if self._vfp_offset_state_cache is not None:
+                        has_vfp_offset, uniform_offset = self._vfp_offset_state_cache
+                        tab.set_vfp_state(has_vfp_offset, uniform_offset)
+            except Exception:
+                # A failed prebuild must not break startup; the tab will be
+                # built lazily on first entry as before.
+                return
+            self.after(100, self._prebuild_next_tab)
+            return
+        if self.tab_autoscan is None and self.tab_vfcurve is not None:
+            try:
+                self.tab_autoscan = AutoscanTab(self.tab_vfcurve.autoscan_host, self)
+                self.register_resize_target(self.tab_autoscan)
+            except Exception:
+                return
 
         # If an older session suspended tab children, restore once and keep normal geometry.
         # Suspending CTkScrollableFrame-heavy tabs can corrupt layout after repeated resizes.
@@ -410,13 +665,6 @@ class App(ctk.CTk):
         """Submit non-UI work to the central GUI task runner."""
         return self.tasks.submit(name, task)
 
-    def _debounce_tabview_configure(self, event=None):
-        """Compatibility shim retained for older experiments; intentionally no-op."""
-        return
-
-    def _process_tabview_resize(self):
-        return
-
     def register_resize_target(self, target: Any):
         """Register a tab-like object that supports on_resize_state_changed()."""
         if target is None or target in self._resize_targets:
@@ -448,13 +696,24 @@ class App(ctk.CTk):
         self._notify_resize_targets(resizing=False, force_flush=True)
 
     def _on_root_configure(self, event):
-        """Track active drag-resize sessions from root window size changes."""
+        """Track active drag-resize AND title-bar move sessions.
+
+        A Windows title-bar drag fires <Configure> with the same w/h but a
+        changing x/y — so gating on width alone missed pure moves and the
+        dashboard NVAPI sweep kept firing once per second, contending with
+        DWM compositing and stuttering the drag. Any geometry change
+        (x/y/w/h) starts (or re-arms) an interaction session that pauses
+        polling; 140 ms of quiet ends it and flushes deferred work.
+        """
         if event.widget is not self:
             return
-        width = int(event.width)
-        if self._last_root_width == width:
+        geom = (int(event.x), int(event.y), int(event.width), int(event.height))
+        # Only width is used downstream by resize-sensitive redraws, but the
+        # session itself keys on the full geometry so moves are covered.
+        self._last_root_width = geom[2]
+        if self._last_root_geom == geom:
             return
-        self._last_root_width = width
+        self._last_root_geom = geom
         self._begin_resize_session()
         if self._resize_settle_after_id:
             try:
@@ -462,10 +721,6 @@ class App(ctk.CTk):
             except Exception:
                 pass
         self._resize_settle_after_id = self.after(140, self._end_resize_session)
-
-    def _on_tabview_configure(self, event):
-        """Compatibility shim: tabview-level binding is not used in CustomTkinter."""
-        return
 
     def _refresh_gpu_list(self):
         """Query native GPU discovery and populate GPU dropdown."""
@@ -478,39 +733,55 @@ class App(ctk.CTk):
         self.run_background("gpu-list", _worker)
 
     def _start_gpu_reprobe(self) -> None:
-        """Schedule discovery retries until an NVIDIA GPU becomes available."""
-        if self._exiting or self._gpu_reprobe_after_id is not None:
+        """Begin background GPU rediscovery (scenario A: no GPU at startup).
+
+        Re-runs discovery every few seconds until a non-empty GPU list lands,
+        then stops itself. Lets the GUI pick up the dGPU the moment the user
+        re-enables it without requiring a manual 'Detect' click.
+        """
+        if getattr(self, "_exiting", False):
             return
+        if self._gpu_reprobe_after_id is not None:
+            return  # already armed
         self._gpu_reprobe_after_id = self.after(5000, self._gpu_reprobe_tick)
 
     def _gpu_reprobe_tick(self) -> None:
         self._gpu_reprobe_after_id = None
-        if self._exiting:
+        if getattr(self, "_exiting", False):
             return
-        if self.selected_gpu_target() is None:
+        # Still no usable GPU? re-probe. _apply_gpu_list re-arms the timer if
+        # the list is still empty/failed, and stops it once a GPU lands.
+        if not self.selected_gpu_target():
             self._refresh_gpu_list()
+        # else: a GPU is selected now — _apply_gpu_list already stopped the
+        # reprobe when it populated the dropdown.
 
     def _stop_gpu_reprobe(self) -> None:
-        if self._gpu_reprobe_after_id is None:
-            return
-        try:
-            self.after_cancel(self._gpu_reprobe_after_id)
-        except Exception:
-            pass
-        self._gpu_reprobe_after_id = None
+        if self._gpu_reprobe_after_id is not None:
+            try:
+                self.after_cancel(self._gpu_reprobe_after_id)
+            except Exception:
+                pass
+            self._gpu_reprobe_after_id = None
 
     def _apply_gpu_list(
         self, retcode: int, output: str, items: List[Dict[str, Any]]
     ) -> None:
         """Apply native GPU discovery results to the dropdown."""
-        offline_error = retcode != 0 and _is_discovery_offline_error(output)
-        if output and not offline_error:
+        # Suppress per-tick discovery-error spam during offline backoff: the
+        # dashboard already logged one "dGPU probably offline" hint and is
+        # re-probing on a slow cadence. Logging every failed re-probe (each
+        # producing "NvAPI_EnumPhysicalGPUs failed: API_NOT_INITIALIZED")
+        # floods the console just like the pre-backoff status spam did.
+        if output and not (retcode != 0 and _is_discovery_offline_error(output)):
             self.console.append(output if output.endswith("\n") else f"{output}\n")
         if retcode != 0:
-            if not offline_error:
+            if not _is_discovery_offline_error(output):
                 self.console.append("[GUI] Failed to detect GPUs.\n")
             self.gpu_dropdown.configure(values=["(detection failed)"])
             self.gpu_var.set("(detection failed)")
+            # No GPU detected (e.g. dGPU disabled at launch) — start a background
+            # re-probe so the dGPU is picked up when re-enabled.
             self._start_gpu_reprobe()
             return
 
@@ -518,6 +789,11 @@ class App(ctk.CTk):
         long_labels: Dict[int, str] = {}
         gpu_names: Dict[int, str] = {}
         gpu_uuid_map: Dict[int, str] = {}
+        # Probe-time capability flags (gpu_type.rs detect_gpu_type computed in
+        # discover_gpus) — available the moment detection lands, before the
+        # info query, so the overclock panel never paints the desktop modal
+        # first and re-packs on a mobile GPU.
+        self._gpu_flags_by_idx: Dict[int, Dict[str, Any]] = {}
 
         for fallback_idx, item in enumerate(items):
             try:
@@ -536,6 +812,14 @@ class App(ctk.CTk):
             arch = str(item.get("arch") or item.get("codename") or "").strip()
             if arch:
                 self.gpu_arches[idx] = arch
+            self._gpu_flags_by_idx[idx] = {
+                "gpu_name": name,
+                "gpu_architecture": arch,
+                "codename": str(item.get("codename") or ""),
+                "is_mobile": item.get("is_mobile"),
+                "is_legacy_voltage": item.get("is_legacy_voltage"),
+                "xbar_supported": item.get("xbar_supported"),
+            }
 
         ordered_indices = sorted(short_labels.keys())
         if not ordered_indices:
@@ -545,6 +829,7 @@ class App(ctk.CTk):
                 self.gpu_var.set("(no GPUs found)")
             finally:
                 self._programmatic_gpu_set = False
+            # No GPUs visible — re-probe in the background.
             self._start_gpu_reprobe()
             return
 
@@ -572,74 +857,26 @@ class App(ctk.CTk):
         finally:
             self._programmatic_gpu_set = False
         self.console.append(f"[GUI] Found {len(ordered_indices)} GPU(s).\n")
+        # A GPU landed — stop the background re-probe (no longer needed).
         self._stop_gpu_reprobe()
+        # Detection landed after the overclock panel was built (slow NVAPI
+        # init / GCOFF wake): apply the probe-time capability flags now so
+        # the mobile/desktop layout corrects immediately, not at info time.
+        if self.tab_overclock is not None:
+            flags = self._gpu_flags_by_idx.get(last_idx)
+            if flags:
+                try:
+                    self.tab_overclock.check_capabilities(dict(flags))
+                except Exception:
+                    pass
         self._query_gpu_info()
-
-    def _parse_gpu_list(self, retcode: int, output: str):
-        """Parse GPU list output and update dropdown."""
-        self.console.append(output)
-        if retcode != 0:
-            self.console.append("[GUI] Failed to detect GPUs.\n")
-            self.gpu_dropdown.configure(values=["(detection failed)"])
-            self.gpu_var.set("(detection failed)")
-            return
-
-        short_labels, long_labels, gpu_names, uuid_map = parse_gpu_list_output(output)
-        ordered_indices = sorted(short_labels.keys())
-
-        # Use long labels for dropdown entries so users can see full UUID when expanded.
-        gpus = [long_labels[i] for i in ordered_indices]
-
-        if gpus:
-            # Build reverse map: display_text -> gpu_index
-            self.gpu_map = {}
-            for idx in ordered_indices:
-                self.gpu_map[short_labels[idx]] = idx
-                self.gpu_map[long_labels[idx]] = idx
-
-            self._gpu_short_label_by_idx = short_labels
-            self._gpu_long_label_by_idx = long_labels
-
-            # Store GPU names for capabilities check
-            self.gpu_names = gpu_names
-
-            # Store UUID map
-            self.gpu_uuid_map = uuid_map
-
-            self.gpu_dropdown.configure(values=gpus)
-            # Try to restore last selection by index first, then by legacy label
-            last_idx_raw = str(self.config.get("last_gpu_idx", "")).strip()
-            last_idx = int(last_idx_raw) if last_idx_raw.isdigit() else None
-            last = self.config.get("last_gpu_id", "")
-            if last_idx is None and last in self.gpu_map:
-                last_idx = self.gpu_map[last]
-            if last_idx is None and last:
-                m_last = re.match(r"^GPU\s+(\d+)\s*:", last)
-                if m_last:
-                    last_idx = int(m_last.group(1))
-
-            if last_idx not in ordered_indices:
-                last_idx = ordered_indices[0]
-
-            self._programmatic_gpu_set = True
-            try:
-                # Keep collapsed selector compact (no UUID), but dropdown values still include UUID.
-                self.gpu_var.set(short_labels[last_idx])
-            finally:
-                self._programmatic_gpu_set = False
-            self.console.append(f"[GUI] Found {len(gpus)} GPU(s).\n")
-            # Query GPU info for hardware limits
-            self._query_gpu_info()
-        else:
-            self.gpu_dropdown.configure(values=["(no GPUs found)"])
-            self._programmatic_gpu_set = True
-            try:
-                self.gpu_var.set("(no GPUs found)")
-            finally:
-                self._programmatic_gpu_set = False
 
     def _on_gpu_changed(self, selected: str):
         """Called by CTkOptionMenu when the user picks a different GPU."""
+        # A pending wheel-debounced switch is superseded by this explicit pick
+        if self._gpu_wheel_after_id is not None:
+            self.after_cancel(self._gpu_wheel_after_id)
+            self._gpu_wheel_after_id = None
         if self._programmatic_gpu_set:
             return  # ignore changes triggered by our own gpu_var.set() calls
         if selected.startswith("("):
@@ -666,8 +903,10 @@ class App(ctk.CTk):
         # Reset dashboard VFP-lock sentinel so first poll after switch always syncs
         if self.tab_dashboard is not None:
             self.tab_dashboard._last_vfp_lock_mv = object()
+        self._invalidate_query_cache()
         self._dashboard_gpu_lock_active = False
         self._dashboard_mem_lock_active = False
+        self._pstates_cached_for = None
         self._vfp_offset_state_cache = None
         self._gpu_pstates_cache = []
         if self.tab_overclock:
@@ -677,13 +916,25 @@ class App(ctk.CTk):
         # Re-run the full init chain: info → limits → status → OC values → curve
         self._query_gpu_info()
 
+    def _on_gpu_wheel_settled(self, label: str):
+        """Fire the GPU-switch query chain after wheel scrolling settles."""
+        self._gpu_wheel_after_id = None
+        self._on_gpu_changed(label)
+
     def _query_gpu_info(self):
-        """Run 'info' for the selected GPU and parse hardware limits."""
+        """Run 'info' for the selected GPU and parse hardware limits.
+
+        'get' (P-States / OC capabilities) has no dependency on 'info' — fire
+        it concurrently; pynvoc queries run lock-free against the Arc'd
+        inventory snapshot, so they genuinely overlap instead of queueing.
+        'status' stays chained after info (its merge wants the info cache).
+        """
         self.run_gpu_query_async(
             ["info"],
             lambda _retcode, output: self._parse_gpu_info(output),
             thread_name="gpu-info",
         )
+        self.run_gpu_query_async(["get"], self._apply_gpu_get, thread_name="gpu-get")
 
     def _parse_gpu_info(self, output: str):
         """Parse 'info' output to extract hardware limits for overclock tab."""
@@ -708,6 +959,18 @@ class App(ctk.CTk):
             # spawned *after* _gpu_limits_cache is fully populated, so
             # _apply_initial_status always sees a complete cache.
             self._gpu_limits_cache = limits
+            # Persist for next session's first-paint layout pre-apply (see
+            # _prebuild_next_tab): the payload carries the capability flags
+            # (is_mobile / xbar_supported / is_legacy_voltage, from gpu_type.rs)
+            # plus the slider ranges. Validate JSON-safety first — a
+            # non-serializable value would kill config's flush-loop thread.
+            import json as _json
+
+            try:
+                _json.loads(_json.dumps(limits))
+                self.config.set("last_gpu_limits", limits)
+            except (TypeError, ValueError):
+                pass
             if self.tab_overclock:
                 self.tab_overclock.check_capabilities(limits)
                 self.tab_overclock.update_limits(limits)
@@ -720,8 +983,8 @@ class App(ctk.CTk):
 
         # Always query status after info, regardless of parse result.
         # _apply_initial_status will merge into whatever _gpu_limits_cache contains.
+        # ('get' was already fired concurrently with 'info' in _query_gpu_info.)
         self._query_initial_status()
-        self._query_gpu_get()
 
     def _query_initial_status(self):
         """Run 'status' once at startup to detect VFP lock, then refresh VF curve."""
@@ -736,13 +999,11 @@ class App(ctk.CTk):
     def _query_overclock_status(self):
         """Run 'status' and refresh Overclock current values from latest cache."""
         self.run_gpu_query_async(
-            ["status"], self._apply_overclock_status, thread_name="overclock-status"
+            ["status"],
+            self._apply_overclock_status,
+            thread_name="overclock-status",
+            allow_wake=False,  # automatic refresh chain: never block GC6
         )
-
-    @staticmethod
-    def _voltage_text_to_mv(value_text: str, unit_text: str) -> int:
-        """Convert a voltage text pair (value + unit) into integer mV."""
-        return voltage_text_to_mv(value_text, unit_text)
 
     @staticmethod
     def _native_query_payload(output: str) -> Optional[Dict[str, Any]]:
@@ -792,21 +1053,42 @@ class App(ctk.CTk):
         """Merge supported P-State data from CLI 'get' into the cached GPU state."""
         merged = dict(getattr(self, "_gpu_limits_cache", {}))
         if retcode != 0:
+            # Transient read failure (dGPU waking from GC6): KEEP the last
+            # known-good P-States instead of wiping the cache to 'unsupported',
+            # and schedule a delayed re-probe (wake + re-query).
             self.console.append(
-                "[GUI] Warning: failed to query supported P-States via 'get'.\n"
+                "[GUI] 'get' query failed (GPU may be waking); keeping last known P-States.\n"
             )
-            self._gpu_pstates_cache = []
-            merged["supported_pstates"] = []
+            merged["supported_pstates"] = list(self._gpu_pstates_cache or [])
             self._gpu_limits_cache = merged
             self._sync_dashboard_lock_state_from_cache(merged)
             if self.tab_overclock:
                 self.tab_overclock.update_limits(merged)
             if self.tab_vfcurve:
                 self.tab_vfcurve.sync_freq_locks_from_cache(merged)
+            retries = getattr(self, "_get_reprobe_count", 0)
+            if retries < 2 and getattr(self, "_get_reprobe_pending", False) is False:
+                self._get_reprobe_pending = True
+                self._get_reprobe_count = retries + 1
+                self.after(
+                    1500,
+                    lambda: (
+                        setattr(self, "_get_reprobe_pending", False),
+                        self.run_background(
+                            "wake-gpu",
+                            lambda: self.backend.force_wake(
+                                self.selected_gpu_target() or ""
+                            ),
+                        ),
+                        self._query_gpu_get(),
+                    ),
+                )
             return
 
         native_payload = self._native_query_payload(output)
         if native_payload is not None:
+            self._get_reprobe_count = 0  # success: reset the re-probe budget
+            self._pstates_cached_for = self.selected_gpu_target()
             merged.update(native_payload)
             for key in (
                 "vfp_lock_gpu_core_upperbound_mhz",
@@ -817,17 +1099,20 @@ class App(ctk.CTk):
                 merged.pop(key, None)
             merged.update(normalize_native_vfp_lock_bounds(native_payload))
             pstates = native_payload.get("supported_pstates", [])
-            self._gpu_pstates_cache = (
+            fresh = (
                 [str(pstate) for pstate in pstates] if isinstance(pstates, list) else []
             )
+            if fresh or not self._gpu_pstates_cache:
+                self._gpu_pstates_cache = fresh
+            # else: empty result on a possibly half-awake GPU — keep the last
+            # known-good list rather than silently downgrading to 'unsupported'.
             merged["supported_pstates"] = self._gpu_pstates_cache
             self._gpu_limits_cache = merged
             self._sync_dashboard_lock_state_from_cache(merged)
-            if self._gpu_pstates_cache:
-                self.console.append(
-                    f"[GUI] Supported P-States: {', '.join(self._gpu_pstates_cache)}\n"
-                )
-            else:
+            if fresh and fresh != self._last_pstates_logged:
+                self._last_pstates_logged = list(fresh)
+                self.console.append(f"[GUI] Supported P-States: {', '.join(fresh)}\n")
+            elif not self._gpu_pstates_cache:
                 self.console.append(
                     "[GUI] Warning: native settings returned no supported P-States.\n"
                 )
@@ -878,8 +1163,11 @@ class App(ctk.CTk):
         self._gpu_limits_cache = merged
         self._sync_dashboard_lock_state_from_cache(merged)
 
-        if pstates:
+        if pstates and pstates != self._last_pstates_logged:
+            self._last_pstates_logged = list(pstates)
             self.console.append(f"[GUI] Supported P-States: {', '.join(pstates)}\n")
+        elif pstates:
+            pass
         else:
             self.console.append(
                 "[GUI] Warning: 'get' returned no parseable supported P-States.\n"
@@ -959,41 +1247,16 @@ class App(ctk.CTk):
         else:
             self.console.append("[GUI] VFP lock: None\n")
 
-        # Sync lock state into vfcurve tab, then trigger a full curve refresh
+        # Sync lock state into vfcurve tab. A curve fetch is only needed to
+        # resolve the pending lock before data exists; with data loaded the
+        # sync itself maps the lock to a point index.
         self._locked_voltage_mv_cache = locked_voltage_mv
         if self.tab_vfcurve:
             self.tab_vfcurve.sync_lock_from_voltage(locked_voltage_mv)
-            self.tab_vfcurve._refresh_curve()
+            if not self.tab_vfcurve._voltages:
+                self.tab_vfcurve._refresh_curve()
         else:
             self.refresh_vfp_offset_state()
-
-    def _get_vfp_cache_path(self) -> str:
-        """Return the VFP CSV cache path for the current GPU."""
-        app_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        cache_dir = os.path.join(app_dir, VFCurveTab._EXPORT_DIR)
-        os.makedirs(cache_dir, exist_ok=True)
-
-        uuid = self.get_current_gpu_uuid()
-        if uuid:
-            fname = f"{uuid}.csv"
-        else:
-            idx = self.get_current_gpu_index()
-            fname = f"gpu_{idx if idx is not None else 0}.csv"
-        return os.path.join(cache_dir, fname)
-
-    @staticmethod
-    def _analyze_vfp_offsets(
-        frequencies: List[float], defaults: List[float]
-    ) -> Tuple[bool, Optional[int]]:
-        """Return (has_any_offset, uniform_core_offset_mhz_if_flat_curve)."""
-        return analyze_vfp_offsets(frequencies, defaults)
-
-    @staticmethod
-    def _get_vfp_offset_state_from_csv(
-        csv_path: str,
-    ) -> Optional[Tuple[bool, Optional[int]]]:
-        """Read a VF export and return (has_any_offset, uniform_core_offset_mhz_if_flat_curve)."""
-        return get_vfp_offset_state_from_csv(csv_path)
 
     def _apply_vfp_offset_state(
         self, has_vfp_offset: bool, uniform_core_offset_mhz: Optional[int] = None
@@ -1026,7 +1289,6 @@ class App(ctk.CTk):
         if gpu is None:
             return
 
-        csv_path = self._get_vfp_cache_path()
         self._vfp_offset_refresh_inflight = True
         self._pending_vfp_offset_refresh = False
         gpu_key = self._get_vfp_offset_gpu_key()
@@ -1035,9 +1297,8 @@ class App(ctk.CTk):
             retcode = 0
             vfp_offset_state = None
             try:
-                points = self.backend.query_domain_vfp_points(gpu)
-                write_vfp_points(csv_path, points)
-                vfp_offset_state = self._get_vfp_offset_state_from_csv(csv_path)
+                points = self.backend.query_public_vftable(gpu)
+                vfp_offset_state = get_vfp_offset_state_from_points(points)
             except Exception:
                 retcode = -1
             self.after(
@@ -1125,11 +1386,29 @@ class App(ctk.CTk):
             thread_name=f"show-{command_name or 'query'}",
         )
 
+    # TTL for reused query results. Tab entry / GPU-switch chains re-query the
+    # same (gpu, command) within a couple of seconds; serving the cached
+    # result collapses those redundant driver round-trips.
+    _QUERY_CACHE_TTL_S = 2.0
+
+    def _query_cache_key(self, gpu: Any, command_name: str) -> Optional[str]:
+        gpu_id = getattr(gpu, "gpu_id", None)
+        if gpu_id is None:
+            uuid = getattr(gpu, "uuid", None)
+            gpu_id = uuid if uuid else repr(gpu)
+        return f"{gpu_id}:{command_name}"
+
+    def _invalidate_query_cache(self) -> None:
+        with self._query_cache_lock:
+            self._query_result_cache.clear()
+
     def run_gpu_query_async(
         self,
         command_args: List[str],
         callback: Callable[[int, str], None],
         thread_name: str = "gpu-query",
+        use_cache: bool = True,
+        allow_wake: bool = True,
     ) -> bool:
         """Run a GPU-scoped native query asynchronously and return whether it started."""
         gpu = self.selected_gpu_target()
@@ -1140,14 +1419,41 @@ class App(ctk.CTk):
             callback(-1, f"Unsupported native query: {command_name}")
             return False
 
+        cache_key = self._query_cache_key(gpu, command_name)
+        if use_cache:
+            now = time.monotonic()
+            with self._query_cache_lock:
+                cached = self._query_result_cache.get(cache_key)
+                if cached is not None:
+                    ts, retcode, output = cached
+                    if now - ts < self._QUERY_CACHE_TTL_S:
+                        self.after(0, lambda: callback(retcode, output))
+                        return True
+
         def _worker():
-            retcode, output, _parsed = self.backend.run_query(gpu, command_name)
-            self.after(0, lambda: callback(retcode, output))
+            retcode, output, _parsed = self.backend.run_query(
+                gpu, command_name, allow_wake=allow_wake
+            )
+            if retcode == 0:
+                with self._query_cache_lock:
+                    self._query_result_cache[cache_key] = (
+                        time.monotonic(),
+                        retcode,
+                        output,
+                    )
+            # Guard the main-thread marshal during shutdown: an inflight
+            # worker (dash-poll / vfcurve-refresh) may complete after
+            # _do_shutdown sets _exiting and tears down widgets; scheduling
+            # after() on a destroyed root raises a Tcl error.
+            if not getattr(self, "_exiting", False):
+                self.after(0, lambda: callback(retcode, output))
 
         self.run_background(thread_name, _worker)
         return True
 
     def _on_native_output(self, text: str, _level: str = "info") -> None:
+        if getattr(self, "_exiting", False):
+            return
         self.after(0, lambda: self.console.append(text))
 
     def run_native_action(
@@ -1165,8 +1471,13 @@ class App(ctk.CTk):
             description,
             action,
             self._on_native_output,
-            lambda code: self.after(
-                0, lambda: self._after_native_action(code, on_finished)
+            lambda code: (
+                None
+                if getattr(self, "_exiting", False)
+                else self.after(
+                    0,
+                    lambda: self._after_native_action(code, on_finished, description),
+                )
             ),
         )
         if not started:
@@ -1177,12 +1488,18 @@ class App(ctk.CTk):
         self, commands: List[Tuple[str, Callable[[Any], Optional[str]]]]
     ) -> None:
         queue = list(commands)
+        all_commands = list(commands)
 
         def start_next(_code: int = 0) -> None:
             if _code != 0:
                 return
             if not queue:
-                self.refresh_after_native_action()
+                self.refresh_after_native_action(
+                    curve_affecting=any(
+                        k in " ".join(d for d, _ in all_commands).lower()
+                        for k in self._CURVE_AFFECTING
+                    )
+                )
                 return
             description, action = queue.pop(0)
             started = self.backend.run_action(
@@ -1196,16 +1513,34 @@ class App(ctk.CTk):
 
         start_next()
 
+    # Only these actions can change the VF curve; everything else (PPAB,
+    # fan, D-Notifier, TGP, temp ...) skips the curve re-query.
+    _CURVE_AFFECTING = ("vfp", "offset", "curve", "reset all")
+
     def _after_native_action(
-        self, code: int, on_finished: Optional[Callable[[int], None]] = None
+        self,
+        code: int,
+        on_finished: Optional[Callable[[int], None]] = None,
+        description: str = "",
     ) -> None:
         if on_finished is not None:
             on_finished(code)
         if code == 0:
-            self.refresh_after_native_action()
+            low = description.lower()
+            self.refresh_after_native_action(
+                curve_affecting=any(k in low for k in self._CURVE_AFFECTING)
+            )
 
-    def refresh_after_native_action(self) -> None:
-        """Coalesce bursts into one deferred status refresh chain."""
+    def refresh_after_native_action(self, curve_affecting: bool = False) -> None:
+        """Re-query everything after a native action (4-query chain).
+
+        Coalesced: bursts (chained actions, PPAB auto-enable during mobile
+        panel load) collapse into one deferred chain instead of stacking
+        callback storms on the UI thread. The VF-curve re-query runs only
+        when the action can actually change the curve (offsets / VFP ops).
+        """
+        if curve_affecting:
+            self._pending_chain_curve = True
         if self._refresh_chain_after_id is not None:
             self.after_cancel(self._refresh_chain_after_id)
         self._refresh_chain_after_id = self.after(
@@ -1214,11 +1549,15 @@ class App(ctk.CTk):
 
     def _refresh_after_native_action_now(self) -> None:
         self._refresh_chain_after_id = None
+        want_curve = getattr(self, "_pending_chain_curve", False)
+        self._pending_chain_curve = False
+        # A native action mutated GPU state — cached query results are stale.
+        self._invalidate_query_cache()
         self._query_gpu_get()
         self._query_overclock_status()
         if self.tab_dashboard:
             self.tab_dashboard._fetch_once()
-        if self.tab_vfcurve:
+        if self.tab_vfcurve and want_curve:
             self.tab_vfcurve._refresh_curve()
 
     def run_cli_display(
@@ -1330,6 +1669,24 @@ class App(ctk.CTk):
                 pass
         self._tray_icon = self._build_tray_icon()
         self._tray_thread = self.run_background("tray-icon", self._tray_icon.run)
+        # Keep-alive: after long tray idles Windows pages the GUI's working
+        # set out, making the first restore repaint painfully slow. A slow
+        # layout tick keeps the widget pages resident.
+        if self._tray_keepalive_id is None:
+            self._tray_keepalive_tick()
+
+    _tray_keepalive_id = None
+
+    def _tray_keepalive_tick(self):
+        if self._exiting or self.winfo_viewable():
+            self._tray_keepalive_id = None
+            return
+        try:
+            self.update_idletasks()
+        except Exception:
+            self._tray_keepalive_id = None
+            return
+        self._tray_keepalive_id = self.after(30000, self._tray_keepalive_tick)
 
     def _show_from_tray(self, icon=None, item=None):
         """Restore the main window from the tray."""
@@ -1422,35 +1779,50 @@ class App(ctk.CTk):
 
     def _do_shutdown(self):
         """Perform shutdown cleanup. Must run on the main Tk thread."""
-        # 1. Stop all periodic timers
-        if self._refresh_chain_after_id is not None:
-            self.after_cancel(self._refresh_chain_after_id)
-            self._refresh_chain_after_id = None
-
+        # 1. Stop all periodic timers FIRST so they cannot re-arm during
+        # the join below and submit new work into a draining runner.
         if hasattr(self, "tab_dashboard") and self.tab_dashboard is not None:
             self.tab_dashboard._stop_polling()
-
-        self._stop_gpu_reprobe()
-
-        if hasattr(self, "tab_overclock") and self.tab_overclock is not None:
-            if hasattr(self.tab_overclock, "_stop_auto_refresh"):
-                self.tab_overclock._stop_auto_refresh()
-            if hasattr(self.tab_overclock, "cleanup"):
-                self.tab_overclock.cleanup()
+        # Cancel the background GPU re-probe timer (scenario A).
+        if hasattr(self, "_stop_gpu_reprobe"):
+            self._stop_gpu_reprobe()
 
         if hasattr(self, "tab_vfcurve") and self.tab_vfcurve is not None:
+            if hasattr(self.tab_vfcurve, "_stop_auto_refresh"):
+                self.tab_vfcurve._stop_auto_refresh()
             if hasattr(self.tab_vfcurve, "cleanup"):
                 self.tab_vfcurve.cleanup()
+
+        # Cancel the post-native-action refresh chain BEFORE joining workers:
+        # a vfcurve-refresh worker inflight when the curve tab was active can
+        # take seconds (VFP RM escape + GCOFF wake+retry, serialized on the
+        # pynvoc InventoryCache mutex with the dash-poll worker). Its
+        # after(0,...) completion re-arms this chain; cancel it now.
+        if getattr(self, "_refresh_chain_after_id", None) is not None:
+            try:
+                self.after_cancel(self._refresh_chain_after_id)
+            except Exception:
+                pass
+            self._refresh_chain_after_id = None
 
         # 2. Stop tray icon (no-op if already stopped from tray thread)
         if self._tray_icon is not None:
             self._tray_icon.stop()
             self._tray_icon = None
+        if self._tray_keepalive_id is not None:
+            self.after_cancel(self._tray_keepalive_id)
+            self._tray_keepalive_id = None
 
-        # 3. Shut down workers (safe on main thread — main thread is not a worker)
+        # 3. Shut down workers. Use wait=False: GuiTaskRunner workers are
+        # daemon threads, so an inflight NVAPI call (which can block seconds
+        # on a GCOFF mobile dGPU, holding the InventoryCache mutex) won't
+        # deadlock the main thread in a join — the process reaps the daemons
+        # on exit. cancel_futures drops anything still queued. The
+        # _cleaned_up guard in vfcurve._refresh_curve/_on_query_done stops
+        # the curve refresh chain from re-submitting after cleanup.
         self.runner.shutdown()
         self.backend.shutdown()
-        self.tasks.shutdown(wait=True)
+        self.tasks.shutdown(wait=False, cancel_futures=True)
         self._flush_cli_output()
         self.config.close()
 

--- a/gui/src/backend/__init__.py
+++ b/gui/src/backend/__init__.py
@@ -1,7 +1,6 @@
 """Backend adapters for GUI operations."""
 
 from src.backend.base import FanSettings
-from src.backend.cli import CliBackend
 from src.backend.native import NativeBackend
 
-__all__ = ["CliBackend", "FanSettings", "NativeBackend"]
+__all__ = ["FanSettings", "NativeBackend"]

--- a/gui/src/backend/native.py
+++ b/gui/src/backend/native.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib
 import json
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -44,7 +45,40 @@ class NativeBackend:
         gpus = [item for item in items if isinstance(item, dict)]
         return 0, f"Detected {len(gpus)} GPU(s) via pynvoc.", gpus
 
-    def run_query(self, gpu: str, command_name: str) -> tuple[int, str, dict[str, Any]]:
+    def _force_wake(self, gpu: str) -> bool:
+        """Native GC6 wake (force_gc6_exit) via pynvoc.
+
+        Mobile dGPUs drop to GCOFF after a few idle seconds; NVAPI reads then
+        fail and get misreported as 'unsupported' (mobile controls, P-States,
+        missing live-point data). Best-effort: desktop GPUs return False.
+        """
+        try:
+            wake = getattr(self._pynvoc(), "force_wake", None)
+            return bool(wake(gpu)) if callable(wake) else False
+        except Exception:
+            return False
+
+    def force_wake(self, gpu: str) -> bool:
+        """Public alias for the GC6 wake (used by the GUI re-probe path)."""
+        return self._force_wake(gpu)
+
+    def run_query(
+        self, gpu: str, command_name: str, allow_wake: bool = True
+    ) -> tuple[int, str, dict[str, Any]]:
+        retcode, output, parsed = self._run_query_once(gpu, command_name)
+        if retcode != 0 and allow_wake:
+            # A failed read on a mobile GPU is often just GCOFF (idle dGPU
+            # powered down) — wake it, give the D0 transition a moment, and
+            # retry once before giving up. Monitoring polls pass
+            # allow_wake=False so they never block GC6 sleep.
+            self._force_wake(gpu)
+            time.sleep(0.3)
+            retcode, output, parsed = self._run_query_once(gpu, command_name)
+        return retcode, output, parsed
+
+    def _run_query_once(
+        self, gpu: str, command_name: str
+    ) -> tuple[int, str, dict[str, Any]]:
         try:
             native = self._pynvoc()
             if command_name == "info":
@@ -61,8 +95,125 @@ class NativeBackend:
         except Exception as exc:
             return -1, f"pynvoc {command_name} query failed: {exc}", {}
 
-    def query_domain_vfp_points(self, gpu: str, domain: str = "graphics") -> list[dict]:
-        return self._pynvoc().query_domain_vfp_points(gpu, domain, True)
+    def query_public_vftable(self, gpu: str, domain: str = "graphics") -> list[dict]:
+        try:
+            return self._pynvoc().query_public_vftable(gpu, domain, True)
+        except Exception:
+            self._force_wake(gpu)
+            return self._pynvoc().query_public_vftable(gpu, domain, True)
+
+    def query_private_vftable(self, gpu: str) -> dict | None:
+        """Read the private ClockClient V/F-POINTS table (segments + points).
+
+        Returns ``None`` when the private family is absent (the open VFP
+        interface is the only source for that GPU). Best-effort wake like the
+        public read.
+        """
+        try:
+            return self._pynvoc().query_private_vftable(gpu)
+        except Exception:
+            self._force_wake(gpu)
+            try:
+                return self._pynvoc().query_private_vftable(gpu)
+            except Exception:
+                return None
+
+    def query_private_freq_domain_status(self, gpu: str, domain_bit: int) -> dict | None:
+        """Direct physical clock for one domain (green-curve MEASURE 0x527FC458).
+
+        Returns ``{"domain_bit", "freq_khz"}`` (``freq_khz == 0`` ⇒ driver
+        refused / not measurable — caller should not draw a live point), or
+        ``{"supported": false}`` when the family is absent, or ``None`` on a
+        transient error. Preferred over the counter-based read for XBAR/HOST
+        live-point polling: one call, no 50 ms sleep.
+        """
+        try:
+            return self._pynvoc().query_private_freq_domain_status(gpu, int(domain_bit))
+        except Exception:
+            self._force_wake(gpu)
+            try:
+                return self._pynvoc().query_private_freq_domain_status(gpu, int(domain_bit))
+            except Exception:
+                return None
+
+    def query_mobile_limits(self, gpu: str) -> dict[str, Any]:
+        """Fetch the mobile power/thermal control surface (all NVAPI).
+
+        Returns ``{"tgp": dict|None, "dnotifier": dict|None,
+        "temp_policies": list, "volt_rail": dict|None}``;
+        ``None`` sub-dicts mean the private interface isn't exposed by this
+        driver.
+        """
+        data = self._query_mobile_limits_once(gpu)
+        attempts = 0
+        while (
+            data["tgp"] is None
+            and data["dnotifier"] is None
+            and not data["temp_policies"]
+            and data.get("volt_rail") is None
+            and data.get("power_limit_w") is None
+            and attempts < 3
+        ):
+            # All three failed at once is the GCOFF signature, not three
+            # coincidental 'unsupported' verdicts. The wake call returns
+            # before the dGPU actually reaches D0, so allow a few
+            # wake->settle->retry rounds before concluding 'unsupported'.
+            self._force_wake(gpu)
+            time.sleep(0.4)
+            data = self._query_mobile_limits_once(gpu)
+            attempts += 1
+        return data
+
+    def _query_mobile_limits_once(self, gpu: str) -> dict[str, Any]:
+        native = self._pynvoc()
+        # All five sub-queries are independent NVAPI reads and pynvoc runs
+        # them lock-free against the Arc'd inventory snapshot — fan them out
+        # so the mobile control surface loads in ~max(query) instead of the
+        # sum (each sweep is 100-500ms on a woken dGPU).
+        from concurrent.futures import ThreadPoolExecutor
+
+        def _safe(fn, default):
+            try:
+                return fn()
+            except Exception:
+                return default
+
+        with ThreadPoolExecutor(
+            max_workers=5, thread_name_prefix="nvoc-mobile"
+        ) as pool:
+            tgp_f = pool.submit(_safe, lambda: native.query_tgp_watt_range(gpu), None)
+            dnotifier_f = pool.submit(_safe, lambda: native.query_dnotifier(gpu), None)
+            policies_f = pool.submit(
+                _safe, lambda: native.query_target_temp_policies(gpu), []
+            )
+            enforced_f = pool.submit(
+                _safe,
+                # NVML enforced power limit: the actually-active power wall
+                # (post D-Notifier/load clamp) — the TGP policy itself exposes
+                # no current-value read, so this is the closest real position.
+                lambda: native.query_status(gpu, "both").get("power_limit_w"),
+                None,
+            )
+            # Private VoltRails P0 bounds: VBIOS/VRM voltage ceilings + the
+            # currently-effective voltage wall (the limit slider position).
+            volt_rail_f = pool.submit(_safe, lambda: native.query_volt_rails(gpu), None)
+
+        tgp = tgp_f.result()
+        dnotifier = dnotifier_f.result()
+        policies = policies_f.result()
+        enforced_w = enforced_f.result()
+        volt_rail = volt_rail_f.result()
+        if not isinstance(policies, list):
+            policies = []
+        if not isinstance(volt_rail, dict):
+            volt_rail = None
+        return {
+            "tgp": tgp,
+            "dnotifier": dnotifier,
+            "temp_policies": policies,
+            "volt_rail": volt_rail,
+            "power_limit_w": enforced_w,
+        }
 
     def run_action(
         self,

--- a/gui/src/backend/native.py
+++ b/gui/src/backend/native.py
@@ -118,7 +118,9 @@ class NativeBackend:
             except Exception:
                 return None
 
-    def query_private_freq_domain_status(self, gpu: str, domain_bit: int) -> dict | None:
+    def query_private_freq_domain_status(
+        self, gpu: str, domain_bit: int
+    ) -> dict | None:
         """Direct physical clock for one domain (green-curve MEASURE 0x527FC458).
 
         Returns ``{"domain_bit", "freq_khz"}`` (``freq_khz == 0`` ⇒ driver
@@ -132,7 +134,9 @@ class NativeBackend:
         except Exception:
             self._force_wake(gpu)
             try:
-                return self._pynvoc().query_private_freq_domain_status(gpu, int(domain_bit))
+                return self._pynvoc().query_private_freq_domain_status(
+                    gpu, int(domain_bit)
+                )
             except Exception:
                 return None
 

--- a/gui/src/parsing.py
+++ b/gui/src/parsing.py
@@ -35,45 +35,6 @@ def as_float(value: object) -> Optional[float]:
     return None
 
 
-def parse_gpu_list_output(
-    output: str,
-) -> tuple[dict[int, str], dict[int, str], dict[int, str], dict[int, str]]:
-    gpu_pattern = re.compile(r"^GPU\s+(\d+)\s*:\s*(.+)$")
-    uuid_pattern = re.compile(r"^UUID=(GPU-[\w-]+)")
-    short_labels: dict[int, str] = {}
-    gpu_names: dict[int, str] = {}
-    uuid_map: dict[int, str] = {}
-    last_gpu_idx: Optional[int] = None
-
-    for line in output.strip().split("\n"):
-        line = line.strip()
-        match = gpu_pattern.match(line)
-        if match:
-            idx = int(match.group(1))
-            name = match.group(2).strip()
-            inline_uuid = re.search(r"(?i)\buuid\s*[:=]\s*(GPU-[\w-]+)", name)
-            if inline_uuid:
-                uuid_map[idx] = inline_uuid.group(1)
-            name = re.split(r"(?i)\buuid\s*[:=]\s*gpu-[\w-]+", name, maxsplit=1)[
-                0
-            ].strip()
-            name = re.sub(r"\s*\[\s*GPU-[\w-]+\s*\].*$", "", name, flags=re.IGNORECASE)
-            last_gpu_idx = idx
-            if idx not in short_labels:
-                short_labels[idx] = f"GPU {idx}: {name}"
-                gpu_names[idx] = name
-            continue
-        uuid_match = uuid_pattern.match(line)
-        if uuid_match and last_gpu_idx is not None:
-            uuid_map[last_gpu_idx] = uuid_match.group(1)
-
-    long_labels = {
-        idx: f"{short}  [{uuid_map[idx]}]" if idx in uuid_map else short
-        for idx, short in short_labels.items()
-    }
-    return short_labels, long_labels, gpu_names, uuid_map
-
-
 def parse_info_limits(output: str) -> dict[str, Any]:
     native_payload = native_query_payload(output)
     if native_payload is not None:
@@ -423,6 +384,21 @@ def analyze_vfp_offsets(
             return False, None
         return True, int(round(offsets[0]))
     return any(abs(offset) > eps for offset in offsets), None
+
+
+def get_vfp_offset_state_from_points(
+    points: list[dict[str, Any]],
+) -> Optional[tuple[bool, Optional[int]]]:
+    """Analyze in-memory VFP points (pynvoc dicts, kHz) for offset state."""
+    frequencies: list[float] = []
+    defaults: list[float] = []
+    for point in points:
+        freq = point.get("frequency_khz", 0) / 1000.0
+        default_khz = point.get("default_frequency_khz")
+        default = freq if default_khz is None else default_khz / 1000.0
+        frequencies.append(freq)
+        defaults.append(default)
+    return analyze_vfp_offsets(frequencies, defaults)
 
 
 def get_vfp_offset_state_from_csv(

--- a/gui/src/tabs/__init__.py
+++ b/gui/src/tabs/__init__.py
@@ -1,0 +1,1 @@
+"""GUI tabs (dashboard-centric layout)."""

--- a/gui/src/tabs/dashboard/__init__.py
+++ b/gui/src/tabs/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Dashboard tab and its hosted sections."""
+
+from .tab import DashboardTab
+
+__all__ = ["DashboardTab"]

--- a/gui/src/tabs/dashboard/sections/__init__.py
+++ b/gui/src/tabs/dashboard/sections/__init__.py
@@ -1,0 +1,6 @@
+"""Sections hosted on the Dashboard tab."""
+
+from .overclock import OverclockTab
+from .fan import FanControlPane
+
+__all__ = ["OverclockTab", "FanControlPane"]

--- a/gui/src/tabs/dashboard/sections/fan.py
+++ b/gui/src/tabs/dashboard/sections/fan.py
@@ -1,0 +1,520 @@
+"""Fan Control pane - compact full-width section for the dashboard.
+
+Layout:
+  row 1 : [🌀 Fan Control] [All/Fan dropdown] [0-30-50-70-100 node slider + entry%] ...[NVAPI/NVML]
+  row 2 : [Policy: [menu]] (1/3)      [✅ Apply] (1/3)      [🔄 Reset] (1/3)
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from typing import Callable, Optional, Protocol, Sequence
+
+import customtkinter as ctk
+
+from src.backend.base import FanSettings, GuiBackend
+from src.widgets.lightweight_controls import (
+    ct_button_font,
+    LiteButton,
+    LiteEntry,
+)
+
+# De-CTk'd inner-panel palette (matches overclock.py / CTk dark theme)
+_PANE_BG = "#2b2b2b"
+_TEXT_FG = "#e5e5e5"
+_TEXT_FG_DIM = "#b3b3b3"
+_FONT_BODY = ("Segoe UI", 11)
+_FONT_HEADER = ("Segoe UI", 13, "bold")
+_SECTION_BORDER = "#1f4e79"
+
+
+NVAPI_POLICIES = [
+    "default",
+    "manual",
+    "perf",
+    "discrete",
+    "continuous",
+    "hybrid",
+    "software",
+    "default32",
+]
+NVML_POLICIES = ["continuous", "manual"]
+
+
+class FanControlPaneProtocol(Protocol):
+    def selected_api(self) -> str: ...
+    def selected_fan_id(self) -> str: ...
+    def selected_policy(self) -> str: ...
+    def fan_level(self) -> int: ...
+    def fan_level_text(self) -> str: ...
+    def set_policy_values(self, values: Sequence[str]) -> None: ...
+    def set_policy(self, policy: str) -> None: ...
+    def set_level(self, level: int) -> None: ...
+    def set_supported_state(self, supported: bool) -> None: ...
+
+
+class FanControlController:
+    def __init__(self, pane: FanControlPaneProtocol, backend: GuiBackend) -> None:
+        self.pane = pane
+        self.backend = backend
+
+    def selected_backend(self) -> str:
+        selected = self.pane.selected_api().strip().upper()
+        return "nvml-cooler" if selected == "NVML" else "nvapi-cooler"
+
+    def allowed_policies(self) -> list[str]:
+        if self.selected_backend() == "nvml-cooler":
+            return list(NVML_POLICIES)
+        return list(NVAPI_POLICIES)
+
+    def normalize_policy(self) -> str:
+        policy = self.pane.selected_policy().lower().strip()
+        allowed = self.allowed_policies()
+        if policy not in allowed:
+            policy = "continuous" if "continuous" in allowed else allowed[0]
+            self.pane.set_policy(policy)
+        return policy
+
+    def fan_id(self) -> Optional[str]:
+        selected = self.pane.selected_fan_id().strip()
+        if not selected.startswith("Fan "):
+            return None
+        parts = selected.split()
+        return parts[1] if len(parts) > 1 else None
+
+    def settings(self, *, reset: bool = False) -> FanSettings:
+        return FanSettings(
+            backend=self.selected_backend(),
+            fan_id=self.fan_id(),
+            policy="auto" if reset else self.normalize_policy(),
+            level=0 if reset else self.pane.fan_level(),
+        )
+
+    def on_backend_change(self) -> None:
+        self.pane.set_policy_values(self.allowed_policies())
+        self.normalize_policy()
+
+    def on_slider_change(self, value: float) -> None:
+        self.pane.set_level(int(value))
+
+    def on_entry_change(self) -> None:
+        text = self.pane.fan_level_text().strip()
+        if not text:
+            return
+        try:
+            level = int(text)
+        except ValueError:
+            return
+        self.pane.set_level(max(0, min(100, level)))
+
+    def set_preset(self, level: int) -> None:
+        self.pane.set_policy("continuous")
+        self.pane.set_level(level)
+        self.apply()
+
+    def apply(self) -> None:
+        self.backend.apply_fan_settings(self.settings())
+
+    def reset(self) -> None:
+        self.backend.reset_fan_settings(self.settings(reset=True))
+
+    def set_supported(self, supported: bool) -> None:
+        self.pane.set_supported_state(supported)
+
+
+class FanLevelSelector(tk.Frame):
+    """Fan level control: 5 snap nodes (0/30/50/70/100) on a track.
+
+    - Click/drag snaps to the nearest node (PState/D-selector styling).
+    - Mouse wheel adjusts steplessly (+/- 1%) across 0..100.
+    - Value is mirrored to ``variable`` (the % entry); external writes to
+      the variable redraw the handle.
+    """
+
+    _NODES = (0, 30, 50, 70, 100)
+    _NODE_COLORS = ("#44cc88", "#9acd32", "#f9a825", "#ff8c00", "#e53935")
+    _TRACK_Y = 14
+    _NODE_R = 9
+    _HANDLE_R = 8
+    _PAD_X = 34
+
+    def __init__(
+        self,
+        master,
+        variable: ctk.StringVar,
+        command: Optional[Callable[[int], None]] = None,
+        bg: str = _PANE_BG,
+    ):
+        super().__init__(master, bg=bg, bd=0, highlightthickness=0)
+        self._variable = variable
+        self._command = command
+        self._bg = bg
+        self._value = 60
+        self._syncing = False
+        self._active = True
+
+        self._canvas = tk.Canvas(
+            self, width=1, height=48, highlightthickness=0, bd=0, bg=bg
+        )
+        self._canvas.pack(fill="both", expand=True)
+        self._canvas.bind("<Button-1>", self._on_click)
+        self._canvas.bind("<B1-Motion>", self._on_drag)
+        self._canvas.bind("<MouseWheel>", self._on_wheel)
+        self._canvas.bind("<Button-4>", lambda e: self._step(-1))
+        self._canvas.bind("<Button-5>", lambda e: self._step(1))
+        self._canvas.bind("<Configure>", lambda _e: self._redraw())
+        variable.trace_add("write", lambda *_: self._on_var())
+
+    # ── geometry helpers ──────────────────────────────────────────────
+    def _track(self):
+        w = max(1, self._canvas.winfo_width())
+        x0 = self._PAD_X
+        x1 = max(x0 + 1, w - self._PAD_X)
+        return x0, x1
+
+    def _value_to_x(self, value: float) -> float:
+        x0, x1 = self._track()
+        return x0 + (value / 100.0) * (x1 - x0)
+
+    def _x_to_value(self, x: float) -> float:
+        x0, x1 = self._track()
+        ratio = max(0.0, min(1.0, (x - x0) / max(1e-9, (x1 - x0))))
+        return ratio * 100.0
+
+    # ── public API (CanvasSlider-compatible subset) ───────────────────
+    def get(self) -> float:
+        return float(self._value)
+
+    def set(self, value) -> None:
+        v = int(max(0, min(100, round(float(value)))))
+        if v == self._value:
+            return
+        self._value = v
+        self._redraw()
+
+    def configure(self, **kwargs):
+        state = kwargs.pop("state", None)
+        if state is not None:
+            self._state = state
+        self._redraw()
+
+    def set_active(self, active: bool) -> None:
+        """Unsupported GPUs hide the handle (no misleading position)."""
+        if active != self._active:
+            self._active = active
+            self._redraw()
+
+    _state = "normal"
+
+    # ── interaction ───────────────────────────────────────────────────
+    def _on_click(self, event):
+        """Click snaps to the nearest preset node."""
+        if getattr(self, "_state", "normal") == "disabled":
+            return
+        value = self._x_to_value(float(event.x))
+        node = min(self._NODES, key=lambda n: abs(n - value))
+        self._commit(node)
+
+    def _on_drag(self, event):
+        """Dragging is stepless — snapping only happens on click."""
+        if getattr(self, "_state", "normal") == "disabled":
+            return
+        self._commit(int(round(self._x_to_value(float(event.x)))))
+
+    def _on_wheel(self, event):
+        if getattr(self, "_state", "normal") == "disabled":
+            return
+        delta = int(getattr(event, "delta", 0) or 0)
+        if delta == 0:
+            return
+        self._step(-1 if delta > 0 else 1)
+
+    def _step(self, direction: int):
+        if getattr(self, "_state", "normal") == "disabled":
+            return
+        self._commit(int(max(0, min(100, self._value + direction))))
+
+    def _commit(self, value: int):
+        value = int(max(0, min(100, value)))
+        if value == self._value:
+            return
+        self._syncing = True
+        try:
+            self._value = value
+            self._variable.set(str(value))
+            if callable(self._command):
+                self._command(value)
+        finally:
+            self._syncing = False
+        self._redraw()
+
+    def _on_var(self):
+        if self._syncing:
+            return
+        try:
+            value = int(float(self._variable.get().strip()))
+        except ValueError:
+            return
+        value = int(max(0, min(100, value)))
+        if value != self._value:
+            self._value = value
+            self._redraw()
+
+    # ── drawing ───────────────────────────────────────────────────────
+    def _redraw(self):
+        c = self._canvas
+        c.delete("all")
+        x0, x1 = self._track()
+
+        c.create_line(
+            x0,
+            self._TRACK_Y,
+            x1,
+            self._TRACK_Y,
+            fill="#3a3a3a",
+            width=4,
+            capstyle=tk.ROUND,
+        )
+
+        for node, color in zip(self._NODES, self._NODE_COLORS):
+            nx = self._value_to_x(node)
+            c.create_oval(
+                nx - self._NODE_R,
+                self._TRACK_Y - self._NODE_R,
+                nx + self._NODE_R,
+                self._TRACK_Y + self._NODE_R,
+                fill=color,
+                outline="",
+            )
+            c.create_text(
+                nx,
+                self._TRACK_Y + 22,
+                text=str(node),
+                fill="#7e8da1",
+                font=("Segoe UI", 8, "bold"),
+            )
+
+        # current-value handle (PState/D handle styling) — hidden when the
+        # fan control is unsupported so no default position misleads.
+        if self._active:
+            hx = self._value_to_x(self._value)
+            c.create_oval(
+                hx - self._HANDLE_R,
+                self._TRACK_Y - self._HANDLE_R,
+                hx + self._HANDLE_R,
+                self._TRACK_Y + self._HANDLE_R,
+                fill="#f5f7fb",
+                outline="#59b0ff",
+                width=2,
+            )
+
+
+class FanControlPane:
+    """Compact fan-control section (dashboard integration)."""
+
+    def __init__(
+        self,
+        parent: ctk.CTkFrame,
+        backend: GuiBackend,
+        embedded: bool = True,
+        content_parent: ctk.CTkFrame | None = None,
+    ) -> None:
+        self.frame = parent
+        self.controller = FanControlController(self, backend)
+        self._interactive_widgets: list[object] = []
+        self._supported_state = True
+
+        host = content_parent if content_parent is not None else parent
+        self._build_content(host)
+
+    # ── UI ────────────────────────────────────────────────────────────────
+    def _build_content(self, host: ctk.CTkFrame) -> None:
+        section = ctk.CTkFrame(
+            host, border_width=1, border_color=_SECTION_BORDER, corner_radius=10
+        )
+        section.pack(fill="x", pady=(0, 10))
+
+        # ── One shared grid, two rows x (third | separator | third | separator | third).
+        # Hard vertical separators enforce the 1/3 alignment visually.
+        grid = tk.Frame(section, bg=_PANE_BG)
+        grid.pack(fill="x", padx=12, pady=(10, 10))
+        for col in (0, 2, 4):
+            grid.columnconfigure(col, weight=1, uniform="fan_thirds")
+        for col in (1, 3):
+            grid.columnconfigure(col, weight=0)
+        for sep_col in (1, 3):
+            tk.Frame(
+                grid, width=1, height=84, bg="#3f3f3f", bd=0, highlightthickness=0
+            ).grid(row=0, column=sep_col, rowspan=2, sticky="ns", padx=8)
+
+        # Row 0, left third: title + fan ID
+        r0_left = tk.Frame(grid, bg=_PANE_BG)
+        r0_left.grid(row=0, column=0, sticky="ew")
+        self.cooler_title = tk.Label(
+            r0_left,
+            text="🌀 Fan Control",
+            font=_FONT_HEADER,
+            bg=_PANE_BG,
+            fg=_TEXT_FG,
+        )
+        self.cooler_title.pack(side="left")
+        self.fan_id_var = ctk.StringVar(value="All")
+        self.fan_id_menu = ctk.CTkOptionMenu(
+            r0_left,
+            variable=self.fan_id_var,
+            values=["All", "Fan 1", "Fan 2"],
+            width=84,
+            anchor="center",
+            font=ct_button_font(r0_left),
+        )
+        # right-aligned to the 1/3 boundary (matches the Policy dropdown edge)
+        self.fan_id_menu.pack(side="right")
+        self._interactive_widgets.append(self.fan_id_menu)
+
+        # Row 0, middle third: level slider + entry%
+        self.level_var = ctk.StringVar(value="60")
+        r0_mid = tk.Frame(grid, bg=_PANE_BG)
+        r0_mid.grid(row=0, column=2, sticky="ew")
+        self.level_slider = FanLevelSelector(
+            r0_mid,
+            self.level_var,
+            command=self.controller.on_slider_change,
+        )
+        self.level_slider.pack(side="left", fill="x", expand=True)
+        self._interactive_widgets.append(self.level_slider)
+
+        # Row 0, right third: NVAPI/NVML
+        r0_right = tk.Frame(grid, bg=_PANE_BG)
+        r0_right.grid(row=0, column=4, sticky="ew")
+        self.level_entry = LiteEntry(
+            r0_right, textvariable=self.level_var, width=4, justify="right"
+        )
+        self.level_entry.pack(side="left", padx=(0, 2))
+        self._interactive_widgets.append(self.level_entry)
+        tk.Label(
+            r0_right, text="%", font=_FONT_BODY, bg=_PANE_BG, fg=_TEXT_FG_DIM
+        ).pack(side="left", padx=(0, 10))
+        self.cooler_api_var = ctk.StringVar(value="NVAPI")
+        self.cooler_api_menu = ctk.CTkOptionMenu(
+            r0_right,
+            variable=self.cooler_api_var,
+            values=["NVAPI", "NVML"],
+            width=84,
+            anchor="center",
+            command=lambda _: self.controller.on_backend_change(),
+            font=ct_button_font(r0_right),
+        )
+        self.cooler_api_menu.pack(side="right")
+        self._interactive_widgets.append(self.cooler_api_menu)
+
+        self.level_var.trace_add("write", lambda *_: self.controller.on_entry_change())
+
+        # Row 1, left third: Policy
+        r1_left = tk.Frame(grid, bg=_PANE_BG)
+        r1_left.grid(row=1, column=0, sticky="ew", pady=(8, 0))
+        r1_left.grid_columnconfigure(1, weight=1)
+        tk.Label(
+            r1_left,
+            text="Policy:",
+            font=_FONT_BODY,
+            bg=_PANE_BG,
+            fg=_TEXT_FG,
+        ).grid(row=0, column=0, sticky="w")
+        self.policy_var = ctk.StringVar(value="continuous")
+        self.policy_menu = ctk.CTkOptionMenu(
+            r1_left,
+            variable=self.policy_var,
+            values=NVAPI_POLICIES,
+            width=1,  # grid stretches it to fill the third
+            anchor="center",
+            font=ct_button_font(r1_left),
+        )
+        self.policy_menu.grid(row=0, column=1, sticky="ew", padx=(6, 0))
+        self._interactive_widgets.append(self.policy_menu)
+
+        # Row 1, middle third: Apply
+        self.btn_apply_cooler = LiteButton(
+            grid,
+            text="✅ Apply Section",
+            width=10,
+            fg_color="#1a6b2a",
+            hover_color="#145220",
+            command=self.controller.apply,
+        )
+        self.btn_apply_cooler.grid(row=1, column=2, sticky="ew", pady=(8, 0))
+        self._interactive_widgets.append(self.btn_apply_cooler)
+
+        # Row 1, right third: Reset
+        self.btn_reset_cooler = LiteButton(
+            grid,
+            text="🔄 Reset to Auto",
+            width=10,
+            fg_color="#c0392b",
+            hover_color="#96281b",
+            command=self.controller.reset,
+        )
+        self.btn_reset_cooler.grid(row=1, column=4, sticky="ew", pady=(8, 0))
+        self._interactive_widgets.append(self.btn_reset_cooler)
+
+    # ── Controller protocol ───────────────────────────────────────────────
+    def selected_api(self) -> str:
+        return self.cooler_api_var.get()
+
+    def selected_fan_id(self) -> str:
+        return self.fan_id_var.get()
+
+    def selected_policy(self) -> str:
+        return self.policy_var.get()
+
+    def fan_level(self) -> int:
+        try:
+            return int(self.level_slider.get())
+        except (TypeError, ValueError):
+            return 0
+
+    def fan_level_text(self) -> str:
+        return self.level_var.get()
+
+    def set_policy_values(self, values: Sequence[str]) -> None:
+        self.policy_menu.configure(values=list(values))
+
+    def set_policy(self, policy: str) -> None:
+        self.policy_var.set(policy)
+
+    def set_level(self, level: int) -> None:
+        text = str(level)
+        if self.level_var.get() != text:
+            self.level_var.set(text)
+        self.level_slider.set(level)
+
+    def set_supported(self, supported: bool) -> None:
+        self.set_supported_state(supported)
+
+    def set_supported_state(self, supported: bool) -> None:
+        if supported == self._supported_state:
+            return
+        self._supported_state = supported
+
+        state = "normal" if supported else "disabled"
+        for widget in self._interactive_widgets:
+            try:
+                widget.configure(state=state)
+            except Exception:
+                pass
+
+        self.level_slider.set_active(supported)
+        if supported:
+            if not self.level_var.get().strip():
+                self.level_var.set(str(int(self.level_slider.get())))
+        else:
+            # No fan control on this GPU: blank the % value instead of
+            # showing the 60 default.
+            self.level_var.set("")
+
+        self.cooler_title.configure(fg=_TEXT_FG if supported else "#8a8a8a")
+
+    def on_resize_state_changed(
+        self, resizing: bool, force_flush: bool = False
+    ) -> None:
+        """Compatibility hook for app-level resize coordinator."""
+        return

--- a/gui/src/tabs/dashboard/sections/overclock.py
+++ b/gui/src/tabs/dashboard/sections/overclock.py
@@ -1,0 +1,2089 @@
+"""
+Overclock Tab - OC offset (slider + entry) and power/thermal limits.
+Ranges are queried from GPU hardware via the CLI 'info' command.
+"""
+
+from typing import TYPE_CHECKING, Tuple, Dict, Any, Optional, Union
+
+import tkinter as tk
+
+import customtkinter as ctk
+
+from src.tabs.dashboard.sections.fan import FanControlPane
+from src.widgets.lightweight_controls import (
+    ct_button_font,
+    CanvasSlider,
+    LiteButton,
+    LiteCheckbutton,
+    LiteEntry,
+    SegmentRangeSelector,
+    SegmentToggleSelector,
+    install_mousewheel_support,
+)
+from src.widgets.hover_tooltip import HoverTooltip
+
+# ── De-CTk'd panel palette ──────────────────────────────────────────────
+# Inner layout uses plain tk widgets: one bg for every container (matches
+# CTk dark-theme frame/scroll bg), plus text colors. Keeping these in one
+# place makes the light/dark question a one-spot change.
+_PANEL_BG = "#2b2b2b"  # CTk dark frame/scroll background
+_TEXT_FG = "#e5e5e5"  # default label text
+_TEXT_FG_DIM = "#b3b3b3"  # 'gray70' hints
+_TEXT_FG_FAINT = "#999999"  # 'gray60' status text
+_FONT_BODY = ("Segoe UI", 11)
+_FONT_HEADER = ("Segoe UI", 13, "bold")
+
+
+if TYPE_CHECKING:
+    from src.app import App
+
+
+class OverclockTab:
+    """Overclock tab for GPU OC offset settings with slider + numeric entry."""
+
+    # ── Fallback defaults (overridden by real GPU info) ──
+    _DEFAULTS = {
+        "core_clock_min": -500,
+        "core_clock_max": 500,
+        "mem_clock_min": -500,
+        "mem_clock_max": 1500,
+        "power_limit_min": 50,
+        "power_limit_max": 150,
+        "power_limit_default": 100,
+        "thermal_limit_min": 60,
+        "thermal_limit_max": 95,
+        "thermal_limit_default": 83,
+        "voltage_boost_min": 0,
+        "voltage_boost_max": 100,
+    }
+
+    def __init__(
+        self,
+        parent: ctk.CTkFrame,
+        app: "App",
+        content_parent: Optional[Any] = None,
+        fan_parent: Optional[Any] = None,
+    ):
+        self.app = app
+        self.frame = parent
+        self._syncing = False  # guard against feedback loops
+        self._is_vfp_mode = False
+        self._vfp_uniform_offset_mhz = None  # type: Optional[int]
+        self._limit_supported_state = True
+        self._limit_panel_mode = "desktop"  # "desktop" | "mobile" | "off"
+        self._mobile_mode = False
+        self._tgp_policy_index = 2
+        self._mobile_ppab_initialized_for = None  # type: Optional[str]
+        self._mobile_limits_gpu = None  # type: Optional[str]
+        self._mobile_load_in_flight = False
+        self._volt_rail_bit = 0  # VoltRails rail bit (0 on single-rail mobile GPUs)
+        self._xbar_supported = False  # Xbar row: Turing (GTX 16系) and newer
+        self._is_resize_active = False
+        self._pending_limits = None  # type: Optional[Dict[str, Any]]
+        self._pending_capabilities = None  # type: Optional[Dict[str, Any]]
+        self._pending_vfp_state = None  # type: Optional[Tuple[bool, Optional[int]]]
+        self._supported_pstates = []  # type: List[str]
+
+        scroll = ctk.CTkScrollableFrame(self.frame)
+        scroll.pack(fill="both", expand=True, padx=10, pady=10)
+        install_mousewheel_support(scroll)
+
+        # Mutable defaults – updated by update_limits() when real GPU info arrives
+        self._power_default = self._DEFAULTS["power_limit_default"]
+        self._thermal_default = self._DEFAULTS["thermal_limit_default"]
+
+        d = self._DEFAULTS
+
+        # Top panels (Clock Offsets + Power & Thermal Limits) can be hosted by
+        # the dashboard (integration mode) or live in this tab's scroll frame.
+        content_host = content_parent if content_parent is not None else scroll
+        content_row = tk.Frame(content_host, bg=_PANEL_BG)
+        content_row.pack(fill="x", pady=(0, 10))
+        # uniform: strictly equal card widths regardless of requested sizes
+        content_row.grid_columnconfigure(0, weight=1, uniform="oc_cards")
+        content_row.grid_columnconfigure(1, weight=1, uniform="oc_cards")
+
+        # ═══════════════════════════════════════════
+        # Clock Offset (OC)
+        # ═══════════════════════════════════════════
+        # Thin rounded dark-blue frame marks the section boundary
+        oc_frame = ctk.CTkFrame(
+            content_row, border_width=1, border_color="#1f4e79", corner_radius=10
+        )
+        # "new": natural height, top aligned — with "nsew" the two cards
+        # stretch to the taller one's height and the shorter card shows a
+        # large empty gap under its sliders (e.g. mobile mode layout).
+        oc_frame.grid(row=0, column=0, sticky="new", padx=(0, 5))
+        oc_header = tk.Frame(oc_frame, bg=_PANEL_BG)
+        oc_header.pack(fill="x", padx=10, pady=(10, 9))
+        tk.Label(
+            oc_header,
+            text="⚡ Clock Offsets",
+            font=_FONT_HEADER,
+            bg=_PANEL_BG,
+            fg=_TEXT_FG,
+        ).pack(side="left")
+        self.oc_api_var = ctk.StringVar(value="NVAPI")
+        self.oc_api_selector = ctk.CTkOptionMenu(
+            oc_header,
+            values=["NVAPI", "NVML"],
+            variable=self.oc_api_var,
+            width=84,
+            anchor="center",
+            font=ct_button_font(oc_header),
+            height=28,
+            command=self._on_oc_api_changed,
+        )
+        self.oc_api_selector.pack(side="right")
+        oc_api_tip = (
+            "Clock offset API selector (core/memory + PState lock).\n"
+            "- NVAPI: --core-offset / --mem-offset values are in kHz.\n"
+            "- NVML: --core-offset / --mem-offset values are in MHz.\n"
+            "NVAPI-only rows (Xbar, Volt Limit) grey out under NVML."
+        )
+        HoverTooltip(self.oc_api_selector, oc_api_tip)
+
+        # PState lock selector
+        ps_row = tk.Frame(oc_frame, bg=_PANEL_BG)
+        ps_row.pack(fill="x", padx=(26, 10), pady=(0, 5))
+        ps_row.grid_columnconfigure(1, weight=1)
+        tk.Label(
+            ps_row,
+            text="PState 🔒:",
+            anchor="w",
+            font=_FONT_BODY,
+            bg=_PANEL_BG,
+            fg=_TEXT_FG,
+        ).grid(row=0, column=0, sticky="nw", pady=(5, 0))
+        self.pstate_selector = SegmentRangeSelector(ps_row, values=[])
+        self.pstate_selector.grid(row=0, column=1, sticky="ew", padx=(2, 8))
+        ps_btns = tk.Frame(ps_row, bg=_PANEL_BG)
+        ps_btns.grid(row=0, column=2, sticky="ne", pady=(4, 0))
+        self.btn_apply_pstate = LiteButton(
+            ps_btns, text="✅", width=34, command=self._apply_pstate_lock
+        )
+        self.btn_apply_pstate.pack(side="left", padx=(0, 5))
+        self.btn_unlock_pstate = LiteButton(
+            ps_btns,
+            text="🔄",
+            width=34,
+            fg_color="#c0392b",
+            hover_color="#96281b",
+            command=self._unlock_pstate_lock,
+        )
+        self.btn_unlock_pstate.pack(side="left")
+        self.set_supported_pstates([])
+
+        # Core Clock slider + entry. Step 2.5 MHz with one decimal — the
+        # LCM-friendly grid that divides both the 7.5 MHz frequency step on
+        # 30-series and newer and the 12.5 MHz step on 10/16/20-series.
+        # entry_width=8 like Volt Limit: "+122.5" needs the extra char.
+        self.core_slider, self.core_entry, self.core_var, _ = self._make_slider_row(
+            oc_frame,
+            "Core:",
+            d["core_clock_min"],
+            d["core_clock_max"],
+            0,
+            step=2.5,
+            apply_cmd=self._apply_core_only,
+            signed=True,
+            unit="MHz",
+            decimals=1,
+            entry_width=8,
+        )
+
+        # Memory Clock slider + entry
+        self.mem_slider, self.mem_entry, self.mem_var, btn_apply_mem = (
+            self._make_slider_row(
+                oc_frame,
+                "Mem:",
+                d["mem_clock_min"],
+                d["mem_clock_max"],
+                0,
+                step=5,
+                apply_cmd=self._apply_mem_only,
+                signed=True,
+                unit="MHz",
+            )
+        )
+        btn_apply_mem.configure(shift_command=self._apply_mem_with_sync)
+        HoverTooltip(
+            btn_apply_mem,
+            "Shift+Click: apply global offset then sync P2 memory VFP to P0 frequency",
+        )
+
+        # Xbar (crossbar fabric) clock offset — NVAPI-only private ClockClient
+        # domain offset (pynvoc set_clk_domain_offset, the GUI-MHz face of the
+        # CLI's `set-clk-domain-offset xbar <kHz>`). Same row format as
+        # Core/Mem; arch-gated to Turing (GTX 16-series) and newer, and greyed
+        # under the NVML backend selection. Range ±500 MHz with a 5 MHz
+        # wheel/drag step — the article only documented a ±60 MHz XBAR bound
+        # on GB202, but 50-series fabric clocks run far higher, so leave the
+        # wide range and let the driver reject unsafe writes (the medium
+        # layer snapshot/SET/readback/restore guards the write itself).
+        (
+            self.xbar_slider,
+            self.xbar_entry,
+            self.xbar_var,
+            self.btn_apply_xbar,
+        ) = self._make_slider_row(
+            oc_frame,
+            "Xbar:",
+            -500,
+            500,
+            0,
+            step=5,
+            apply_cmd=self._apply_xbar_only,
+            signed=True,
+            unit="MHz",
+        )
+
+        # Buttons — apply/reset each take half the row
+        btn_oc = tk.Frame(oc_frame, bg=_PANEL_BG)
+        btn_oc.pack(fill="x", padx=(26, 10), pady=(5, 10))
+        btn_oc.columnconfigure(0, weight=1, uniform="oc_btns")
+        btn_oc.columnconfigure(1, weight=1, uniform="oc_btns")
+        # Anchor for repacking the arch-gated Xbar row (kept just below Mem).
+        self._oc_buttons_row = btn_oc
+        LiteButton(
+            btn_oc, text="✅ Apply Section", width=10, command=self._apply_oc
+        ).grid(row=0, column=0, sticky="ew", padx=(0, 5))
+        LiteButton(
+            btn_oc,
+            text="🔄 Reset Section",
+            width=10,
+            fg_color="#c0392b",
+            hover_color="#96281b",
+            command=self._reset_oc,
+        ).grid(row=0, column=1, sticky="ew", padx=(5, 0))
+
+        # Xbar is arch-gated (Turing/16-series and newer): hidden until
+        # check_capabilities() sees a matching architecture.
+        self.xbar_slider.master.pack_forget()
+
+        # ═══════════════════════════════════════════
+        # Power & Thermal Limits
+        # ═══════════════════════════════════════════
+        self.limit_frame = ctk.CTkFrame(
+            content_row, border_width=1, border_color="#1f4e79", corner_radius=10
+        )
+        self.limit_frame.grid(row=0, column=1, sticky="new", padx=(5, 0))
+        limit_header = tk.Frame(self.limit_frame, bg=_PANEL_BG)
+        limit_header.pack(fill="x", padx=10, pady=(10, 13))
+        self.limit_title_label = tk.Label(
+            limit_header,
+            text="⚡ Power & Thermal Limits",
+            font=_FONT_HEADER,
+            bg=_PANEL_BG,
+            fg=_TEXT_FG,
+        )
+        self.limit_title_label.pack(side="left")
+        self.power_api_var = ctk.StringVar(value="NVAPI")
+        self.power_api_selector = ctk.CTkOptionMenu(
+            limit_header,
+            values=["NVAPI", "NVML"],
+            variable=self.power_api_var,
+            width=84,
+            anchor="center",
+            font=ct_button_font(limit_header),
+            height=28,
+            command=self._on_power_api_changed,
+        )
+        self.power_api_selector.pack(side="right")
+        power_api_tip = (
+            "Power limit API selector (power slider only).\n"
+            "- NVAPI: --power-limit is percentage (%).\n"
+            "- NVML: --power-limit is watts (W)."
+        )
+        HoverTooltip(self.power_api_selector, power_api_tip)
+        self.limit_status_label = tk.Label(
+            self.limit_frame,
+            text="Power / thermal controls are unsupported on mobile/laptop GPUs.",
+            font=_FONT_BODY,
+            bg=_PANEL_BG,
+            fg=_TEXT_FG_FAINT,
+        )
+
+        # ── Mobile-mode widgets (packed only when a mobile GPU is active) ──
+        self.ppab_var = ctk.BooleanVar(value=False)
+        # CTk-styled checkbox with the box to the RIGHT of the text.
+        self.ppab_checkbox = LiteCheckbutton(
+            limit_header,
+            text="PPAB",
+            variable=self.ppab_var,
+            command=self._on_ppab_toggled,
+            font=_FONT_BODY,
+            bg=_PANEL_BG,
+            fg=_TEXT_FG,
+        )
+        ppab_tip = (
+            "PPAB / Dynamic Boost (NVAPI, mobile only).\n"
+            "CPU↔GPU dynamic power shifting (set-dynamic-boost).\n"
+            "No read-back API exists; enabling the panel turns it on."
+        )
+        HoverTooltip(self.ppab_checkbox, ppab_tip)
+
+        self.dnotifier_row = tk.Frame(self.limit_frame, bg=_PANEL_BG)
+        self.dnotifier_row.grid_columnconfigure(1, weight=1)
+        tk.Label(
+            self.dnotifier_row,
+            text="D-Notifier:",
+            anchor="w",
+            font=_FONT_BODY,
+            bg=_PANEL_BG,
+            fg=_TEXT_FG,
+        ).grid(row=0, column=0, sticky="nw", pady=(5, 0))
+        # Selection only applies via the ✓ button (mirrors the slider rows).
+        self.dnotifier_selector = SegmentToggleSelector(self.dnotifier_row, values=[])
+        self.dnotifier_selector.grid(row=0, column=1, sticky="ew", padx=(2, 8))
+        self.btn_apply_dnotifier = LiteButton(
+            self.dnotifier_row,
+            text="✓",
+            width=34,
+            command=self._apply_dnotifier,
+        )
+        self.btn_apply_dnotifier.grid(row=0, column=2, sticky="ne", pady=(4, 0))
+        dnotifier_tip = (
+            "D-Notifier level (D1-D5, mobile NVAPI).\n"
+            "The actual power cap never exceeds the active D-state's\n"
+            "watt budget shown under each level (set-dnotifier)."
+        )
+        HoverTooltip(self.dnotifier_selector, dnotifier_tip)
+
+        # Power Limit slider + entry
+        self.plimit_label_var = ctk.StringVar(value="Pwr Limit:")
+        self.plimit_unit_var = ctk.StringVar(value="%")
+        (
+            self.plimit_slider,
+            self.plimit_entry,
+            self.plimit_var,
+            self.btn_apply_plimit,
+        ) = self._make_slider_row(
+            self.limit_frame,
+            self.plimit_label_var,
+            d["power_limit_min"],
+            d["power_limit_max"],
+            d["power_limit_default"],
+            apply_cmd=self._apply_plimit_only,
+            unit=self.plimit_unit_var,
+        )
+
+        # Thermal Limit slider + entry
+        (
+            self.tlimit_slider,
+            self.tlimit_entry,
+            self.tlimit_var,
+            self.btn_apply_tlimit,
+        ) = self._make_slider_row(
+            self.limit_frame,
+            "Thrm Limit:",
+            d["thermal_limit_min"],
+            d["thermal_limit_max"],
+            d["thermal_limit_default"],
+            apply_cmd=self._apply_tlimit_only,
+            unit="℃",
+        )
+
+        # Volt Limit slider + entry (mobile-only absolute voltage target on the
+        # private VoltRails path). Min is a hard 300 mV floor; max is overridden
+        # by min(VBIOS, VRM) walls in update_mobile_limits(); the starting
+        # position is the effective voltage wall (post-clamp). Desktop leaves
+        # this row packed-away — VoltBoost is the desktop voltage control.
+        # Step is 2.5 mV (the LCM-friendly grid that divides both the 5 mV
+        # rail step on 30/40-series and the 12.5 mV step on 10/20-series);
+        # decimals=1 renders that half-mV in the entry.
+        self.vlimit_label_var = ctk.StringVar(value="Volt Limit:")
+        (
+            self.vlimit_slider,
+            self.vlimit_entry,
+            self.vlimit_var,
+            self.btn_apply_vlimit,
+        ) = self._make_slider_row(
+            self.limit_frame,
+            self.vlimit_label_var,
+            300,
+            1200,
+            1085,
+            step=2.5,
+            apply_cmd=self._apply_vlimit_only,
+            unit="mV",
+            decimals=1,
+            entry_width=8,
+        )
+
+        # Voltage Boost / Offset slider + entry
+        self.vboost_label_var = ctk.StringVar(value="VoltBoost:")
+        self.vboost_unit_var = ctk.StringVar(value="%")
+        (
+            self.vboost_slider,
+            self.vboost_entry,
+            self.vboost_var,
+            self.btn_apply_vboost,
+        ) = self._make_slider_row(
+            self.limit_frame,
+            self.vboost_label_var,
+            d["voltage_boost_min"],
+            d["voltage_boost_max"],
+            0,
+            step=100,
+            apply_cmd=self._apply_vboost_only,
+            unit=self.vboost_unit_var,
+        )
+
+        # Volt Limit row is mobile-only; hide it on the default desktop layout.
+        self.vlimit_slider.master.pack_forget()
+
+        btn_limits = tk.Frame(self.limit_frame, bg=_PANEL_BG)
+        btn_limits.pack(fill="x", padx=(26, 10), pady=(5, 10))
+        btn_limits.columnconfigure(0, weight=1, uniform="oc_btns")
+        btn_limits.columnconfigure(1, weight=1, uniform="oc_btns")
+        self.btn_apply_limits = LiteButton(
+            btn_limits, text="✅ Apply Section", width=10, command=self._apply_limits
+        )
+        self.btn_apply_limits.grid(row=0, column=0, sticky="ew", padx=(0, 5))
+        self.btn_reset_all = LiteButton(
+            btn_limits,
+            text="🔄 Reset Section",
+            width=10,
+            fg_color="#c0392b",
+            hover_color="#96281b",
+            command=self._reset_all,
+        )
+        self.btn_reset_all.grid(row=0, column=1, sticky="ew", padx=(5, 0))
+
+        fan_host = fan_parent if fan_parent is not None else scroll
+        self.fan_section = FanControlPane(fan_host, self.app.backend, embedded=True)
+        self._limit_enabled_frame_color = self.limit_frame.cget("fg_color")
+        self._limit_dim_frame_color = ("gray86", "gray20")
+        self._limit_enabled_title_color = _TEXT_FG  # tk.Label: plain fg color
+        self._limit_dim_title_color = "gray55"
+
+    # ────────────────────────────────────────────
+    # Dynamic limit update from GPU info
+    # ────────────────────────────────────────────
+    def _safe_get_state(self, widget) -> str:
+        try:
+            return widget.cget("state")
+        except Exception:
+            return "normal"
+
+    def _safe_set_state(self, widget, state: str):
+        try:
+            widget.configure(state=state)
+        except Exception:
+            pass
+
+    def _set_limit_panel_supported(self, supported: bool):
+        """Back-compat shim: map a boolean onto the panel mode machine."""
+        self._set_limit_panel_mode("desktop" if supported else "off")
+
+    def _set_limit_panel_mode(self, mode: str):
+        """Switch the power/thermal section between desktop/mobile/off modes.
+
+        desktop: original NVAPI%/NVML-W layout.
+        mobile: NVAPI-only mobile layout (PPAB checkbox, D-Notifier selector,
+                TGP watts slider, target-temp slider).
+        off: dimmed/unsupported.
+        """
+        if mode == self._limit_panel_mode:
+            return
+        self._limit_panel_mode = mode
+        supported = mode != "off"
+
+        if mode == "mobile":
+            self._enter_mobile_mode()
+        else:
+            self._exit_mobile_mode()
+
+        state = "normal" if supported else "disabled"
+        widgets = [
+            self.plimit_slider,
+            self.plimit_entry,
+            self.btn_apply_plimit,
+            self.tlimit_slider,
+            self.tlimit_entry,
+            self.btn_apply_tlimit,
+            self.btn_apply_limits,
+            self.btn_reset_all,
+        ]
+        if mode == "mobile":
+            widgets.append(self.dnotifier_selector)
+            widgets.append(self.btn_apply_dnotifier)
+            widgets.append(self.vlimit_slider)
+            widgets.append(self.vlimit_entry)
+            widgets.append(self.btn_apply_vlimit)
+        else:
+            widgets.extend([
+                self.power_api_selector,
+                self.vboost_slider,
+                self.vboost_entry,
+                self.btn_apply_vboost,
+            ])
+        for widget in widgets:
+            self._safe_set_state(widget, state)
+
+        # Card background stays unchanged in the dim state: repainting it gray
+        # would mismatch the fixed-bg canvases/labels inside.
+        self.limit_title_label.configure(
+            fg=self._limit_enabled_title_color
+            if supported
+            else self._limit_dim_title_color
+        )
+
+        if supported:
+            self.limit_status_label.pack_forget()
+        elif not self.limit_status_label.winfo_manager():
+            self.limit_status_label.pack(anchor="w", padx=10, pady=(0, 6))
+
+        # Re-apply the OC-backend gate: the loop above just re-enabled the
+        # mobile widgets, which would clear an active NVML greying.
+        self._refresh_nvapi_only_rows()
+
+    # ────────────────────────────────────────────
+    # Mobile (laptop GPU) power & thermal mode
+    # ────────────────────────────────────────────
+    def _enter_mobile_mode(self):
+        """Swap the limit panel into its mobile layout. Idempotent."""
+        if self._mobile_mode:
+            return
+        self._mobile_mode = True
+        self.power_api_selector.pack_forget()
+        self.ppab_checkbox.pack(side="right", padx=(0, 8))
+        self.plimit_unit_var.set("W")
+        # D-Notifier selector sits above the power slider row.
+        plimit_row = self.plimit_slider.master
+        tlimit_row = self.tlimit_slider.master
+        self.dnotifier_row.pack(fill="x", padx=(26, 10), pady=(0, 3), before=plimit_row)
+        # Voltage Boost row is hidden on mobile (unvalidated NVAPI % path).
+        self.vboost_slider.master.pack_forget()
+        # Tighten the three mobile slider rows (Pwr/Thrm/Volt): repack with a
+        # smaller pady than the desktop default (3) so they read as a group.
+        # Repack in front-to-back order using before= against an already-packed
+        # later sibling so relative order is preserved (dnotifier, plimit,
+        # tlimit, vlimit, buttons).
+        btn_limits_row = self.btn_apply_limits.master
+        self.vlimit_slider.master.pack(
+            fill="x", padx=(26, 10), pady=1, before=btn_limits_row
+        )
+        tlimit_row.pack(
+            fill="x", padx=(26, 10), pady=1, before=self.vlimit_slider.master
+        )
+        plimit_row.pack(fill="x", padx=(26, 10), pady=1, before=tlimit_row)
+        self._load_mobile_limits()
+
+    def _exit_mobile_mode(self):
+        """Restore the desktop limit panel layout. Idempotent."""
+        if not self._mobile_mode:
+            return
+        self._mobile_mode = False
+        self.ppab_checkbox.pack_forget()
+        self.dnotifier_row.pack_forget()
+        self.vlimit_slider.master.pack_forget()
+        # Restore the desktop layout + pady=3. Repack the vboost row before the
+        # buttons row (original order), then anchor plimit/tlimit before it so
+        # the final order is plimit, tlimit, vboost, buttons — matching the
+        # construction order — with pady restored to 3.
+        btn_limits_row = self.btn_apply_limits.master
+        self.vboost_slider.master.pack(fill="x", padx=10, pady=3, before=btn_limits_row)
+        tlimit_row = self.tlimit_slider.master
+        plimit_row = self.plimit_slider.master
+        tlimit_row.pack(
+            fill="x", padx=(26, 10), pady=3, before=self.vboost_slider.master
+        )
+        plimit_row.pack(fill="x", padx=(26, 10), pady=3, before=tlimit_row)
+        self.power_api_selector.pack(side="right")
+        self.plimit_unit_var.set("%")
+
+    def _load_mobile_limits(self):
+        """Background-load the mobile control surface (TGP range, D-Notifier,
+        target-temp policies) via pynvoc and apply it on the UI thread."""
+        gpu = self.app.selected_gpu_target()
+        if gpu is None or self._mobile_load_in_flight:
+            return
+        self._mobile_load_in_flight = True
+        backend = self.app.backend
+
+        def worker():
+            try:
+                data = backend.query_mobile_limits(gpu)
+            except Exception as exc:
+                data = {"error": str(exc)}
+            try:
+                self.frame.after(0, lambda: self._mobile_limits_loaded(gpu, data))
+            except Exception:
+                self._mobile_load_in_flight = False
+
+        try:
+            self.app.run_background("mobile-limits", worker)
+        except Exception:
+            self._mobile_load_in_flight = False
+            raise
+
+    def _mobile_limits_loaded(self, gpu: str, data: dict):
+        self._mobile_load_in_flight = False
+        if not self._mobile_mode:
+            return
+        self._mobile_limits_gpu = gpu
+        self.update_mobile_limits(data)
+
+        # PPAB has no read-back API; enable it once per GPU on panel load.
+        # Only attempt when the private NVAPI surface actually resolved —
+        # on Linux (libnvidia-api stub) / older drivers the setters are
+        # NO_IMPLEMENTATION and auto-enabling would just log an error.
+        tgp_ok = isinstance(data.get("tgp"), dict) and data.get("tgp")
+        dnotifier_ok = isinstance(data.get("dnotifier"), dict) and data.get("dnotifier")
+        if (tgp_ok or dnotifier_ok) and self._mobile_ppab_initialized_for != gpu:
+            self._mobile_ppab_initialized_for = gpu
+            self._syncing = True
+            self.ppab_var.set(True)
+            self._syncing = False
+            self.app.run_native_action(
+                "enable dynamic boost",
+                lambda native, gpu=gpu: (
+                    native.set_dynamic_boost(gpu, True)
+                    or "Dynamic Boost (PPAB) enabled."
+                ),
+            )
+
+    def update_mobile_limits(self, data: dict):
+        """Apply the mobile control surface (see NativeBackend.query_mobile_limits).
+
+        Mobile controls are assumed SUPPORTED: a missing sub-query is treated
+        as a transient read failure (dGPU powering up after GC6 wake), not a
+        capability verdict — controls stay enabled with the last/default
+        ranges, and a genuinely failing SET reports through the console.
+        """
+        if not self._mobile_mode:
+            return
+        tgp = data.get("tgp") if isinstance(data.get("tgp"), dict) else None
+        dnotifier = (
+            data.get("dnotifier") if isinstance(data.get("dnotifier"), dict) else None
+        )
+        policies = data.get("temp_policies") or []
+
+        if tgp and tgp.get("max_watt") is not None and tgp.get("min_watt") is not None:
+            self._tgp_policy_index = int(tgp.get("policy_index", 2))
+            min_w = int(round(float(tgp["min_watt"])))
+            max_w = int(round(float(tgp["max_watt"])))
+            self._power_default = int(
+                round(float(tgp.get("default_watt") or tgp.get("min_watt")))
+            )
+            # Position the slider at the enforced power limit (NVML, from
+            # the mobile-limits query) — the actually-active wall. The TGP
+            # policy exposes no current-value read; default_watt is only
+            # the fallback.
+            current_w = data.get("power_limit_w")
+            position = self._power_default
+            if current_w is not None:
+                current_w = int(round(float(current_w)))
+                if min_w <= current_w <= max_w:
+                    position = current_w
+            self._reconfigure_slider(
+                self.plimit_slider,
+                self.plimit_var,
+                min_w,
+                max_w,
+                position,
+                step=1,
+            )
+
+        if dnotifier and dnotifier.get("levels"):
+            levels = dnotifier["levels"]
+            values = [str(item.get("level", "")).upper() for item in levels]
+            subtitles = [
+                f"{float(item['watts']):.0f}W"
+                if item.get("watts") is not None
+                else None
+                for item in levels
+            ]
+            self.dnotifier_selector.set_values(values, subtitles)
+            self.dnotifier_selector.set_selection(dnotifier.get("active"))
+            self._safe_set_state(self.dnotifier_selector, "normal")
+
+        target = None
+        for policy in policies:
+            # Only the TargetTemp slot exposes a writable range (min < max);
+            # other slots report min == max and must be skipped.
+            if (
+                isinstance(policy, dict)
+                and policy.get("min") is not None
+                and policy.get("max") is not None
+                and float(policy["max"]) > float(policy["min"])
+            ):
+                target = policy
+                break
+        if target is not None:
+            current = int(
+                round(float(target.get("celsius", target.get("default", 83))))
+            )
+            self._thermal_default = current
+            self._reconfigure_slider(
+                self.tlimit_slider,
+                self.tlimit_var,
+                int(round(float(target["min"]))),
+                int(round(float(target["max"]))),
+                current,
+                step=1,
+            )
+
+        # Volt Limit (private VoltRails P0 bounds). Slider floor is a hard
+        # 300 mV; the ceiling is min(VBIOS wall, VRM max wall). A wall reading
+        # of 0 means 'not reported' and is skipped; both 0 falls back to
+        # 1200 mV (the ~1.2 V domain ceiling observed on Ada mobile). The
+        # starting position is the effective voltage wall (post-clamp), the
+        # analog of TGP positioning at the enforced power limit — NOT the
+        # live core voltage, which bounces with load. The 2.5 mV step grid is
+        # applied in _volt_limit_bounds_from_p0 (LCM of 5 and 12.5 mV rail
+        # steps) so the entry's one-decimal render and the thumb agree.
+        vr = data.get("volt_rail") if isinstance(data.get("volt_rail"), dict) else None
+        if vr:
+            self._volt_rail_bit = self._resolve_volt_rail_bit(vr)
+            p0 = vr.get("p0") if isinstance(vr.get("p0"), dict) else None
+            if p0:
+                min_mv, max_mv, pos_mv = self._volt_limit_bounds_from_p0(p0)
+                self._reconfigure_slider(
+                    self.vlimit_slider,
+                    self.vlimit_var,
+                    min_mv,
+                    max_mv,
+                    pos_mv,
+                    step=2.5,
+                )
+
+    @staticmethod
+    def _volt_limit_bounds_from_p0(p0: dict) -> tuple[float, float, float]:
+        """Compute (min_mV, max_mV, current_mV) for the Volt Limit slider.
+
+        - min is a hard 300 mV floor
+        - max is min(VBIOS wall, VRM max wall); a wall of 0 ('not reported')
+          is skipped; both 0 falls back to 1200 mV (the ~1.2 V domain ceiling
+          observed on Ada mobile)
+        - current is the effective voltage wall (post-clamp), the analog of
+          TGP positioning at the enforced power limit — NOT the live core
+          voltage, which bounces with load. Clamped into [min, max].
+        Both max and current are snapped to the 2.5 mV grid (LCM of the 5 mV
+        rail step on 30/40-series and the 12.5 mV step on 10/20-series) so
+        the one-decimal entry text and the canvas thumb agree; max snaps
+        DOWN so no offered position exceeds the actual wall.
+        """
+        STEP = 2.5
+        vbios = int(p0.get("vbios_wall_uV", 0) or 0)
+        vrm = int(p0.get("vrm_max_wall_uV", 0) or 0)
+        walls = [w for w in (vbios, vrm) if w > 0]
+        ceiling_uV = min(walls) if walls else 1_200_000
+        max_mv = max(300.0, ceiling_uV / 1000.0)
+        # int() truncates toward zero == floor for the positive span here.
+        max_mv = int(max_mv / STEP) * STEP
+        eff = int(p0.get("effective_wall_uV", 0) or 0)
+        pos_mv = eff / 1000.0 if eff > 0 else max_mv
+        pos_mv = max(300.0, min(max_mv, pos_mv))
+        # Snap the starting position to the grid (round to nearest).
+        pos_mv = round(pos_mv / STEP) * STEP
+        return 300.0, max_mv, max(300.0, pos_mv)
+
+    def _resolve_volt_rail_bit(self, volt_rail: dict) -> int:
+        """Pick the VoltRails rail bit to target.
+
+        Uses the first rail descriptor's ``rail_bit`` when descriptors are
+        exposed; otherwise falls back to the lowest set bit of ``rail_mask``.
+        Single-rail mobile GPUs (e.g. 4060L, mask 0x1) resolve to 0.
+        """
+        descs = volt_rail.get("rail_descriptors")
+        if isinstance(descs, list) and descs:
+            first = descs[0]
+            if isinstance(first, dict) and first.get("rail_bit") is not None:
+                try:
+                    return int(first["rail_bit"])
+                except (TypeError, ValueError):
+                    pass
+        mask = volt_rail.get("rail_mask")
+        if isinstance(mask, str) and mask:
+            try:
+                return (int(mask, 16) & -int(mask, 16)).bit_length() - 1
+            except ValueError:
+                pass
+        return 0
+
+    @staticmethod
+    def _xbar_supported_from_info(info: dict) -> bool:
+        """Xbar support verdict for the GPU described by ``info``.
+
+        Primary signal: the pynvoc ``query_info`` payload's
+        ``xbar_supported`` flag, computed in Rust by core's ``gpu_type.rs``
+        ``detect_gpu_type`` (name + codename) — the project's single source
+        of truth for generation detection. That path is what makes Ada work:
+        ``gpu_architecture`` reads 'Unknown:400:7:161' there (the ArchInfo
+        enum has no AD variant), so string-matching the arch alone cannot
+        see a 40-series.
+
+        Fallback: the local ``_xbar_supported_arch`` heuristic for payloads
+        without the flag (CLI-parsed info, NVML-only info, older pynvoc).
+        """
+        flag = info.get("xbar_supported")
+        if isinstance(flag, bool):
+            return flag
+        return OverclockTab._xbar_supported_arch(
+            str(info.get("gpu_architecture", "") or ""),
+            str(info.get("codename", "") or ""),
+            str(info.get("gpu_name", "") or ""),
+        )
+
+    @staticmethod
+    def _xbar_supported_arch(
+        arch_id: str, codename: str = "", gpu_name: str = ""
+    ) -> bool:
+        """True for Turing (the GTX 16-series) and every newer architecture.
+
+        Three signals, in priority order:
+        1. Chip codes from the codename or the arch string (tu106, ga102,
+           ad107, gb202 — optionally suffixed ":rev", "-B", " (process)").
+           The codename matters: on Ada the pynvoc ArchInfo enum has no AD
+           variant and reports ``gpu_architecture = 'Unknown:400:7:161'``,
+           while ``codename = 'AD107-B'`` carries the real chip code.
+        2. Friendly architecture names (Turing, Ampere, Ada, Blackwell) from
+           the CLI human output.
+        3. Marketing-name fallback: ``RTX 4060`` / ``GTX 1660`` — the model
+           number >= 1600 means 16-series or newer (GTX 1080/10-series and
+           below stay hidden).
+        Pascal (gp), Volta (gv) and older return False — the XBAR
+        ClockClient domain postdates them.
+        """
+        # 1) chip codes (codename first — it is the reliable one on Ada).
+        for raw in (codename, arch_id):
+            head = (
+                raw.lower().split("(", 1)[0].split(":", 1)[0].split("-", 1)[0].strip()
+            )
+            if head.startswith(("tu", "ga", "ad", "gb")):
+                return True
+        # 2) friendly names.
+        if any(
+            name in arch_id.lower() for name in ("turing", "ampere", "ada", "blackwell")
+        ):
+            return True
+        # 3) marketing name: RTX/GTX + model number, 1600 = 16-series floor.
+        match = __import__("re").search(r"\b(?:rtx|gtx)\s*(\d{3,4})", gpu_name.lower())
+        if match:
+            return int(match.group(1)) >= 1600
+        return False
+
+    @staticmethod
+    def _format_volt_rail_target_result(target_mv: float, result: Any) -> str:
+        """Build the console message from a ``set_volt_rail_target`` result.
+
+        Unlike the other NVAPI setters (``set_tgp_watt`` etc. return ``None``
+        so ``setter() or "msg"`` works), ``set_volt_rail_target`` always
+        returns a dict — either the applied payload (with the post-clamp
+        ``effective_wall_uV``) or ``{"supported": False}``. A truthy dict
+        would short-circuit ``or`` and yield the dict itself (which then fails
+        ``.endswith`` in the native worker), so format the message here.
+        ``target_mv`` may carry one decimal (2.5 mV grid); :g drops the
+        trailing .0 for whole-mV values.
+        """
+        if isinstance(result, dict):
+            if result.get("applied"):
+                eff = result.get("effective_wall_uV")
+                if isinstance(eff, (int, float)) and eff:
+                    return (
+                        f"Successfully applied Volt Limit {target_mv:g} mV "
+                        f"(effective wall {eff / 1000.0:g} mV)."
+                    )
+                return f"Successfully applied Volt Limit {target_mv:g} mV."
+            if result.get("supported") is False:
+                return "Volt-rail target not supported by this driver."
+        return f"Applied Volt Limit {target_mv:g} mV."
+
+    @staticmethod
+    def _format_xbar_offset_result(offset_mhz: int, result: Any) -> str:
+        """Build the console message from a ``set_clk_domain_offset`` result.
+
+        Like ``set_volt_rail_target``, the pynvoc call returns a dict (the
+        applied payload with the driver's readback ``applied_kHz``, or
+        ``{"supported": False}``) — never ``None`` — so the message must be
+        formatted here rather than via ``setter() or "msg"``.
+        """
+        if isinstance(result, dict):
+            if result.get("applied"):
+                applied = result.get("applied_kHz")
+                if isinstance(applied, (int, float)):
+                    return (
+                        f"Successfully applied Xbar offset {offset_mhz:+d} MHz "
+                        f"(driver readback {applied / 1000.0:+g} MHz)."
+                    )
+                return f"Successfully applied Xbar offset {offset_mhz:+d} MHz."
+            if result.get("supported") is False:
+                return "Xbar clock-domain offset not supported by this driver."
+        return f"Applied Xbar offset {offset_mhz:+d} MHz."
+
+    def _on_ppab_toggled(self):
+        if self._syncing or not self._mobile_mode:
+            return
+        gpu = self.app.selected_gpu_target()
+        if gpu is None:
+            return
+        active = bool(self.ppab_var.get())
+        self.app.run_native_action(
+            "toggle dynamic boost",
+            lambda native, gpu=gpu, active=active: (
+                native.set_dynamic_boost(gpu, active)
+                or f"Dynamic Boost (PPAB) {'enabled' if active else 'disabled'}."
+            ),
+        )
+
+    def _on_dnotifier_selected(self, level: str):
+        """Kept for API compatibility — selection no longer auto-applies."""
+        return
+
+    def _apply_dnotifier(self):
+        """Apply the currently selected D-Notifier level (✓ button)."""
+        if self._syncing or not self._mobile_mode:
+            return
+        level = self.dnotifier_selector.get_selection()
+        if not level:
+            return
+        gpu = self.app.selected_gpu_target()
+        if gpu is None:
+            return
+        try:
+            d_level = int(str(level).strip().upper().lstrip("D"))
+        except ValueError:
+            return
+        if not 1 <= d_level <= 5:
+            return
+
+        def on_finished(_code):
+            # D-Notifier SET clamps the TGP wall — refresh levels + slider.
+            self._load_mobile_limits()
+
+        self.app.run_native_action(
+            "set D-Notifier level",
+            lambda native, gpu=gpu, d_level=d_level: (
+                native.set_dnotifier(gpu, d_level) or f"Successfully set D-Notifier to D{d_level}."
+            ),
+            on_finished=on_finished,
+        )
+
+    def on_resize_state_changed(self, resizing: bool, force_flush: bool = False):
+        """Coalesce expensive slider/state updates during active resize."""
+        self._is_resize_active = resizing
+        if (not resizing) and force_flush:
+            if self._pending_capabilities is not None:
+                pending = self._pending_capabilities
+                self._pending_capabilities = None
+                self.check_capabilities(pending)
+            if self._pending_limits is not None:
+                pending = self._pending_limits
+                self._pending_limits = None
+                self.update_limits(pending)
+            if self._pending_vfp_state is not None:
+                pending = self._pending_vfp_state
+                self._pending_vfp_state = None
+                self.set_vfp_state(*pending)
+
+        cb = getattr(self.fan_section, "on_resize_state_changed", None)
+        if callable(cb):
+            cb(resizing=resizing, force_flush=force_flush)
+
+    def update_limits(self, limits: Dict[str, Any]):
+        """
+        Update slider ranges with real hardware limits from GPU info.
+
+        Expected keys (all optional):
+            core_clock_min, core_clock_max,  [core_clock_current]
+            mem_clock_min,  mem_clock_max,   [mem_clock_current]
+            power_limit_min, power_limit_max, power_limit_default, [power_limit_current]
+            power_limit_nvml_min_w, power_limit_nvml_max_w, [power_limit_nvml_current_w]
+            thermal_limit_min, thermal_limit_max, thermal_limit_default, [thermal_limit_current]
+            [voltage_boost_current]
+        """
+        if self._is_resize_active:
+            if self._pending_limits is None:
+                self._pending_limits = dict(limits)
+            else:
+                self._pending_limits.update(limits)
+            return
+
+        # Store current states of control widgets that may be disabled by check_capabilities
+        plimit_entry_state = self._safe_get_state(self.plimit_entry)
+        plimit_btn_state = self._safe_get_state(self.btn_apply_plimit)
+        tlimit_entry_state = self._safe_get_state(self.tlimit_entry)
+        tlimit_btn_state = self._safe_get_state(self.btn_apply_tlimit)
+        vboost_entry_state = self._safe_get_state(self.vboost_entry)
+        vboost_btn_state = self._safe_get_state(self.btn_apply_vboost)
+
+        if "core_clock_min" in limits and "core_clock_max" in limits:
+            current = limits.get("core_clock_current", 0)
+            self._reconfigure_slider(
+                self.core_slider,
+                self.core_var,
+                limits["core_clock_min"],
+                limits["core_clock_max"],
+                current,
+                step=2.5,
+            )
+        elif "core_clock_current" in limits:
+            self._set_slider_value(
+                self.core_slider, self.core_var, limits["core_clock_current"]
+            )
+
+        if "mem_clock_min" in limits and "mem_clock_max" in limits:
+            current = limits.get("mem_clock_current", 0)
+            self._reconfigure_slider(
+                self.mem_slider,
+                self.mem_var,
+                limits["mem_clock_min"],
+                limits["mem_clock_max"],
+                current,
+                step=5,
+            )
+        elif "mem_clock_current" in limits:
+            self._set_slider_value(
+                self.mem_slider, self.mem_var, limits["mem_clock_current"]
+            )
+
+        if self._mobile_mode:
+            # Mobile ranges come from update_mobile_limits() (pynvoc NVAPI
+            # private interfaces); the generic %/W desktop keys don't apply.
+            if "supported_pstates" in limits:
+                self.set_supported_pstates(limits.get("supported_pstates"))
+            return
+
+        power_backend = self._selected_power_backend()
+        if power_backend == "nvml":
+            self.plimit_unit_var.set("W")
+            if (
+                "power_limit_nvml_min_w" in limits
+                and "power_limit_nvml_max_w" in limits
+            ):
+                min_w = int(limits["power_limit_nvml_min_w"])
+                max_w = int(limits["power_limit_nvml_max_w"])
+                current_w = limits.get("power_limit_nvml_current_w", min_w)
+                default = int(current_w) if current_w is not None else min_w
+                self._power_default = default
+                self._reconfigure_slider(
+                    self.plimit_slider,
+                    self.plimit_var,
+                    min_w,
+                    max_w,
+                    default,
+                    step=1,
+                )
+            elif "power_limit_nvml_current_w" in limits:
+                self._set_slider_value(
+                    self.plimit_slider,
+                    self.plimit_var,
+                    int(limits["power_limit_nvml_current_w"]),
+                )
+        else:
+            self.plimit_unit_var.set("%")
+            if "power_limit_min" in limits and "power_limit_max" in limits:
+                default_raw = limits.get("power_limit_default", 100)
+                default = int(default_raw) if default_raw is not None else 100
+                self._power_default = default
+                current_raw = limits.get("power_limit_current", default)
+                current = int(current_raw) if current_raw is not None else default
+                self._reconfigure_slider(
+                    self.plimit_slider,
+                    self.plimit_var,
+                    limits["power_limit_min"],
+                    limits["power_limit_max"],
+                    current,
+                    step=1,
+                )
+            elif "power_limit_current" in limits:
+                self._set_slider_value(
+                    self.plimit_slider, self.plimit_var, limits["power_limit_current"]
+                )
+
+        if "thermal_limit_min" in limits and "thermal_limit_max" in limits:
+            default_raw = limits.get("thermal_limit_default", 83)
+            default = int(default_raw) if default_raw is not None else 83
+            self._thermal_default = default
+            current_raw = limits.get("thermal_limit_current", default)
+            current = int(current_raw) if current_raw is not None else default
+            self._reconfigure_slider(
+                self.tlimit_slider,
+                self.tlimit_var,
+                limits["thermal_limit_min"],
+                limits["thermal_limit_max"],
+                current,
+                step=1,
+            )
+        elif "thermal_limit_current" in limits:
+            self._set_slider_value(
+                self.tlimit_slider, self.tlimit_var, limits["thermal_limit_current"]
+            )
+
+        # Prefer explicit legacy overvolt bounds when present.
+        # This avoids stale `_is_legacy_gpu` timing from preventing slider updates.
+        if (
+            "legacy_overvolt_min_mv" in limits
+            and "legacy_overvolt_max_mv" in limits
+            and "legacy_overvolt_current_mv" in limits
+        ):
+            current = limits.get("legacy_overvolt_current_mv", 0)
+            self.vboost_label_var.set("Overvolt:")
+            self.vboost_unit_var.set("mV")
+            self._reconfigure_slider(
+                self.vboost_slider,
+                self.vboost_var,
+                int(
+                    limits["legacy_overvolt_min_mv"] / 10
+                ),  # open too wide down-volt will result in instant crash!!!!!!
+                int(limits["legacy_overvolt_max_mv"]) - 1,
+                int(current),
+                step=1,
+            )
+            self._set_slider_value(
+                self.vboost_slider,
+                self.vboost_var,
+                int(limits["legacy_overvolt_current_mv"]),
+            )
+
+        else:
+            current = limits.get("voltage_boost_current")
+            min_boost = limits.get("voltage_boost_min")
+            max_boost = limits.get("voltage_boost_max")
+
+            if min_boost is not None and max_boost is not None:
+                current_val = int(current) if current is not None else int(min_boost)
+                self._reconfigure_slider(
+                    self.vboost_slider,
+                    self.vboost_var,
+                    int(min_boost),
+                    int(max_boost),
+                    current_val,
+                    step=1,
+                )
+                # Keep current value in sync after range changes.
+                self._set_slider_value(self.vboost_slider, self.vboost_var, current_val)
+            elif current is not None:
+                # Partial cache update: only current value is known, keep existing range.
+                self._set_slider_value(
+                    self.vboost_slider, self.vboost_var, int(current)
+                )
+
+        # Restore saved states to entry and button widgets
+        self._safe_set_state(self.plimit_entry, plimit_entry_state)
+        self._safe_set_state(self.btn_apply_plimit, plimit_btn_state)
+        self._safe_set_state(self.tlimit_entry, tlimit_entry_state)
+        self._safe_set_state(self.btn_apply_tlimit, tlimit_btn_state)
+        self._safe_set_state(self.vboost_entry, vboost_entry_state)
+        self._safe_set_state(self.btn_apply_vboost, vboost_btn_state)
+
+        if "supported_pstates" in limits:
+            self.set_supported_pstates(limits.get("supported_pstates"))
+
+    def set_vfp_state(
+        self, has_vfp_offset: bool, uniform_core_offset_mhz: Optional[int] = None
+    ):
+        """Track whether VFP offsets exist without changing scalar OC controls."""
+        if self._is_resize_active:
+            self._pending_vfp_state = (has_vfp_offset, uniform_core_offset_mhz)
+            return
+
+        self._is_vfp_mode = has_vfp_offset
+        self._vfp_uniform_offset_mhz = (
+            int(uniform_core_offset_mhz)
+            if (has_vfp_offset and uniform_core_offset_mhz is not None)
+            else None
+        )
+
+    def check_capabilities(self, info: dict):
+        """Enable/disable controls based on GPU capabilities."""
+        if self._is_resize_active:
+            self._pending_capabilities = dict(info)
+            return
+
+        # Mobile/Laptop GPU test. Primary signal: the pynvoc query_info
+        # payload's is_mobile flag (core gpu_type.rs detect_gpu_type — the
+        # single source of truth; it reads name + codename, so it also works
+        # on Ada where gpu_architecture is 'Unknown:...'). Fallback: the
+        # name-keyword heuristic for payloads without the flag (CLI-parsed
+        # info, NVML-only info, older pynvoc).
+        gpu_name = str(info.get("gpu_name", "")).lower()
+        arch_id = str(info.get("gpu_architecture", "")).lower().strip()
+        arch_head = arch_id.split("(", 1)[0].strip().split(":", 1)[0].strip()
+        mobile_flag = info.get("is_mobile")
+        if isinstance(mobile_flag, bool):
+            is_mobile = mobile_flag
+        else:
+            # Check for mobile/laptop indicators: explicit keywords, RTX XXM
+            # (mobile suffix), RTX for laptops with M suffix
+            is_mobile = (
+                "mobile" in gpu_name
+                or "laptop" in gpu_name
+                or " m " in gpu_name
+                or gpu_name.endswith(" m")
+                or " mx " in gpu_name
+                or gpu_name.endswith(" mx")
+            )
+
+        self._set_limit_panel_mode("mobile" if is_mobile else "desktop")
+        if is_mobile and self._mobile_mode:
+            # Re-load when switching between two mobile GPUs.
+            gpu = self.app.selected_gpu_target()
+            if gpu is not None and gpu != self._mobile_limits_gpu:
+                self._load_mobile_limits()
+        self.fan_section.set_supported(not is_mobile)
+
+        # Xbar (private ClockClient domain offset) exists from Turing — the
+        # GTX 16-series — onward. Older archs hide the row entirely; when it
+        # is shown, the OC backend dropdown gate also applies (NVML has no
+        # Xbar path).
+        xbar_ok = self._xbar_supported_from_info(info)
+        if xbar_ok != self._xbar_supported:
+            self._xbar_supported = xbar_ok
+            if xbar_ok:
+                self.xbar_slider.master.pack(
+                    fill="x", padx=(26, 10), pady=3, before=self._oc_buttons_row
+                )
+            else:
+                self.xbar_slider.master.pack_forget()
+            self._refresh_nvapi_only_rows()
+        # Maxwell / 900 series and older detection. Primary signal: the
+        # payload's is_legacy_voltage flag (core gpu_type.rs — 9系 GM 及更旧,
+        # 含 Kepler/Fermi 落 Unknown 的保守归类). Fallback heuristic below for
+        # payloads without the flag. NOTE the deliberate semantic difference:
+        # is_legacy_voltage(Unknown) = true (core's write-path conservatism),
+        # so a day-one unrecognized future GPU shows the legacy Overvolt UI
+        # here until detect_gpu_type learns its chip prefix.
+        legacy_flag = info.get("is_legacy_voltage")
+        if isinstance(legacy_flag, bool):
+            is_legacy = legacy_flag
+        else:
+            # Simple heuristic: architectural series usually exposed in info
+            # or if missing VFP, fallback arch check from name
+            is_legacy = False
+            if "gtx" in gpu_name:
+                match = __import__("re").search(r"gtx\s*(\d+)", gpu_name)
+                if match and int(match.group(1)) < 1000:
+                    is_legacy = True
+            if not is_legacy and arch_id:
+                if any(x in arch_id for x in ["maxwell", "kepler", "fermi"]):
+                    is_legacy = True
+                elif arch_head.startswith(("gm", "gk", "gf")):
+                    is_legacy = True
+
+        if is_legacy:
+            self._is_legacy_gpu = True
+            if hasattr(self.app, "notebook"):
+                # Ideally disable or hide VF Curve entirely if possible via app
+                pass
+            vfcurve_tab = getattr(self.app, "tab_vfcurve", None)
+            if vfcurve_tab is not None and hasattr(vfcurve_tab, "frame"):
+                for child in vfcurve_tab.frame.winfo_children():
+                    try:
+                        child.configure(state="disabled")
+                    except Exception:
+                        pass
+
+            # Legacy GPUs use Overvolt controls in mV terminology.
+            self.vboost_label_var.set("Overvolt:")
+            self.vboost_unit_var.set("mV")
+        else:
+            self._is_legacy_gpu = False
+            self.vboost_label_var.set("VoltBoost:")
+            self.vboost_unit_var.set("%")
+
+    @staticmethod
+    def _normalize_pstate_label(value: Any) -> Optional[str]:
+        if isinstance(value, str):
+            val = value.lower().strip()
+            # If the CLI outputs 'p8(locked)', normalise it to just 'p8'
+            if "(" in val:
+                val = val.split("(")[0].strip()
+            return val
+        return str(value)
+
+    def set_supported_pstates(self, pstates: Any):
+        """Update the available P-State lock points from CLI 'get' output."""
+        normalized = []  # type: List[str]
+        seen = set()  # type: Set[str]
+        for state in pstates or []:
+            label = self._normalize_pstate_label(state)
+            if not label or label in seen:
+                continue
+            seen.add(label)
+            normalized.append(label)
+
+        self._supported_pstates = normalized
+        self.pstate_selector.set_values(normalized)
+
+        state = "normal" if normalized else "disabled"
+        self._safe_set_state(self.pstate_selector, state)
+        self._safe_set_state(self.btn_apply_pstate, state)
+        self._safe_set_state(self.btn_unlock_pstate, state)
+
+    @staticmethod
+    def _oc_pstate() -> str:
+        """Core/memory offset commands always target P0."""
+        return "P0"
+
+    def _selected_oc_backend(self) -> str:
+        """Return the selected backend for core/memory offset commands."""
+        selected = self.oc_api_var.get().strip().upper()
+        return "nvml" if selected == "NVML" else "nvapi"
+
+    def _on_oc_api_changed(self, _selected: str):
+        """OC backend dropdown moved: re-apply the NVAPI-only row gate."""
+        self._refresh_nvapi_only_rows()
+
+    def _refresh_nvapi_only_rows(self):
+        """Sync the enabled state of the NVAPI-only rows (Xbar, Volt Limit).
+
+        NVML exposes neither the private ClockClient domain offsets (Xbar)
+        nor the VoltRails family (Volt Limit), so both rows grey out while
+        the Clock Offsets backend dropdown sits on NVML. Volt Limit is only
+        touched in mobile mode — the desktop panel hides the row and the
+        'off' mode has already disabled the whole panel (this re-applies the
+        gate after _set_limit_panel_mode re-enables the mobile widgets).
+        """
+        state = "disabled" if self._selected_oc_backend() == "nvml" else "normal"
+        if self._xbar_supported:
+            for widget in (self.xbar_slider, self.xbar_entry, self.btn_apply_xbar):
+                self._safe_set_state(widget, state)
+        if self._limit_panel_mode == "mobile":
+            for widget in (
+                self.vlimit_slider,
+                self.vlimit_entry,
+                self.btn_apply_vlimit,
+            ):
+                self._safe_set_state(widget, state)
+
+    def _selected_power_backend(self) -> str:
+        """Return the selected backend for power-limit commands only."""
+        if self._mobile_mode:
+            return "nvapi"
+        selected = self.power_api_var.get().strip().upper()
+        return "nvml" if selected == "NVML" else "nvapi"
+
+    def _on_power_api_changed(self, _selected: str):
+        """Re-sync power slider unit/range and refresh current values via get."""
+        if self._mobile_mode:
+            return
+        cached = dict(getattr(self.app, "_gpu_limits_cache", {}) or {})
+        if cached:
+            self.update_limits(cached)
+        # get now refreshes both NVML(W) and NVAPI(%) power current values.
+        self.app._query_gpu_get()
+
+    def _reconfigure_slider(
+        self,
+        slider: Any,
+        var: ctk.StringVar,
+        min_val: float,
+        max_val: float,
+        default: float,
+        step: float = 1,
+    ):
+        """Reconfigure a slider's range, steps, and reset to default value."""
+        # int() (truncation) == floor for the non-negative span/step here; use
+        # it instead of // so a fractional step like 2.5 mV works.
+        n_steps = int((max_val - min_val) / step) if step else int(max_val - min_val)
+
+        # Preserve the current state (disabled/normal) before reconfiguring
+        current_state = self._safe_get_state(slider)
+
+        # Set _syncing BEFORE configure() — CTkSlider fires its command callback
+        # internally during configure when number_of_steps changes, which would
+        # otherwise overwrite var with the wrong (clamped-to-min) value.
+        self._syncing = True
+        try:
+            slider.configure(
+                from_=min_val,
+                to=max_val,
+                number_of_steps=n_steps,
+                state=current_state,
+                require_redraw=False,
+            )
+        except Exception:
+            # Fallback for older custom tkinter versions that don't support state in configure
+            slider.configure(from_=min_val, to=max_val, number_of_steps=n_steps)
+            self._safe_set_state(slider, current_state)
+
+        # Update stored range/step metadata on the slider widget
+        slider._oc_min = min_val
+        slider._oc_max = max_val
+        slider._oc_step = step
+
+        slider.set(default)
+        var.set(self._fmt_slider_value(slider, default))
+        self._syncing = False
+
+    @staticmethod
+    def _fmt_slider_value(slider: Any, value: float) -> str:
+        """Format an entry value, signed for offset rows (see _make_slider_row).
+
+        ``:+`` renders an explicit sign on positives AND on zero (``+0.0``) —
+        offset rows read 0 as "no offset applied", so the + keeps the column
+        visually consistent.
+        """
+        decimals = getattr(slider, "_oc_decimals", 0)
+        signed = getattr(slider, "_oc_signed", False)
+        if decimals:
+            return f"{float(value):{'+.' if signed else '.'}{decimals}f}"
+        if signed:
+            return f"{int(value):+d}"
+        return str(int(value))
+
+    def _set_slider_value(self, slider: Any, var: ctk.StringVar, value: float):
+        """Update a slider's current value without changing its range."""
+        min_val = getattr(slider, "_oc_min", float(slider.cget("from_")))
+        max_val = getattr(slider, "_oc_max", float(slider.cget("to")))
+        clamped = max(min_val, min(max_val, value))
+        self._syncing = True
+        slider.set(clamped)
+        var.set(self._fmt_slider_value(slider, clamped))
+        self._syncing = False
+
+    # ────────────────────────────────────────────
+    # Helper: create a  Label | Slider | Entry  row
+    # ────────────────────────────────────────────
+    def _make_slider_row(
+        self,
+        parent: ctk.CTkFrame,
+        label: Union[str, ctk.StringVar],
+        min_val: float,
+        max_val: float,
+        default: float,
+        step: float = 1,
+        apply_cmd=None,
+        signed: bool = False,
+        unit: Union[str, ctk.StringVar] = "",
+        decimals: int = 0,
+        entry_width: int = 7,
+    ) -> Tuple[Any, ctk.CTkEntry, ctk.StringVar, ctk.CTkButton]:
+        """Create a row with label, slider, numeric entry and apply button.
+
+        signed=True renders the entry value with an explicit +/- sign
+        (offset rows — avoids reading e.g. 150 as an absolute frequency).
+
+        decimals>0 switches the entry to a fixed-point render (e.g.
+        ``decimals=1`` → ``1082.5``) and parses typed input as float — used by
+        the Volt Limit row whose 2.5 mV step needs one decimal on 10/20-series.
+        """
+
+        def _fmt(v: float) -> str:
+            # `:+` also signs zero (+0 / +0.0) — offset rows show 0 as an
+            # explicitly-applied zero offset (see _fmt_slider_value).
+            if decimals:
+                return f"{float(v):{'+.' if signed else '.'}{decimals}f}"
+            return f"{int(v):+d}" if signed else str(int(v))
+
+        row_frame = tk.Frame(parent, bg=_PANEL_BG)
+        row_frame.pack(fill="x", padx=(26, 10), pady=3)
+        row_frame.grid_columnconfigure(1, weight=1)
+
+        if isinstance(label, ctk.StringVar):
+            tk.Label(
+                row_frame,
+                textvariable=label,
+                anchor="w",
+                font=_FONT_BODY,
+                bg=_PANEL_BG,
+                fg=_TEXT_FG,
+            ).grid(row=0, column=0, sticky="w")
+        else:
+            tk.Label(
+                row_frame,
+                text=label,
+                anchor="w",
+                font=_FONT_BODY,
+                bg=_PANEL_BG,
+                fg=_TEXT_FG,
+            ).grid(row=0, column=0, sticky="w")
+
+        # Slider
+        n_steps = int((max_val - min_val) / step) if step else int(max_val - min_val)
+        slider = CanvasSlider(
+            row_frame,
+            from_=min_val,
+            to=max_val,
+            number_of_steps=n_steps,
+        )
+        slider.set(default)
+        slider.grid(row=0, column=1, sticky="ew", padx=(2, 8))
+
+        # Store range info on the slider for dynamic access in callbacks
+        slider._oc_min = min_val
+        slider._oc_max = max_val
+        slider._oc_step = step
+        slider._oc_signed = signed
+        slider._oc_decimals = decimals
+
+        # Entry (fixed width, right-aligned value)
+        var = ctk.StringVar(value=_fmt(default))
+        entry = LiteEntry(
+            row_frame, textvariable=var, width=entry_width, justify="right"
+        )
+        entry.grid(row=0, column=2, padx=(0, 5))
+
+        # ── Sync: slider → entry ──
+        def _on_slider(value, _var=var, _slider=slider):
+            if self._syncing:
+                return
+            self._syncing = True
+            s = _slider._oc_step
+            snapped = round(value / s) * s if s else round(value)
+            _var.set(_fmt(snapped))
+            self._syncing = False
+
+        slider.configure(command=_on_slider)
+
+        # ── Sync: entry → slider ──
+        def _on_entry(*_, _slider=slider, _var=var):
+            if self._syncing:
+                return
+            text = _var.get().strip()
+            # Allow typing a minus sign or empty string without clamping
+            if text in ("", "-", "+"):
+                return
+            if text == "Curve":
+                return
+            try:
+                val = float(text) if _slider._oc_decimals else int(text)
+            except ValueError:
+                return
+            clamped = max(_slider._oc_min, min(_slider._oc_max, val))
+            self._syncing = True
+            _slider.set(clamped)
+            self._syncing = False
+
+        var.trace_add("write", _on_entry)
+
+        # ── On focus-out: clamp entry value ──
+        def _on_focusout(event, _var=var, _slider=slider):
+            text = _var.get().strip()
+            if text == "Curve":
+                return
+            try:
+                val = float(text) if _slider._oc_decimals else int(text)
+            except ValueError:
+                val = getattr(_slider, "_oc_min", float(_slider.cget("from_")))
+            clamped = max(
+                getattr(_slider, "_oc_min", float(_slider.cget("from_"))),
+                min(getattr(_slider, "_oc_max", float(_slider.cget("to"))), val),
+            )
+            s = getattr(_slider, "_oc_step", 1)
+            if s:
+                clamped = round(clamped / s) * s
+            self._syncing = True
+            _var.set(_fmt(clamped))
+            _slider.set(clamped)
+            self._syncing = False
+
+        entry.bind("<FocusOut>", _on_focusout)
+        entry.bind("<Return>", _on_focusout)
+
+        # Unit label right of the entry (matches the fan '%' style)
+        if isinstance(unit, ctk.StringVar):
+            tk.Label(
+                row_frame,
+                textvariable=unit,
+                font=_FONT_BODY,
+                bg=_PANEL_BG,
+                fg=_TEXT_FG_DIM,
+            ).grid(row=0, column=3, padx=(3, 0))
+        elif unit:
+            tk.Label(
+                row_frame,
+                text=unit,
+                font=_FONT_BODY,
+                bg=_PANEL_BG,
+                fg=_TEXT_FG_DIM,
+            ).grid(row=0, column=3, padx=(3, 0))
+
+        # Sub-apply button
+        btn = LiteButton(row_frame, text="✓", width=34, command=apply_cmd)
+        btn.grid(row=0, column=4, padx=(5, 0))
+
+        return slider, entry, var, btn
+
+    # ────────────────────────────────────────────
+    # Actions
+    # ────────────────────────────────────────────
+
+    def _apply_pstate_lock(self):
+        """Apply P-State lock range with the selected OC backend."""
+        selection = self.pstate_selector.get_selection()
+        gpu = self.app.selected_gpu_target()
+        if gpu is None or selection is None:
+            self.app.console.append("[GUI] No supported P-State selection available.\n")
+            return
+
+        start, end = selection
+        # Swap for descending ranges (e.g. p8 to p0) if needed
+        try:
+            start_val = int(start.lower().replace("p", ""))
+            end_val = int(end.lower().replace("p", ""))
+            if start_val > end_val:
+                start, end = end, start
+        except ValueError:
+            pass
+
+        backend = self._selected_oc_backend()
+        self.app.run_native_action(
+            "apply P-State lock",
+            lambda native, gpu=gpu, backend=backend, start=start, end=end: (
+                (
+                    native.set_nvml_pstate_lock(gpu, start, end)
+                    if backend == "nvml"
+                    else native.set_nvapi_pstate_lock(gpu, start, end)
+                )
+                or f"Successfully applied {backend.upper()} P-State lock {start}-{end}."
+            ),
+        )
+
+    def _unlock_pstate_lock(self):
+        """Remove memory lock settings for the selected OC backend."""
+        gpu = self.app.selected_gpu_target()
+        if gpu is None:
+            return
+        backend = self._selected_oc_backend()
+        self.app.run_native_action(
+            "reset memory clocks",
+            lambda native, gpu=gpu, backend=backend: (
+                native.reset_mem_clocks(gpu, backend)
+                or "Successfully reset memory clocks."
+            ),
+        )
+
+    def _apply_core_only(self):
+        core_mhz = self.core_var.get().strip()
+        if core_mhz == "Curve":
+            return
+
+        backend = self._selected_oc_backend()
+        try:
+            # One decimal allowed — the 2.5 MHz grid divides both the 7.5 MHz
+            # (30系+) and 12.5 MHz (10/16/20系) hardware frequency steps;
+            # pynvoc floors it to kHz (NVML rounds to integer MHz).
+            value = float(core_mhz)
+        except ValueError:
+            return
+        gpu = self.app.selected_gpu_target()
+        self.app.run_native_action(
+            "apply core offset",
+            lambda native, gpu=gpu, backend=backend, value=value: (
+                native.set_clock_offset(gpu, backend, "core", value, self._oc_pstate())
+                or f"Successfully applied core offset {value:g} MHz."
+            ),
+        )
+
+    def _apply_mem_only(self):
+        mem_mhz = self.mem_var.get().strip()
+        backend = self._selected_oc_backend()
+        try:
+            value = int(mem_mhz)
+        except ValueError:
+            return
+        gpu = self.app.selected_gpu_target()
+        self.app.run_native_action(
+            "apply memory offset",
+            lambda native, gpu=gpu, backend=backend, value=value: (
+                native.set_clock_offset(
+                    gpu, backend, "memory", value, self._oc_pstate()
+                )
+                or f"Successfully applied memory offset {value} MHz."
+            ),
+        )
+
+    def _apply_mem_with_sync(self):
+        """Shift+click: apply memory offset then sync P2→P0."""
+        mem_mhz = self.mem_var.get().strip()
+        backend = self._selected_oc_backend()
+        try:
+            value = int(mem_mhz)
+        except ValueError:
+            return
+        gpu = self.app.selected_gpu_target()
+        self.app.run_native_action(
+            "apply memory offset + sync P2→P0",
+            lambda native, gpu=gpu, backend=backend, value=value: (
+                native.set_clock_offset(
+                    gpu, backend, "memory", value, self._oc_pstate()
+                ),
+                native.sync_memory_pstate_as_p0(gpu),
+                f"Applied memory offset {value} MHz + synced P2→P0.",
+            )[-1],
+        )
+
+    def _apply_xbar_only(self):
+        """Apply the Xbar fabric-clock offset (NVAPI-only ClockClient path).
+
+        The GUI speaks signed MHz like Core/Mem; pynvoc's
+        ``set_clk_domain_offset`` takes kHz (the CLI spelling is
+        ``set-clk-domain-offset xbar <kHz>``; xbar = domain bit 1). The
+        medium layer snapshots the control block, patches, SETs, readbacks,
+        and restores on mismatch.
+        """
+        xbar = self.xbar_var.get().strip()
+        try:
+            value = int(xbar)
+        except ValueError:
+            return
+        gpu = self.app.selected_gpu_target()
+        self.app.run_native_action(
+            "apply xbar offset",
+            lambda native, gpu=gpu, value=value: self._format_xbar_offset_result(
+                value,
+                native.set_clk_domain_offset(gpu, 1, value * 1000, None, None),
+            ),
+        )
+
+    def _apply_plimit_only(self):
+        plimit = self.plimit_var.get().strip()
+        if plimit:
+            gpu = self.app.selected_gpu_target()
+            if self._mobile_mode:
+                self.app.run_native_action(
+                    "apply TGP watt limit",
+                    lambda native, gpu=gpu, watts=int(plimit): (
+                        native.set_tgp_watt(gpu, watts, self._tgp_policy_index)
+                        or f"Successfully applied TGP limit {watts} W."
+                    ),
+                )
+                return
+            backend = self._selected_power_backend()
+            self.app.run_native_action(
+                "apply power limit",
+                lambda native, gpu=gpu, backend=backend, plimit=int(plimit): (
+                    native.set_power_limit(gpu, backend, plimit)
+                    or f"Successfully applied {backend.upper()} power limit."
+                ),
+            )
+
+    def _apply_tlimit_only(self):
+        tlimit = self.tlimit_var.get().strip()
+        if tlimit:
+            gpu = self.app.selected_gpu_target()
+            if self._mobile_mode:
+                self.app.run_native_action(
+                    "apply target temperature",
+                    lambda native, gpu=gpu, tlimit=float(tlimit): (
+                        native.set_target_temp(gpu, tlimit, 2)
+                        or f"Successfully applied target temperature {tlimit:.0f} C."
+                    ),
+                )
+                return
+            self.app.run_native_action(
+                "apply thermal limit",
+                lambda native, gpu=gpu, tlimit=int(tlimit): (
+                    native.set_thermal_limit(gpu, tlimit)
+                    or "Successfully applied thermal limit."
+                ),
+            )
+
+    def _apply_vlimit_only(self):
+        """Apply the Volt Limit (absolute target mV on the VoltRails path).
+
+        The driver derives the µV offset internally and clamps the effective
+        wall to min(target, vbios_wall, vrm_max_wall); on completion we
+        re-load mobile limits so the slider reflects the new effective wall.
+        ``target_mv`` is parsed as float to honor the 2.5 mV grid (one decimal
+        on 10/20-series); it is floored to µV in the pynvoc layer.
+        """
+        vlimit = self.vlimit_var.get().strip()
+        if not vlimit:
+            return
+        try:
+            target_mv = float(vlimit)
+        except ValueError:
+            return
+        gpu = self.app.selected_gpu_target()
+        if gpu is None:
+            return
+        rail_bit = self._volt_rail_bit
+
+        def on_finished(_code):
+            self._load_mobile_limits()
+
+        self.app.run_native_action(
+            "apply volt-rail target",
+            lambda native, gpu=gpu, rail_bit=rail_bit, target_mv=target_mv: (
+                self._format_volt_rail_target_result(
+                    target_mv,
+                    native.set_volt_rail_target(gpu, rail_bit, target_mv, None),
+                )
+            ),
+            on_finished=on_finished,
+        )
+
+    def _apply_vboost_only(self):
+        vboost = self.vboost_var.get().strip()
+        if vboost:
+            gpu = self.app.selected_gpu_target()
+            if getattr(self, "_is_legacy_gpu", False):
+                try:
+                    vboost_uv = int(vboost) * 1000
+                except ValueError:
+                    return
+                self.app.run_native_action(
+                    "apply legacy voltage delta",
+                    lambda native, gpu=gpu, vboost_uv=vboost_uv: (
+                        native.set_legacy_voltage_delta(gpu, vboost_uv, "P0")
+                        or "Successfully applied legacy voltage delta."
+                    ),
+                )
+            else:
+                self.app.run_native_action(
+                    "apply voltage boost",
+                    lambda native, gpu=gpu, vboost=int(vboost): (
+                        native.set_voltage_boost(gpu, vboost)
+                        or "Successfully applied voltage boost."
+                    ),
+                )
+
+    def _apply_oc(self):
+        gpu = self.app.selected_gpu_target()
+        backend = self._selected_oc_backend()
+
+        core_mhz = self.core_var.get().strip()
+        mem_mhz = self.mem_var.get().strip()
+
+        actions = []
+        if core_mhz != "Curve":
+            try:
+                # One decimal (2.5 MHz grid) — see _apply_core_only.
+                core_value = float(core_mhz)
+                actions.append((
+                    "apply core offset",
+                    lambda native, gpu=gpu, backend=backend, core_value=core_value: (
+                        native.set_clock_offset(
+                            gpu, backend, "core", core_value, self._oc_pstate()
+                        )
+                        or f"Successfully applied core offset {core_value:g} MHz."
+                    ),
+                ))
+            except ValueError:
+                pass
+
+        try:
+            mem_value = int(mem_mhz)
+            actions.append((
+                "apply memory offset",
+                lambda native, gpu=gpu, backend=backend, mem_value=mem_value: (
+                    native.set_clock_offset(
+                        gpu, backend, "memory", mem_value, self._oc_pstate()
+                    )
+                    or f"Successfully applied memory offset {mem_value} MHz."
+                ),
+            ))
+        except ValueError:
+            pass
+
+        # Xbar is NVAPI-only: the row is disabled under the NVML backend
+        # selection, and the state check skips it there (and on archs where
+        # the row is hidden).
+        if self._xbar_supported and self.xbar_slider.cget("state") != "disabled":
+            try:
+                xbar_value = int(self.xbar_var.get().strip())
+                actions.append((
+                    "apply xbar offset",
+                    lambda native, gpu=gpu, xbar_value=xbar_value: (
+                        self._format_xbar_offset_result(
+                            xbar_value,
+                            native.set_clk_domain_offset(
+                                gpu, 1, xbar_value * 1000, None, None
+                            ),
+                        )
+                    ),
+                ))
+            except ValueError:
+                pass
+
+        if not actions:
+            self.app.console.append("[GUI] No valid clock offset values.\n")
+            return
+        self.app.run_native_action_chain(actions)
+
+    def _reset_oc(self):
+        gpu = self.app.selected_gpu_target()
+        # Reset sliders to 0 — var text goes through the row formatter so the
+        # sign convention (+0 / +0.0) matches what typing/focusout renders.
+        self._syncing = True
+        self.core_slider.set(0)
+        self.core_var.set(self._fmt_slider_value(self.core_slider, 0))
+        self.mem_slider.set(0)
+        self.mem_var.set(self._fmt_slider_value(self.mem_slider, 0))
+        if self._xbar_supported:
+            self.xbar_slider.set(0)
+            self.xbar_var.set(self._fmt_slider_value(self.xbar_slider, 0))
+        self._syncing = False
+
+        backend = self._selected_oc_backend()
+        resets = [
+            (
+                "reset core offset",
+                lambda native, gpu=gpu, backend=backend: (
+                    native.set_clock_offset(gpu, backend, "core", 0, self._oc_pstate())
+                    or "Successfully reset core offset."
+                ),
+            ),
+            (
+                "reset memory offset",
+                lambda native, gpu=gpu, backend=backend: (
+                    native.set_clock_offset(
+                        gpu, backend, "memory", 0, self._oc_pstate()
+                    )
+                    or "Successfully reset memory offset."
+                ),
+            ),
+        ]
+        if self._xbar_supported:
+            resets.append((
+                "reset xbar offset",
+                lambda native, gpu=gpu: self._format_xbar_offset_result(
+                    0, native.set_clk_domain_offset(gpu, 1, 0, None, None)
+                ),
+            ))
+        self.app.run_native_action_chain(resets)
+
+    def _apply_limits(self):
+        gpu = self.app.selected_gpu_target()
+        actions = []
+
+        if self._mobile_mode:
+            if self.plimit_slider.cget("state") != "disabled":
+                plimit = self.plimit_var.get().strip()
+                if plimit:
+                    actions.append((
+                        "apply TGP watt limit",
+                        lambda native, gpu=gpu, watts=int(plimit): (
+                            native.set_tgp_watt(gpu, watts, self._tgp_policy_index)
+                            or f"Successfully applied TGP limit {watts} W."
+                        ),
+                    ))
+            if self.tlimit_slider.cget("state") != "disabled":
+                tlimit = self.tlimit_var.get().strip()
+                if tlimit:
+                    actions.append((
+                        "apply target temperature",
+                        lambda native, gpu=gpu, tlimit=float(tlimit): (
+                            native.set_target_temp(gpu, tlimit, 2)
+                            or f"Successfully applied target temperature {tlimit:.0f} C."
+                        ),
+                    ))
+            if self.vlimit_slider.cget("state") != "disabled":
+                vlimit = self.vlimit_var.get().strip()
+                if vlimit:
+                    try:
+                        target_mv = float(vlimit)
+                    except ValueError:
+                        target_mv = None
+                    if target_mv is not None:
+                        rail_bit = self._volt_rail_bit
+                        actions.append((
+                            "apply volt-rail target",
+                            lambda native, gpu=gpu, rail_bit=rail_bit, target_mv=target_mv: (
+                                self._format_volt_rail_target_result(
+                                    target_mv,
+                                    native.set_volt_rail_target(
+                                        gpu, rail_bit, target_mv, None
+                                    ),
+                                )
+                            ),
+                        ))
+            if not actions:
+                self.app.console.append("[GUI] No limit values specified.\n")
+                return
+            self.app.run_native_action_chain(actions)
+            return
+
+        if self.plimit_slider.cget("state") != "disabled":
+            plimit = self.plimit_var.get().strip()
+            if plimit:
+                backend = self._selected_power_backend()
+                actions.append((
+                    "apply power limit",
+                    lambda native, gpu=gpu, backend=backend, plimit=int(plimit): (
+                        native.set_power_limit(gpu, backend, plimit)
+                        or f"Successfully applied {backend.upper()} power limit."
+                    ),
+                ))
+
+        if self.tlimit_slider.cget("state") != "disabled":
+            tlimit = self.tlimit_var.get().strip()
+            if tlimit:
+                actions.append((
+                    "apply thermal limit",
+                    lambda native, gpu=gpu, tlimit=int(tlimit): (
+                        native.set_thermal_limit(gpu, tlimit)
+                        or "Successfully applied thermal limit."
+                    ),
+                ))
+
+        if self.vboost_slider.cget("state") != "disabled":
+            vboost = self.vboost_var.get().strip()
+            if vboost:
+                if getattr(self, "_is_legacy_gpu", False):
+                    try:
+                        vboost_uv = int(vboost) * 1000
+                    except ValueError:
+                        pass
+                    else:
+                        actions.append((
+                            "apply legacy voltage delta",
+                            lambda native, gpu=gpu, vboost_uv=vboost_uv: (
+                                native.set_legacy_voltage_delta(gpu, vboost_uv, "P0")
+                                or "Successfully applied legacy voltage delta."
+                            ),
+                        ))
+                else:
+                    actions.append((
+                        "apply voltage boost",
+                        lambda native, gpu=gpu, vboost=int(vboost): (
+                            native.set_voltage_boost(gpu, vboost)
+                            or "Successfully applied voltage boost."
+                        ),
+                    ))
+
+        if not actions:
+            self.app.console.append("[GUI] No limit values specified.\n")
+            return
+        self.app.run_native_action_chain(actions)
+
+    def _reset_all(self):
+        gpu = self.app.selected_gpu_target()
+        # Reset sliders to their defaults from GPU info (var text through the
+        # row formatter for the +0/+0.0 sign convention)
+        self._syncing = True
+        self.core_slider.set(0)
+        self.core_var.set(self._fmt_slider_value(self.core_slider, 0))
+        self.mem_slider.set(0)
+        self.mem_var.set(self._fmt_slider_value(self.mem_slider, 0))
+        self.plimit_var.set(str(self._power_default))
+        self.plimit_slider.set(self._power_default)
+        self.tlimit_var.set(str(self._thermal_default))
+        self.tlimit_slider.set(self._thermal_default)
+        self.vboost_var.set("0")
+        self.vboost_slider.set(0)
+        self._syncing = False
+
+        if self._mobile_mode:
+            policy_index = self._tgp_policy_index
+
+            def on_finished(_code):
+                # Re-loads TGP/D-Notifier/temp-policies AND volt-rail bounds,
+                # which reconfigures the Volt Limit slider back to the live
+                # effective wall. pynvoc exposes no per-rail volt-rail reset,
+                # so there is no separate reset command — the slider simply
+                # re-anchors to the hardware's current voltage wall.
+                self._load_mobile_limits()
+
+            self.app.run_native_action(
+                "reset TGP to default",
+                lambda native, gpu=gpu, policy_index=policy_index: (
+                    native.reset_tgp_watt(gpu, policy_index)
+                    or "Successfully reset TGP to default."
+                ),
+                on_finished=on_finished,
+            )
+            return
+
+        self.app.run_native_action(
+            "reset all settings",
+            lambda native, gpu=gpu: (
+                native.reset_all(gpu, None) or "Successfully reset all settings."
+            ),
+        )

--- a/gui/src/tabs/dashboard/sections/overclock.py
+++ b/gui/src/tabs/dashboard/sections/overclock.py
@@ -957,7 +957,8 @@ class OverclockTab:
         self.app.run_native_action(
             "set D-Notifier level",
             lambda native, gpu=gpu, d_level=d_level: (
-                native.set_dnotifier(gpu, d_level) or f"Successfully set D-Notifier to D{d_level}."
+                native.set_dnotifier(gpu, d_level)
+                or f"Successfully set D-Notifier to D{d_level}."
             ),
             on_finished=on_finished,
         )

--- a/gui/src/tabs/dashboard/tab.py
+++ b/gui/src/tabs/dashboard/tab.py
@@ -1,0 +1,825 @@
+"""
+Dashboard Tab - Real-time GPU monitoring display.
+Shows: Core Freq, Mem Freq, Core Voltage (lock indicator), Temperature, Power.
+Auto-refreshes at a configurable interval via CLI 'status' command.
+"""
+
+import tkinter as tk
+import customtkinter as ctk
+from typing import TYPE_CHECKING, Optional, Dict, Tuple
+
+from src.parsing import as_float, parse_dashboard_status
+from src.widgets.lightweight_controls import LiteButton, LiteEntry, ct_button_font
+
+if TYPE_CHECKING:
+    from src.app import App
+
+# ── Colour palette ──────────────────────────────────────────────────────────
+_BG_CARD = "#1a1a2e"
+_BG_ROW = "#16213e"
+_BG_BAR = "#0f3460"
+_FG_LABEL = "#8899bb"
+_FG_VALUE = "#e8e8f0"
+_FG_UNIT = "#6688aa"
+_FG_LOCK = "#ff4444"
+_FG_UNLOCK = "#44cc88"
+
+# Bar gradient colour stops per metric (2 or 3 hex strings)
+_BAR_COLORS: Dict[str, tuple] = {
+    "GPU": ("#1e88e5", "#00e5ff", "#00bfa5"),
+    "MEM": ("#7b1fa2", "#e040fb", "#ff4081"),
+    "VOLT": ("#1565c0", "#42a5f5"),
+    "TEMP": ("#1b5e20", "#f9a825", "#c62828"),
+    "PWR": ("#004d40", "#00bcd4", "#ff6f00"),
+}
+
+
+# ── Helper: colour blend ─────────────────────────────────────────────────────
+def _blend_hex(c0: str, c1: str, t: float) -> str:
+    def parse(c):
+        c = c.lstrip("#")
+        return int(c[0:2], 16), int(c[2:4], 16), int(c[4:6], 16)
+
+    r0, g0, b0 = parse(c0)
+    r1, g1, b1 = parse(c1)
+    return "#{:02x}{:02x}{:02x}".format(
+        int(r0 + (r1 - r0) * t),
+        int(g0 + (g1 - g0) * t),
+        int(b0 + (b1 - b0) * t),
+    )
+
+
+def _gradient_color(stops: tuple, ratio: float) -> str:
+    ratio = max(0.0, min(1.0, ratio))
+    if len(stops) == 2:
+        return _blend_hex(stops[0], stops[1], ratio)
+    # 3-stop
+    c0, c1, c2 = stops
+    if ratio < 0.5:
+        return _blend_hex(c0, c1, ratio * 2)
+    return _blend_hex(c1, c2, (ratio - 0.5) * 2)
+
+
+# ── Metric row widget ─────────────────────────────────────────────────────────
+class _MetricRow:
+    """One row: LABEL | segmented-gradient bar | VALUE unit [lock]"""
+
+    _BAR_H = 18
+    _SEG_W = 18
+    _GAP_W = 4
+    _RESIZE_DRAW_DELAY_MS = 45
+    _WIDTH_DELTA_PX = 6
+
+    def __init__(
+        self,
+        parent: ctk.CTkFrame,
+        key: str,
+        label: str,
+        unit: str,
+        val_min: float,
+        val_max: float,
+    ):
+        self.key = key
+        self.unit = unit
+        self.val_min = val_min
+        self.val_max = val_max
+        self._stops = _BAR_COLORS.get(key, ("#1e88e5", "#00e5ff"))
+
+        row = ctk.CTkFrame(parent, fg_color=_BG_ROW, corner_radius=8)
+        row.pack(fill="x", padx=16, pady=3)
+
+        # col 0: label
+        ctk.CTkLabel(
+            row,
+            text=label,
+            font=("Consolas", 13, "bold"),
+            text_color=_FG_LABEL,
+            width=56,
+            anchor="w",
+        ).grid(row=0, column=0, padx=(14, 6), pady=2)
+
+        # col 1: canvas (bar) – expands
+        self._canvas = tk.Canvas(
+            row, height=self._BAR_H, bg=_BG_BAR, highlightthickness=0
+        )
+        self._canvas.grid(row=0, column=1, padx=4, pady=2, sticky="ew")
+        row.columnconfigure(1, weight=1)
+        self._canvas.bind("<Configure>", self._on_resize)
+        self._ratio = 0.0
+        self._last_draw_width: Optional[int] = None
+        self._last_draw_ratio: Optional[float] = None
+        self._resize_after_id: Optional[int] = None
+        self._is_resize_active = False
+
+        # col 2: numeric value
+        self._val_lbl = ctk.CTkLabel(
+            row,
+            text="---",
+            width=86,
+            font=("Consolas", 18, "bold"),
+            text_color=_FG_VALUE,
+            anchor="e",
+        )
+        self._val_lbl.grid(row=0, column=2, padx=(4, 2), pady=2)
+
+        # col 3: unit
+        ctk.CTkLabel(
+            row,
+            text=unit,
+            width=34,
+            font=("Consolas", 11),
+            text_color=_FG_UNIT,
+            anchor="w",
+        ).grid(row=0, column=3, padx=(0, 8), pady=2)
+
+        # col 4: lock icon
+        self._lock_lbl = ctk.CTkLabel(
+            row, text="", width=22, font=("", 13), text_color=_FG_LOCK
+        )
+        self._lock_lbl.grid(row=0, column=4, padx=(0, 12), pady=2)
+
+    def _on_resize(self, event):
+        if self._is_resize_active:
+            return
+        width = max(1, int(event.width))
+        if (
+            self._last_draw_width is not None
+            and abs(width - self._last_draw_width) < self._WIDTH_DELTA_PX
+        ):
+            return
+        if self._resize_after_id:
+            try:
+                self._canvas.after_cancel(self._resize_after_id)
+            except Exception:
+                pass
+        self._resize_after_id = self._canvas.after(
+            self._RESIZE_DRAW_DELAY_MS,
+            lambda r=self._ratio: self._draw_bar(r),
+        )
+
+    def set_resize_active(self, active: bool):
+        self._is_resize_active = active
+        if not active:
+            self._draw_bar(self._ratio, force=True)
+
+    def _draw_bar(self, ratio: float, force: bool = False):
+        self._resize_after_id = None
+        self._ratio = ratio
+        c = self._canvas
+        w = c.winfo_width()
+        h = self._BAR_H
+        if w < 2:
+            return
+        ratio_changed = (
+            self._last_draw_ratio is None or abs(ratio - self._last_draw_ratio) >= 1e-3
+        )
+        if (
+            not force
+            and self._last_draw_width is not None
+            and abs(w - self._last_draw_width) < self._WIDTH_DELTA_PX
+            and not ratio_changed
+        ):
+            return
+        self._last_draw_width = w
+        self._last_draw_ratio = ratio
+        c.delete("all")
+        fill_w = max(0, min(w, int(w * ratio)))
+        sw, gw = self._SEG_W, self._GAP_W
+
+        # filled segments
+        x = 0
+        while x < fill_w:
+            x1 = min(x + sw, fill_w)
+            mid = (x + x1) / 2 / w
+            color = _gradient_color(self._stops, mid)
+            c.create_rectangle(x, 2, x1, h - 2, fill=color, outline="")
+            x += sw + gw
+
+        # dim unfilled segments
+        # restart from aligned position
+        n_filled = fill_w // (sw + gw)
+        x_dim = n_filled * (sw + gw)
+        if x_dim < fill_w:
+            x_dim = fill_w
+        while x_dim < w:
+            x1 = min(x_dim + sw, w)
+            c.create_rectangle(x_dim, 4, x1, h - 4, fill="#243040", outline="")
+            x_dim += sw + gw
+
+    def update(self, value: float, locked: Optional[bool] = None):
+        span = self.val_max - self.val_min
+        ratio = max(0.0, min(1.0, (value - self.val_min) / span)) if span else 0.0
+        if self._is_resize_active:
+            self._ratio = ratio
+        else:
+            self._draw_bar(ratio)
+
+        # Format number
+        if self.key == "VOLT":
+            txt = f"{value:.1f}"
+        elif self.key in ("GPU", "MEM", "TEMP"):
+            txt = f"{value:.0f}"
+        else:
+            txt = f"{value:.1f}"
+        self._val_lbl.configure(text=txt)
+
+        if locked is True:
+            self._lock_lbl.configure(text="🔒", text_color=_FG_LOCK)
+        elif locked is False:
+            self._lock_lbl.configure(text="🔓", text_color=_FG_UNLOCK)
+        else:
+            self._lock_lbl.configure(text="")
+
+    def set_error(self):
+        self._val_lbl.configure(text="---")
+        self._draw_bar(0.0)
+        self._lock_lbl.configure(text="")
+
+
+# ── Main Tab ──────────────────────────────────────────────────────────────────
+class DashboardTab:
+    """Dashboard tab with real-time GPU metric bars."""
+
+    _DEFAULT_INTERVAL_MS = 1000
+    # dGPU-offline backoff: after this many consecutive failed polls whose
+    # error looks like a dead/disappearing GPU (ApiNotInitialized /
+    # NoImplementation / NvidiaDeviceNotFound), stop hammering NVAPI every
+    # second and drop to a slow re-probe cadence. The slow tick re-runs GPU
+    # discovery so the dGPU is picked up again the moment it comes back.
+    _OFFLINE_FAIL_THRESHOLD = 3
+    _OFFLINE_BACKOFF_MS = 5000
+    _OFFLINE_BACKOFF_CAP_MS = 15000
+
+    def __init__(self, parent: ctk.CTkFrame, app: "App") -> None:
+        self.app = app
+        self.frame = parent
+
+        self._poll_job: Optional[str] = None
+        self._polling = False
+        self._fetching = False
+        # The very first successful sample is mandatory (wake the GPU if
+        # needed); afterwards polling never blocks GC6 sleep.
+        self._first_success = False
+        self._first_snapshot_done = False  # one snapshot on first render only
+        self._interval_ms = self._DEFAULT_INTERVAL_MS
+        self._is_resize_active = False
+        self._vfcurve_active = False  # set by _set_vfcurve_active on tab change
+        self._pending_done_payload: Optional[Tuple[int, str]] = None
+        # dGPU-offline backoff state. When the selected GPU's NVAPI handle goes
+        # stale (user disabled the dGPU, or it dropped to a state where NVAPI
+        # returns ApiNotInitialized), every per-second poll fails and floods the
+        # console. Instead: count consecutive offline-looking failures, and once
+        # past the threshold, slow the poll to a re-probe cadence that re-runs
+        # GPU discovery each tick so the dGPU is auto-detected when it returns.
+        self._consecutive_offline = 0
+        self._in_offline_backoff = False
+        self._offline_hint_logged = False
+
+        self._build_ui()
+        self._restore_snapshot()
+        self._sync_lock_state_from_cache()
+        # Force one immediate sample so dashboard-only workflows update right away.
+        self.app.after(120, self._fetch_once)
+        # Start polling automatically after a short delay
+        self.app.after(900, self._start_polling)
+
+    # ── UI ────────────────────────────────────────────────────────────────────
+    def _build_ui(self) -> None:
+        # header
+        header = ctk.CTkFrame(self.frame, fg_color="transparent")
+        header.pack(fill="x", padx=10, pady=(0, 4))
+
+        tk.Label(
+            header,
+            text="📊 GPU Live Monitor",
+            font=("Segoe UI", 13, "bold"),
+            bg="#2b2b2b",
+            fg="#aaccff",
+        ).pack(side="left", padx=8)
+
+        # interval: Refresh: [entry] s — label styled to match the VF tab
+        tk.Label(
+            header,
+            text="s",
+            font=("Segoe UI", 11),
+            bg="#2b2b2b",
+            fg="#e5e5e5",
+        ).pack(side="right", padx=(0, 6))
+        self._interval_var = ctk.StringVar(value="1.0")
+        ie = LiteEntry(
+            header, textvariable=self._interval_var, width=5, justify="right"
+        )
+        ie.pack(side="right", padx=(0, 4))
+        tk.Label(
+            header,
+            text="Refresh:",
+            font=("Segoe UI", 11),
+            bg="#2b2b2b",
+            fg="#e5e5e5",
+        ).pack(side="right", padx=(0, 4))
+        ie.bind("<Return>", self._on_interval_changed)
+        ie.bind("<FocusOut>", self._on_interval_changed)
+
+        self._toggle_btn = ctk.CTkButton(
+            header,
+            text="⏸ Pause",
+            width=90,
+            command=self._toggle_polling,
+            font=ct_button_font(header),
+        )
+        self._toggle_btn.pack(side="right", padx=6)
+
+        ctk.CTkButton(
+            header,
+            text="🔄 Now",
+            width=70,
+            command=self._fetch_once,
+            font=ct_button_font(header),
+        ).pack(side="right", padx=4)
+
+        # metric card
+        card = ctk.CTkFrame(self.frame, fg_color=_BG_CARD, corner_radius=12)
+        card.pack(fill="x", padx=10, pady=(4, 6))
+
+        self._rows: Dict[str, _MetricRow] = {}
+        for key, label, unit, vmin, vmax in [
+            ("GPU", "GPU", "MHz", 100, 3500),
+            ("MEM", "MEM", "MHz", 100, 12000),
+            ("VOLT", "VOLT", "mV", 500, 1250),
+            ("TEMP", "TEMP", "°C", 20, 100),
+            ("PWR", "PWR", "W", 0, 400),
+        ]:
+            self._rows[key] = _MetricRow(card, key, label, unit, vmin, vmax)
+
+        # Status line removed (user request); keep a no-op sink so the
+        # fetch/resize paths can still call configure(text=...) unconditionally.
+        class _NoopLabel:
+            def configure(self, **_kw):
+                pass
+
+        self._status_lbl = _NoopLabel()
+
+        # Host frame for the overclock tab's top panels (Clock Offsets +
+        # Power & Thermal Limits) — the dashboard doubles as the control
+        # center. Empty (zero height) until the overclock tab is built.
+        self.oc_panels_host = tk.Frame(self.frame, bg="#2b2b2b")
+        self.oc_panels_host.pack(fill="x", padx=10, pady=(4, 6))
+
+        # Host frame for the fan-control section (below the two OC cards).
+        self.fan_panels_host = tk.Frame(self.frame, bg="#2b2b2b")
+        self.fan_panels_host.pack(fill="x", padx=10, pady=(0, 6))
+
+        # Quick-access buttons — four equal slots, LiteButton styling to
+        # match the section buttons above.
+        controls = tk.Frame(self.frame, bg="#2b2b2b")
+        controls.pack(fill="x", padx=10, pady=(4, 6))
+        for col in range(4):
+            controls.grid_columnconfigure(col, weight=1, uniform="dash_btns")
+        LiteButton(
+            controls, text="🔄 Refresh Info", width=10, command=self._refresh_info
+        ).grid(row=0, column=0, sticky="ew", padx=4)
+        LiteButton(
+            controls, text="📊 Show Status", width=10, command=self._show_status
+        ).grid(row=0, column=1, sticky="ew", padx=4)
+        LiteButton(
+            controls, text="📋 Show OC Settings", width=10, command=self._show_get
+        ).grid(row=0, column=2, sticky="ew", padx=4)
+        LiteButton(
+            controls,
+            text="🖥 Console",
+            width=10,
+            command=lambda: self.app.console.toggle(),
+        ).grid(row=0, column=3, sticky="ew", padx=4)
+
+    _SNAPSHOT_MAX_AGE_S = 24 * 3600
+
+    def _snapshot_path(self):
+        import os
+
+        base = os.environ.get("LOCALAPPDATA") or os.path.expanduser("~")
+        d = os.path.join(base, "nvoc-gui")
+        try:
+            os.makedirs(d, exist_ok=True)
+            return os.path.join(d, "dashboard_snapshot.json")
+        except OSError:
+            return None
+
+    def _save_snapshot(self, fresh: dict) -> None:
+        """Persist the last dashboard sample (background, best-effort)."""
+
+        def _write():
+            import json
+            import time
+
+            path = self._snapshot_path()
+            if not path:
+                return
+            try:
+                payload = {"ts": time.time(), "values": fresh}
+                with open(path, "w", encoding="utf-8") as f:
+                    json.dump(payload, f)
+            except OSError:
+                pass
+
+        try:
+            self.app.run_background("dash-snapshot", _write)
+        except Exception:
+            pass
+
+    def _restore_snapshot(self) -> None:
+        """Cold start: paint the last saved sample instantly (stale data,
+        replaced by the first live poll)."""
+        import json
+        import os
+        import time
+
+        path = self._snapshot_path()
+        if not path or not os.path.isfile(path):
+            return
+        try:
+            with open(path, encoding="utf-8") as f:
+                payload = json.load(f)
+        except (OSError, ValueError):
+            return
+        if time.time() - payload.get("ts", 0) > self._SNAPSHOT_MAX_AGE_S:
+            return
+        values = payload.get("values") or {}
+        locks = {
+            "GPU": self.app._dashboard_gpu_lock_active
+            if hasattr(self.app, "_dashboard_gpu_lock_active")
+            else False,
+        }
+        for key, row in self._rows.items():
+            val = values.get(key)
+            if val is not None:
+                try:
+                    row.update(float(val), locked=locks.get(key))
+                except (TypeError, ValueError):
+                    continue
+
+    def _sync_lock_state_from_cache(self) -> None:
+        """Refresh dashboard lock flags from app cache even before VF tab is created."""
+        cache = getattr(self.app, "_gpu_limits_cache", {}) or {}
+
+        def _has_pair(lo_key: str, hi_key: str) -> bool:
+            lo = cache.get(lo_key)
+            hi = cache.get(hi_key)
+            return (
+                lo is not None
+                and hi is not None
+                and str(lo).strip() != ""
+                and str(hi).strip() != ""
+            )
+
+        self.app._dashboard_gpu_lock_active = _has_pair(
+            "vfp_lock_gpu_core_lowerbound_mhz",
+            "vfp_lock_gpu_core_upperbound_mhz",
+        )
+        self.app._dashboard_mem_lock_active = _has_pair(
+            "vfp_lock_memory_lowerbound_mhz",
+            "vfp_lock_memory_upperbound_mhz",
+        )
+
+    # ── Polling ───────────────────────────────────────────────────────────────
+    def _start_polling(self) -> None:
+        if self._polling:
+            return
+        self._polling = True
+        self._toggle_btn.configure(text="⏸ Pause")
+        self._schedule_next()
+
+    def _stop_polling(self) -> None:
+        self._polling = False
+        self._toggle_btn.configure(text="▶ Resume")
+        if self._poll_job:
+            try:
+                self.app.after_cancel(self._poll_job)
+            except Exception:
+                pass
+            self._poll_job = None
+
+    def _toggle_polling(self) -> None:
+        if self._polling:
+            self._stop_polling()
+        else:
+            self._start_polling()
+
+    def _on_interval_changed(self, _event: object = None) -> None:
+        try:
+            secs = float(self._interval_var.get())
+            secs = max(0.2, min(60.0, secs))
+            self._interval_ms = int(secs * 1000)
+            self._interval_var.set(f"{secs:.1f}")
+        except ValueError:
+            self._interval_var.set(f"{self._interval_ms / 1000:.1f}")
+
+    def _schedule_next(self) -> None:
+        if self._polling:
+            # In offline backoff the poll cadence is the slow re-probe rate,
+            # not the user's configured interval. Each backoff tick also kicks a
+            # GPU rediscovery so the dGPU is picked up when it comes back.
+            delay = self._current_poll_interval_ms()
+            self._poll_job = self.app.after(delay, self._poll_tick)
+
+    def _current_poll_interval_ms(self) -> int:
+        if not self._in_offline_backoff:
+            return self._interval_ms
+        # Exponential-ish backoff capped: 5s -> 10s -> 15s -> 15s ...
+        step = min(
+            self._consecutive_offline - self._OFFLINE_FAIL_THRESHOLD,
+            self._OFFLINE_BACKOFF_CAP_MS // self._OFFLINE_BACKOFF_MS,
+        )
+        return min(
+            self._OFFLINE_BACKOFF_MS * max(1, step + 1),
+            self._OFFLINE_BACKOFF_CAP_MS,
+        )
+
+    @staticmethod
+    def _looks_like_offline_error(output: str) -> bool:
+        """True when a failed poll's error indicates the dGPU is gone/unreachable.
+
+        These are the signatures seen when the user disables the dGPU (stale
+        NVAPI handle → ApiNotInitialized) or when enumeration finds no GPU
+        (NoImplementation / NvidiaDeviceNotFound). Functional 'NotSupported'
+        is NOT offline and must not trigger backoff.
+        """
+        if not output:
+            return False
+        lowered = output.lower()
+        return (
+            "not_initialized" in lowered
+            or "api_not_initialized" in lowered
+            or "noimplementation" in lowered
+            or "nvidia_device_not_found" in lowered
+            or "novidevicefound" in lowered
+            or "gpu is lost" in lowered
+        )
+
+    def _poll_tick(self) -> None:
+        if not self._polling:
+            return
+        # Pause the NVAPI+NVML sweep during a resize drag: the background
+        # query contends with DWM at the GPU-driver level (synchronized
+        # stutter once per poll interval) and its after(0,...) completion
+        # interrupts the high-frequency Configure event burst on the main
+        # thread. Resize end flushes the last sample via on_resize_state_changed.
+        if self._is_resize_active:
+            self._schedule_next()
+            return
+        # Pause while the VF Curve tab is being interacted with (point drag /
+        # selection drag): the per-second NVAPI sweep's main-thread completion
+        # (parse + rows + snapshot + live-point) interrupts the drag's event
+        # stream. The next tick after the interaction ends resumes polling.
+        tab_vfcurve = getattr(self.app, "tab_vfcurve", None)
+        if tab_vfcurve is not None and getattr(tab_vfcurve, "is_interacting", False):
+            self._schedule_next()
+            return
+        # Don't burn a full NVAPI+NVML status sweep per second while the
+        # window is in the tray. Keep it running on the Dashboard (row
+        # refresh) AND on VF Curve: the curve's green live-crosshair
+        # reuses this status poll's voltage/frequency instead of issuing
+        # its own (heavier) VFP-curve query, so the poll must keep firing
+        # while the curve tab is visible or the crosshair freezes.
+        try:
+            if self.app.state() == "withdrawn":
+                self._schedule_next()
+                return
+            current_tab = str(self.app.tabview.get())
+            if not (
+                current_tab.endswith("Dashboard") or current_tab.endswith("VF Curve")
+            ):
+                self._schedule_next()
+                return
+        except Exception:
+            pass
+        # In offline backoff, each (slow) tick re-runs GPU discovery instead of
+        # a doomed NVAPI status sweep. discover_gpus re-enumerates from the
+        # driver, so the moment the dGPU is back it appears in the list and the
+        # GPU-switch chain (_apply_gpu_list → _on_gpu_changed → _query_gpu_info)
+        # repopulates everything; the next status poll succeeds → backoff exits.
+        if self._in_offline_backoff:
+            try:
+                self.app._refresh_gpu_list()
+            except Exception:
+                pass
+            self._schedule_next()
+            return
+        self._fetch_once()
+
+    def _fetch_once(self) -> None:
+        # Sync lock state from cache at the start of every fetch
+        self._sync_lock_state_from_cache()
+
+        if self._fetching:
+            return
+        gpu_args = self.app.get_gpu_args()
+        if not gpu_args:
+            self._status_lbl.configure(text="⚠ No GPU selected")
+            self._schedule_next()
+            return
+        self._fetching = True
+        self._status_lbl.configure(text="⟳ Fetching…")
+        self.app.run_gpu_query_async(
+            ["status", "-a"],
+            self._on_done,
+            thread_name="dash-poll",
+            use_cache=False,  # polling wants live data, not TTL reuse
+            allow_wake=not self._first_success,  # first sample may wake
+        )
+
+    def _on_done(self, retcode: int, output: str) -> None:
+        self._fetching = False
+        if retcode == 0:
+            self._first_success = True
+            self._exit_offline_backoff()
+
+        if self._is_resize_active:
+            # Keep only latest sample while resize is active, then flush once.
+            self._pending_done_payload = (retcode, output)
+            self._status_lbl.configure(text="⟳ Resizing… deferring dashboard redraw")
+            self._schedule_next()
+            return
+
+        # dGPU-offline detection: a failed poll whose error looks like a
+        # dead/unreachable GPU (stale NVAPI handle → ApiNotInitialized after the
+        # user disabled the dGPU, or NoImplementation when enumeration found no
+        # GPU). Count consecutive such failures and, past the threshold, enter a
+        # slow re-probe backoff instead of hammering NVAPI every second and
+        # flooding the console. A single successful poll exits backoff and
+        # restores the user's configured cadence immediately.
+        if retcode != 0 and self._looks_like_offline_error(output):
+            self._record_offline_failure()
+            # Suppress the per-second error spam while in backoff: the hint was
+            # already logged once on entry. Outside backoff, still let the row
+            # error show (---) but don't double-log.
+            self._status_lbl.configure(text="⚠ dGPU offline")
+            for row in self._rows.values():
+                row.set_error()
+            self._schedule_next()
+            return
+
+        # On the VF Curve tab the metric rows / snapshot are invisible — only
+        # the live crosshair (voltage/frequency) consumes the poll. Skip the
+        # row redraws + snapshot write to keep the main thread free for the
+        # curve's drag/blit event stream (a full _parse_and_update every
+        # second interrupted point drags).
+        live_only = self._vfcurve_active
+        self._apply_done_payload(retcode, output, live_only=live_only)
+        self._schedule_next()
+
+    def _record_offline_failure(self) -> None:
+        self._consecutive_offline += 1
+        if (
+            not self._in_offline_backoff
+            and self._consecutive_offline >= self._OFFLINE_FAIL_THRESHOLD
+        ):
+            self._enter_offline_backoff()
+
+    def _enter_offline_backoff(self) -> None:
+        self._in_offline_backoff = True
+        if not self._offline_hint_logged:
+            self._offline_hint_logged = True
+            try:
+                self.app.console.append(
+                    "[GUI] dGPU probably offline — polling paused, "
+                    "re-probing for the GPU to come back.\n"
+                )
+            except Exception:
+                pass
+        # Kick a rediscovery now (best-effort) — if the dGPU just came back this
+        # picks it up immediately instead of waiting for the next backoff tick.
+        try:
+            self.app._refresh_gpu_list()
+        except Exception:
+            pass
+
+    def _exit_offline_backoff(self) -> None:
+        if self._in_offline_backoff:
+            self._in_offline_backoff = False
+            try:
+                self.app.console.append("[GUI] dGPU back online — resuming polling.\n")
+            except Exception:
+                pass
+        self._consecutive_offline = 0
+        self._offline_hint_logged = False
+
+    def _set_vfcurve_active(self, active: bool) -> None:
+        """Mark whether the VF Curve tab owns the crosshair refresh.
+
+        When active, this dashboard poll's completion pushes volt/freq into
+        vfcurve's thread-safe sink (no blit) instead of scheduling an after(0)
+        blit, so a pending mouse-press on the curve is never delayed.
+        """
+        self._vfcurve_active = active
+
+    def _apply_done_payload(
+        self, retcode: int, output: str, live_only: bool = False
+    ) -> None:
+        """Apply a status poll result to the UI in one batched update.
+
+        ``live_only`` (VF Curve tab) skips the metric-row redraws and the
+        snapshot write — only the live crosshair's voltage/frequency are
+        forwarded to the curve tab.
+        """
+
+        if retcode == 0:
+            self._parse_and_update(output, live_only=live_only)
+        else:
+            if not live_only:
+                self._status_lbl.configure(text="⚠ CLI error")
+                for row in self._rows.values():
+                    row.set_error()
+
+    def on_resize_state_changed(
+        self, resizing: bool, force_flush: bool = False
+    ) -> None:
+        self._is_resize_active = resizing
+        for row in self._rows.values():
+            row.set_resize_active(resizing)
+        should_flush = (not resizing) and (
+            force_flush or self._pending_done_payload is not None
+        )
+        if should_flush and self._pending_done_payload is not None:
+            retcode, output = self._pending_done_payload
+            self._pending_done_payload = None
+            self._apply_done_payload(retcode, output)
+
+    # ── Parsing ───────────────────────────────────────────────────────────────
+    def _parse_and_update(self, output: str, live_only: bool = False) -> None:
+        parsed_status = parse_dashboard_status(output)
+        gpu_mhz = as_float(parsed_status.get("gpu_clock_mhz"))
+        mem_mhz = as_float(parsed_status.get("mem_clock_mhz"))
+        volt_mv = as_float(parsed_status.get("voltage_mv"))
+        temp_c = as_float(parsed_status.get("temperature_c"))
+        pwr_w = as_float(parsed_status.get("power_w"))
+
+        # VF Curve tab: only the live crosshair (voltage/frequency) is visible.
+        # Push the values into vfcurve's thread-safe sink (no blit here) — the
+        # vfcurve live timer drains them. Scheduling a blit from this after(0)
+        # completion would interpose it ahead of a pending mouse-press in the
+        # Tcl queue and delay the first click on the curve.
+        if live_only:
+            if getattr(self.app, "tab_vfcurve", None) is not None:
+                self.app.tab_vfcurve.set_live_pending(volt_mv, gpu_mhz)
+            return
+
+        locked_value = parsed_status.get("vfp_locked")
+        locked: Optional[bool] = (
+            bool(locked_value) if isinstance(locked_value, bool) else None
+        )
+
+        # Fallback: check vfcurve lock state
+        if locked is None and getattr(self.app, "tab_vfcurve", None):
+            lpts = getattr(self.app.tab_vfcurve, "_locked_points", set())
+            locked = len(lpts) > 0
+
+        self._sync_lock_state_from_cache()
+
+        gpu_bar_locked: Optional[bool] = (
+            True if getattr(self.app, "_dashboard_gpu_lock_active", False) else None
+        )
+        mem_bar_locked: Optional[bool] = (
+            True if getattr(self.app, "_dashboard_mem_lock_active", False) else None
+        )
+
+        if getattr(self.app, "tab_vfcurve", None):
+            if getattr(self.app.tab_vfcurve, "_freq_core_lock", None) is not None:
+                gpu_bar_locked = True
+            if getattr(self.app.tab_vfcurve, "_freq_mem_lock", None) is not None:
+                mem_bar_locked = True
+
+        # update vfcurve live point
+        if getattr(self.app, "tab_vfcurve", None):
+            self.app.tab_vfcurve.update_live_point(volt_mv, gpu_mhz)
+
+        # ── update rows ──
+        updates = [
+            ("GPU", gpu_mhz, gpu_bar_locked),
+            ("MEM", mem_mhz, mem_bar_locked),
+            ("VOLT", volt_mv, locked),
+            ("TEMP", temp_c, None),
+            ("PWR", pwr_w, None),
+        ]
+        fresh = {}
+        for key, val, lk in updates:
+            if val is not None:
+                self._rows[key].update(val, locked=lk)
+                fresh[key] = val
+            else:
+                self._rows[key].set_error()
+        # Persist one snapshot on the first successful render — it is only a
+        # cold-start fallback to paint stale data before the first live poll.
+        # Re-writing it every poll was wasted main-thread file I/O.
+        if fresh and not self._first_snapshot_done:
+            self._save_snapshot(fresh)
+            self._first_snapshot_done = True
+
+    # ── Quick-access button handlers ──────────────────────────────────────────
+    def _refresh_info(self) -> None:
+        self.app.show_gpu_command(["info"])
+
+    def _show_status(self) -> None:
+        self.app.show_gpu_command(["status", "-a"])
+
+    def _show_get(self) -> None:
+        self.app.show_gpu_command(["get"])

--- a/gui/src/tabs/vfcurve/__init__.py
+++ b/gui/src/tabs/vfcurve/__init__.py
@@ -1,0 +1,5 @@
+"""VF Curve tab and its hosted sections."""
+
+from .tab import VFCurveTab
+
+__all__ = ["VFCurveTab"]

--- a/gui/src/tabs/vfcurve/sections/__init__.py
+++ b/gui/src/tabs/vfcurve/sections/__init__.py
@@ -1,0 +1,5 @@
+"""Sections hosted on the VF Curve tab."""
+
+from .autoscan import AutoscanTab
+
+__all__ = ["AutoscanTab"]

--- a/gui/src/tabs/vfcurve/sections/autoscan.py
+++ b/gui/src/tabs/vfcurve/sections/autoscan.py
@@ -1,0 +1,337 @@
+"""
+Autoscan Tab - VFP auto-scanning workflow.
+"""
+
+import tkinter as tk
+import customtkinter as ctk
+from tkinter import filedialog
+from typing import TYPE_CHECKING, Optional, Tuple
+from src.widgets.lightweight_controls import (
+    ct_button_font,
+    LiteButton,
+    LiteEntry,
+    install_mousewheel_support,
+)
+
+# De-CTk'd palette (matches overclock.py / fan_control.py)
+_PANE_BG = "#2b2b2b"
+_TEXT_FG = "#e5e5e5"
+_FONT_BODY = ("Segoe UI", 11)
+_FONT_HEADER = ("Segoe UI", 13, "bold")
+_SECTION_BORDER = "#1f4e79"
+
+if TYPE_CHECKING:
+    from src.app import App
+
+
+class AutoscanTab:
+    """Autoscan tab for VFP curve auto-optimization."""
+
+    def __init__(self, parent: ctk.CTkFrame, app: "App") -> None:
+        self.app = app
+        self.frame = parent
+        self._is_resize_active = False
+        self._pending_scan_button_state: Optional[Tuple[bool, bool]] = None
+
+        # Scrollable content
+        scroll = ctk.CTkScrollableFrame(self.frame)
+        scroll.pack(fill="both", expand=True, padx=10, pady=10)
+        install_mousewheel_support(scroll)
+
+        # === Mode Selection ===
+        mode_frame = ctk.CTkFrame(
+            scroll, border_width=1, border_color=_SECTION_BORDER, corner_radius=10
+        )
+        mode_frame.pack(fill="x", pady=(0, 10))
+        tk.Label(
+            mode_frame, text="🔍 Scan Mode", font=_FONT_HEADER, bg=_PANE_BG, fg=_TEXT_FG
+        ).pack(anchor="w", padx=10, pady=(10, 5))
+
+        self.mode_var = ctk.StringVar(value="Standard")
+        mode_row = tk.Frame(mode_frame, bg=_PANE_BG)
+        mode_row.pack(fill="x", padx=10, pady=(0, 10))
+        tk.Label(
+            mode_row, text="Mode:", font=_FONT_BODY, bg=_PANE_BG, fg=_TEXT_FG
+        ).pack(side="left", padx=(0, 6))
+        self.mode_menu = ctk.CTkOptionMenu(
+            mode_row,
+            variable=self.mode_var,
+            values=["Standard", "Ultrafast", "Legacy"],
+            width=140,
+            anchor="center",
+            font=ct_button_font(mode_row),
+        )
+        self.mode_menu.pack(side="left")
+        tk.Label(
+            mode_row, text="BSOD:", font=_FONT_BODY, bg=_PANE_BG, fg=_TEXT_FG
+        ).pack(side="left", padx=(16, 6))
+        self.bsod_var = ctk.StringVar(value="(auto)")
+        self.bsod_menu = ctk.CTkOptionMenu(
+            mode_row,
+            variable=self.bsod_var,
+            values=["(auto)", "aggressive", "traditional"],
+            width=130,
+            anchor="center",
+            font=ct_button_font(mode_row),
+        )
+        self.bsod_menu.pack(side="left")
+
+        # === Parameters (left half) | Actions (right half) ===
+        split = tk.Frame(scroll, bg=_PANE_BG)
+        split.pack(fill="x", pady=(0, 10))
+        split.grid_columnconfigure(0, weight=1, uniform="scan_split")
+        split.grid_columnconfigure(1, weight=1, uniform="scan_split")
+
+        param_frame = ctk.CTkFrame(
+            split, border_width=1, border_color=_SECTION_BORDER, corner_radius=10
+        )
+        param_frame.grid(row=0, column=0, sticky="new", padx=(0, 5))
+        tk.Label(
+            param_frame,
+            text="⚙ Parameters",
+            font=_FONT_HEADER,
+            bg=_PANE_BG,
+            fg=_TEXT_FG,
+        ).pack(anchor="w", padx=10, pady=(10, 5))
+
+        params_grid = tk.Frame(param_frame, bg=_PANE_BG)
+        params_grid.pack(fill="x", padx=10, pady=(0, 10))
+        params_grid.columnconfigure(1, weight=0)
+
+        row = 0
+        # Output CSV
+        tk.Label(
+            params_grid, text="Output CSV:", font=_FONT_BODY, bg=_PANE_BG, fg=_TEXT_FG
+        ).grid(row=row, column=0, sticky="w", padx=5, pady=3)
+        self.output_csv_var = ctk.StringVar(value="./ws/vfp-tem.csv")
+        out_row = tk.Frame(params_grid, bg=_PANE_BG)
+        out_row.grid(row=row, column=1, sticky="ew", padx=5, pady=3)
+        out_entry = LiteEntry(
+            out_row,
+            textvariable=self.output_csv_var,
+            width=20,
+            min_px=140,
+            justify="left",
+        )
+        out_entry.pack(side="left", fill="x", expand=True)
+        LiteButton(
+            out_row,
+            text="...",
+            width=34,
+            command=lambda: self._browse_save(self.output_csv_var),
+        ).pack(side="left", padx=(5, 0))
+
+        row += 1
+        # Init CSV
+        tk.Label(
+            params_grid, text="Init CSV:", font=_FONT_BODY, bg=_PANE_BG, fg=_TEXT_FG
+        ).grid(row=row, column=0, sticky="w", padx=5, pady=3)
+        self.init_csv_var = ctk.StringVar(value="./ws/vfp-init.csv")
+        init_row = tk.Frame(params_grid, bg=_PANE_BG)
+        init_row.grid(row=row, column=1, sticky="ew", padx=5, pady=3)
+        init_entry = LiteEntry(
+            init_row,
+            textvariable=self.init_csv_var,
+            width=20,
+            min_px=140,
+            justify="left",
+        )
+        init_entry.pack(side="left", fill="x", expand=True)
+        LiteButton(
+            init_row,
+            text="...",
+            width=34,
+            command=lambda: self._browse_file(self.init_csv_var),
+        ).pack(side="left", padx=(5, 0))
+
+        # === Action Buttons (right half) ===
+        btn_frame = ctk.CTkFrame(
+            split, border_width=1, border_color=_SECTION_BORDER, corner_radius=10
+        )
+        btn_frame.grid(row=0, column=1, sticky="new", padx=(5, 0))
+        tk.Label(
+            btn_frame, text="▶ Actions", font=_FONT_HEADER, bg=_PANE_BG, fg=_TEXT_FG
+        ).pack(anchor="w", padx=10, pady=(10, 5))
+
+        btn_row = tk.Frame(btn_frame, bg=_PANE_BG)
+        btn_row.pack(fill="x", padx=10, pady=(0, 10))
+
+        LiteButton(
+            btn_row, text="📤 Export Init VFP", width=10, command=self._export_init
+        ).pack(side="left", fill="x", expand=True, padx=5)
+        LiteButton(
+            btn_row,
+            text="🔓 Reset VFP",
+            width=10,
+            fg_color="#c0392b",
+            hover_color="#96281b",
+            command=self._reset_unlock,
+        ).pack(side="left", fill="x", expand=True, padx=5)
+        LiteButton(
+            btn_row, text="🔧 Fix Results", width=10, command=self._fix_result
+        ).pack(side="left", fill="x", expand=True, padx=5)
+
+        btn_row2 = tk.Frame(btn_frame, bg=_PANE_BG)
+        btn_row2.pack(fill="x", padx=10, pady=(0, 10))
+
+        self.start_btn = LiteButton(
+            btn_row2,
+            text="▶ Start Autoscan",
+            width=160,
+            fg_color="#2d8a4e",
+            hover_color="#236b3c",
+            command=self._start_scan,
+        )
+        self.start_btn.pack(side="left", padx=5)
+
+        self.stop_btn = LiteButton(
+            btn_row2,
+            text="⏹ Stop",
+            width=100,
+            fg_color="#c0392b",
+            hover_color="#96281b",
+            command=self._stop_scan,
+        )
+        self.stop_btn.configure(state="disabled")
+        self.stop_btn.pack(side="left", padx=5)
+
+        btn_row3 = tk.Frame(btn_frame, bg=_PANE_BG)
+        btn_row3.pack(fill="x", padx=10, pady=(0, 10))
+
+        LiteButton(
+            btn_row3, text="📥 Import Final VFP", width=10, command=self._import_final
+        ).pack(side="left", fill="x", expand=True, padx=5)
+        LiteButton(
+            btn_row3, text="📤 Export Final VFP", width=160, command=self._export_final
+        ).pack(side="left", padx=5)
+
+    def _browse_file(self, var: ctk.StringVar) -> None:
+        path = filedialog.askopenfilename()
+        if path:
+            var.set(path)
+
+    def _browse_save(self, var: ctk.StringVar) -> None:
+        path = filedialog.asksaveasfilename(
+            defaultextension=".csv", filetypes=[("CSV", "*.csv"), ("All", "*.*")]
+        )
+        if path:
+            var.set(path)
+
+    def _set_scan_buttons(self, start_enabled: bool, stop_enabled: bool):
+        if self._is_resize_active:
+            self._pending_scan_button_state = (start_enabled, stop_enabled)
+            return
+
+        desired_start = "normal" if start_enabled else "disabled"
+        desired_stop = "normal" if stop_enabled else "disabled"
+        if self.start_btn.cget("state") != desired_start:
+            self.start_btn.configure(state=desired_start)
+        if self.stop_btn.cget("state") != desired_stop:
+            self.stop_btn.configure(state=desired_stop)
+
+    def on_resize_state_changed(
+        self, resizing: bool, force_flush: bool = False
+    ) -> None:
+        self._is_resize_active = resizing
+        if (
+            (not resizing)
+            and force_flush
+            and self._pending_scan_button_state is not None
+        ):
+            start_enabled, stop_enabled = self._pending_scan_button_state
+            self._pending_scan_button_state = None
+            self._set_scan_buttons(start_enabled, stop_enabled)
+
+    def _export_init(self) -> None:
+        gpu_args = self.app.get_gpu_args()
+        gpu = self.app.selected_gpu_target()
+        self.app.console.append("[GUI] Resetting core offset/curve...\n")
+
+        def export_after_reset(code: int) -> None:
+            if code == 0:
+                self.app.run_cli_display(gpu_args + ["export-vfp", "-q", "-"])
+
+        self.app.run_native_action(
+            "reset core offset",
+            lambda native, gpu=gpu: (
+                native.set_clock_offset(gpu, "nvml", "core", 0, "P0")
+                or "Successfully reset core offset."
+            ),
+            on_finished=export_after_reset,
+        )
+
+    def _reset_unlock(self) -> None:
+        """Reset VF curve explicitly and unlock NVAPI VFP states, then auto refresh."""
+        gpu_args = self.app.get_gpu_args()
+        gpu = self.app.selected_gpu_target()
+
+        def refresh_curve(_code: int) -> None:
+            if getattr(self.app, "tab_vfcurve", None):
+                self.app.tab_vfcurve._refresh_curve()
+
+        def reset_curve_after_unlock(code: int) -> None:
+            if code == 0:
+                self.app.run_cli_display(
+                    gpu_args + ["reset-vfp"],
+                    on_finished=refresh_curve,
+                )
+
+        self.app.run_native_action(
+            "reset VFP lock",
+            lambda native, gpu=gpu: (
+                native.reset_vfp_lock(gpu) or "Successfully reset VFP lock."
+            ),
+            on_finished=reset_curve_after_unlock,
+        )
+
+    def _start_scan(self) -> None:
+        gpu_args = self.app.get_gpu_args()
+        mode = {
+            "Ultrafast": "ultrafast",
+            "Legacy": "legacy",
+        }.get(self.mode_var.get(), "standard")
+
+        if mode == "legacy":
+            args = gpu_args + ["autoscan-vfp-legacy"]
+            bsod = self.bsod_var.get()
+            if bsod != "(auto)":
+                args += ["-b", bsod]
+        else:
+            args = gpu_args + ["autoscan-vfp"]
+            if mode == "ultrafast":
+                args.append("-u")
+            args += ["-o", self.output_csv_var.get()]
+            args += ["-i", self.init_csv_var.get()]
+            bsod = self.bsod_var.get()
+            if bsod != "(auto)":
+                args += ["-b", bsod]
+
+        self._set_scan_buttons(start_enabled=False, stop_enabled=True)
+
+        def on_finished(retcode: int) -> None:
+            self.frame.after(
+                0,
+                lambda: self._set_scan_buttons(start_enabled=True, stop_enabled=False),
+            )
+
+        self.app.run_cli(args, on_finished=on_finished)
+
+    def _stop_scan(self) -> None:
+        self.app.cancel_cli()
+        self._set_scan_buttons(start_enabled=True, stop_enabled=False)
+
+    def _fix_result(self) -> None:
+        gpu_args = self.app.get_gpu_args()
+        mode = {"Ultrafast": "ultrafast"}.get(self.mode_var.get(), "standard")
+        args = gpu_args + ["fix-vfp-result", "-m", "1"]
+        if mode == "ultrafast":
+            args.append("-u")
+        self.app.run_cli_display(args)
+
+    def _import_final(self) -> None:
+        gpu_args = self.app.get_gpu_args()
+        self.app.run_cli_display(gpu_args + ["import-vfp", "./ws/vfp.csv"])
+
+    def _export_final(self) -> None:
+        gpu_args = self.app.get_gpu_args()
+        self.app.run_cli_display(gpu_args + ["export-vfp", "./ws/vfp-final.csv"])

--- a/gui/src/tabs/vfcurve/tab.py
+++ b/gui/src/tabs/vfcurve/tab.py
@@ -568,6 +568,7 @@ class VFCurveTab:
             color="#e08020",
             fontsize=7,
         )
+
         # one decimal on BOTH axes (0.5 / 1.0 / 1.5 ...) — uniform columns.
         # NOTE: with a FuncFormatter attached, matplotlib regenerates tick
         # TEXT on every draw, so the "Volt/V" unit caption must come FROM

--- a/gui/src/tabs/vfcurve/tab.py
+++ b/gui/src/tabs/vfcurve/tab.py
@@ -1,0 +1,2977 @@
+"""
+VF Curve Tab - Interactive voltage-frequency curve chart with matplotlib,
+plus VFP export/import, lock/unlock, and point adjustment controls.
+"""
+
+import csv
+import os
+import time as _time
+
+import tkinter as tk
+import customtkinter as ctk
+from tkinter import filedialog
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+
+if TYPE_CHECKING:
+    from src.app import App
+
+from src.widgets.lightweight_controls import (
+    ct_button_font,
+    LiteButton,
+    LiteEntry,
+)
+from src.parsing import analyze_vfp_offsets, load_vfp_deltas, write_vfp_points
+
+# ── De-CTk'd panel palette (matches overclock.py / fan_control.py) ──
+_PANEL_BG = "#2b2b2b"  # CTk dark frame/scroll background
+_TEXT_FG = "#e5e5e5"  # default label text
+_TEXT_FG_DIM = "#b3b3b3"  # 'gray70' hints
+_FONT_BODY = ("Segoe UI", 11)
+_FONT_HEADER = ("Segoe UI", 13, "bold")
+_CARD_KW = dict(border_width=1, border_color="#1f4e79", corner_radius=10)
+
+# ── Multi-curve palette ──
+# Per-curve current/default colors. The current/default line styles
+# (solid+marker / dashed) are inherited from the original single-curve look.
+_CURVE_COLORS = {
+    "gpc": {"current": "#00ccff", "default": "#1f4e79"},  # cyan / deep blue
+    "xbar": {"current": "#FF8C00", "default": "#7a3d00"},  # bright orange / dark orange
+    "host": {"current": "#B026FF", "default": "#4B0082"},  # bright purple / dark purple
+}
+# Display label + private-domain class for the raw-converted prior.
+_CURVE_META = {
+    "gpc": {"label": "GPC", "class": "graphics", "domain_bit": 0},
+    "xbar": {"label": "XBAR", "class": "fabric", "domain_bit": 1},
+    "host": {"label": "HOST", "class": "fabric", "domain_bit": 5},
+}
+
+
+class _CurveData:
+    """One VF curve (GPC/XBAR/HOST) loaded from public or private NVAPI.
+
+    ``voltages``/``frequencies``/``defaults`` are in display units (mV / MHz).
+    ``source`` is "public" (GPC via the open VFP interface) or "private"
+    (any segment from ``query_private_vftable``). ``seg_start``/``seg_end`` are
+    the inclusive private point indices within ``bank`` (used for private
+    apply/reset); for the public GPC curve they mirror the public index range.
+    ``write_mode`` decides how ``_apply_adj`` / reset reach the GPU.
+    """
+
+    __slots__ = (
+        "curve_id",
+        "voltages",
+        "frequencies",
+        "defaults",
+        "source",
+        "bank",
+        "seg_start",
+        "seg_end",
+        "write_mode",
+        "has_fixed",
+    )
+
+    def __init__(self, curve_id: str):
+        self.curve_id = curve_id
+        self.voltages: List[float] = []
+        self.frequencies: List[float] = []
+        self.defaults: List[float] = []
+        self.source = "public"
+        self.bank = 0
+        self.seg_start = 0
+        self.seg_end = 0
+        # "public" (open VFP) | "private_mode0" (private freq-kHz offset) |
+        # "private_raw_converted" (private mode-1 raw f-offset via g(def))
+        self.write_mode = "public"
+        self.has_fixed = False
+
+
+class VFCurveTab:
+    """VF Curve management tab with interactive chart."""
+
+    # ── Chart export directory (relative to GUI project root) ──
+    _EXPORT_DIR = "vfp_cache"
+    _DEFAULT_AUTO_REFRESH_INTERVAL_MS = 1000
+
+    @staticmethod
+    def _np():
+        """Lazy numpy: only the chart interaction paths need it (~34ms import)."""
+        import numpy as np
+
+        return np
+
+    def __init__(self, parent: ctk.CTkFrame, app: "App"):
+        self.app = app
+        self.frame = parent
+
+        # VF data (in display units: mV and MHz)
+        self._voltages: List[float] = []
+        self._frequencies: List[float] = []  # current
+        self._defaults: List[float] = []  # default_frequency
+
+        # ── Multi-curve state ──
+        # One _CurveData per discovered curve (gpc/xbar/host). _voltages /
+        # _frequencies / _defaults above are kept as a live view of the active
+        # curve's lists (same object references) so every existing single-curve
+        # call site (drag, keyboard, space-key, lock, dashboard poll, tests)
+        # continues to operate on the active curve unchanged.
+        self._curves: Dict[str, _CurveData] = {}
+        self._active_curve: str = "gpc"
+        self._curve_visible: Dict[str, bool] = {}
+        self._curve_lines: Dict[str, dict] = {}  # curve_id -> {"current","default"}
+        self._curve_selector_row: Optional[tk.Frame] = None
+        self._curve_selector_btns: Dict[str, tk.Frame] = {}
+        # per-GPU probe of which private write mode each curve supports, so a
+        # mode-0 capability probe isn't repeated every refresh.
+        self._curve_probe_cache: Dict[str, Dict[str, str]] = {}
+        # Monotonic guard so a stale async query doesn't overwrite a newer load.
+        self._curve_query_epoch: int = 0
+
+        # Selection state  (indices into the data arrays)
+        self._sel_start: Optional[int] = None
+        self._sel_end: Optional[int] = None
+
+        # Single-point lock state: set of locked point indices
+        self._locked_points = set()  # type: Set[int]
+
+        # Frequency lock state (core/memory): (min_mhz, max_mhz)
+        self._freq_core_lock = None  # type: Optional[Tuple[int, int]]
+        self._freq_mem_lock = None  # type: Optional[Tuple[int, int]]
+        self._freq_core_lock_backend = None  # type: Optional[str]
+        self._freq_mem_lock_backend = None  # type: Optional[str]
+
+        # Drag state
+        self._dragging = False
+        self._drag_start_y: Optional[float] = None
+        self._drag_orig_freqs = None  # numpy array, created lazily
+
+        # Live point state
+        self._live_volt: Optional[float] = None
+        self._live_freq: Optional[float] = None
+        self._live_elements: list = []
+        self._live_hline = None
+        self._live_vline = None
+        self._live_marker = None
+        self._live_text = None
+        self._cleaned_up = False
+        # x-tick value whose label renders as "Volt/V" (set after each
+        # curve load; consumed by the x-axis FuncFormatter in _style_axes)
+        self._volt_unit_tick: Optional[float] = None
+        self._chart_build_after_id: Optional[str] = None
+        self._chart_resize_after_id = None
+        self._chart_configure_bind_id: Optional[str] = None
+        self._mpl_connection_ids: list[int] = []
+        self._last_chart_event_width: Optional[int] = None
+        self._last_chart_event_height: Optional[int] = None
+        self._last_chart_resize_width: Optional[int] = None
+        self._last_chart_resize_height: Optional[int] = None
+        self._pending_chart_resize_wh: Optional[Tuple[int, int]] = None
+        self._is_resize_active = False
+        # True while a mouse button is held on the chart (point drag /
+        # selection drag). The dashboard poll's live-point update is deferred
+        # to pending during interaction — its per-second matplotlib blit was
+        # contending with the drag's own blit over the cached background,
+        # making point drags stutter once per second.
+        self._mouse_pressed = False
+        self._pending_live_point: Optional[Tuple[Optional[float], Optional[float]]] = (
+            None
+        )
+        self._pending_full_redraw = False
+        self._refresh_curve_inflight = False
+        self._refresh_curve_pending = False
+        self._last_load_ts = 0.0  # dedupes back-to-back refresh chains
+        self._auto_refresh_job: Optional[str] = None
+        self._auto_refreshing = False
+        self._auto_refresh_interval_ms = self._DEFAULT_AUTO_REFRESH_INTERVAL_MS
+        self._auto_interval_var = ctk.StringVar(value="1.0")
+        self._auto_toggle_btn = None
+        self.quick_export_var = ctk.BooleanVar(value=True)
+        # Live crosshair poller — independent of the dashboard poll so its
+        # after(0,_on_done) cannot interpose a blit ahead of a mouse-press
+        # event in the Tcl queue. The worker writes volt/freq into
+        # _live_pending (GIL-safe scalar); this timer picks them up and
+        # blits at a low cadence, skipping while the user is interacting.
+        self._live_poll_job: Optional[str] = None
+        self._live_pending: Tuple[Optional[float], Optional[float]] = (None, None)
+        self._live_poll_inflight = False
+        # Direct-read inflight guard for xbar/host live-point polling.
+        self._direct_read_inflight = False
+
+        # ── Top: chart area (controls row + plot) ──
+        self._chart_area = tk.Frame(self.frame, bg=_PANEL_BG)
+        self._chart_area.pack(fill="x", expand=False, padx=10, pady=(10, 5))
+
+        chart_top = tk.Frame(self._chart_area, bg=_PANEL_BG)
+        chart_top.pack(fill="x", pady=(0, 4))
+        tk.Label(
+            chart_top,
+            text="📈 VF Curve",
+            font=_FONT_HEADER,
+            bg=_PANEL_BG,
+            fg="#aaccff",
+        ).pack(side="left", padx=8)
+
+        io_row = tk.Frame(chart_top, bg=_PANEL_BG)
+        io_row.pack(side="left", padx=(12, 0))
+        ctk.CTkCheckBox(
+            io_row, text="Quick export", variable=self.quick_export_var, width=100
+        ).pack(side="left", padx=(0, 8))
+        LiteButton(io_row, text="📤Export", width=75, command=self._export_vfp).pack(
+            side="left", padx=(0, 4)
+        )
+        LiteButton(io_row, text="📥Import", width=75, command=self._import_vfp).pack(
+            side="left", padx=(0, 4)
+        )
+        LiteButton(
+            io_row,
+            text="🔁Reset",
+            width=75,
+            fg_color="#c0392b",
+            hover_color="#96281b",
+            command=self._reset_vfp,
+        ).pack(side="left")
+
+        auto_row = tk.Frame(chart_top, bg=_PANEL_BG)
+        auto_row.pack(side="right")
+        self._auto_toggle_btn = LiteButton(
+            auto_row, text="▶ Auto", width=82, command=self._toggle_auto_refresh
+        )
+        self._auto_toggle_btn.pack(side="left", padx=(0, 8))
+        tk.Label(
+            auto_row, text="Refresh:", font=_FONT_BODY, bg=_PANEL_BG, fg=_TEXT_FG
+        ).pack(side="left", padx=(0, 4))
+        auto_interval_entry = LiteEntry(
+            auto_row,
+            textvariable=self._auto_interval_var,
+            width=5,
+            min_px=52,
+            justify="right",
+        )
+        auto_interval_entry.pack(side="left", padx=(0, 2))
+        tk.Label(
+            auto_row, text="s", font=_FONT_BODY, bg=_PANEL_BG, fg=_TEXT_FG_DIM
+        ).pack(side="left")
+        auto_interval_entry.bind("<Return>", self._on_auto_interval_changed)
+        auto_interval_entry.bind("<FocusOut>", self._on_auto_interval_changed)
+
+        self._chart_frame = ctk.CTkFrame(self._chart_area)
+        self._chart_frame.pack(fill="both", expand=True)
+
+        # ── Per-curve selector row (below the chart, above the toolbar) ──
+        # Only packed when more than one curve is discovered (see _rebuild_selector).
+        self._curve_selector_host = tk.Frame(self.frame, bg=_PANEL_BG)
+
+        # Schedule heavy chart init (and matplotlib import) to occur after UI starts
+        self._chart_build_after_id = self.app.after(50, self._build_chart_if_alive)
+
+        # ── Chart toolbar ──
+        toolbar = tk.Frame(self.frame, bg=_PANEL_BG)
+        toolbar.pack(fill="x", padx=10, pady=(0, 5))
+        LiteButton(
+            toolbar, text="🔄 Refresh Curve", width=140, command=self._refresh_curve
+        ).pack(side="left", padx=5)
+        LiteButton(
+            toolbar, text="↩ Undo Drag Edit", width=140, command=self._undo_drag
+        ).pack(side="left", padx=5)
+        LiteButton(
+            toolbar, text="🗑 Clear Selection", width=130, command=self._clear_selection
+        ).pack(side="left", padx=5)
+        LiteButton(
+            toolbar,
+            text="✅ Apply to GPU",
+            width=130,
+            fg_color="#1a6b2a",
+            hover_color="#145220",
+            command=self._apply_adj,
+        ).pack(side="left", padx=5)
+        tk.Label(toolbar, text="API:", font=_FONT_BODY, bg=_PANEL_BG, fg=_TEXT_FG).pack(
+            side="left", padx=(10, 2)
+        )
+        self.freq_lock_api_var = ctk.StringVar(value="NVAPI")
+        self.freq_lock_api_menu = ctk.CTkOptionMenu(
+            toolbar,
+            values=["NVAPI", "NVML"],
+            variable=self.freq_lock_api_var,
+            width=84,
+            height=28,
+            anchor="center",
+            font=ct_button_font(toolbar),
+        )
+        self.freq_lock_api_menu.pack(side="left", padx=(0, 5))
+
+        # ── Bottom half: host for the autoscan section ──
+        self.autoscan_host = tk.Frame(self.frame, bg=_PANEL_BG)
+        self.autoscan_host.pack(fill="both", expand=True, padx=10, pady=(0, 10))
+
+        # ── State vars kept for logic compatibility (Point-Adj / lock UIs
+        # removed: chart drag/wheel/space covers those operations) ──
+        self.adj_start_var = ctk.StringVar(value="0")
+        self.adj_end_var = ctk.StringVar(value="0")
+        self.adj_delta_var = ctk.StringVar(value="0")
+        self.lock_point_var = ctk.StringVar(value="55")
+        self.lock_voltage_var = ctk.BooleanVar(value=False)
+        self.core_lock_min_var = ctk.StringVar(value="0")
+        self.core_lock_max_var = ctk.StringVar(value="0")
+        self.mem_lock_min_var = ctk.StringVar(value="0")
+        self.mem_lock_max_var = ctk.StringVar(value="0")
+
+    # ────────────────────────────────────────────
+    # Chart setup
+    # ────────────────────────────────────────────
+    def _build_chart_if_alive(self):
+        self._chart_build_after_id = None
+        if self._cleaned_up:
+            return
+        try:
+            if not self._chart_frame.winfo_exists():
+                return
+        except Exception:
+            return
+        # Don't import matplotlib on the UI thread while the background warm-up
+        # (font cache build) is still running — retry shortly instead.
+        mpl_ready = getattr(self.app, "_mpl_ready", None)
+        if mpl_ready is not None and not mpl_ready.is_set():
+            self._chart_build_after_id = self.app.after(100, self._build_chart_if_alive)
+            return
+        self._build_chart(self._chart_frame)
+
+    @staticmethod
+    def _get_screen_dpi_scale(widget) -> float:
+        """Return the effective DPI scaling factor of the screen hosting *widget*.
+
+        On Windows at 150% scaling the physical DPI reported by Tk is ~144.
+        We normalise against 96 (100% baseline) so the chart figure dpi
+        grows proportionally and the canvas always fills its allocated space.
+        """
+        try:
+            screen_dpi = widget.winfo_fpixels("1i")
+            if screen_dpi < 90:
+                screen_dpi = 96.0
+            return screen_dpi / 96.0
+        except Exception:
+            return 1.0
+
+    def _build_chart(self, parent: ctk.CTkFrame):
+        """Create the matplotlib figure embedded in customtkinter."""
+        if self._cleaned_up or getattr(self, "canvas", None) is not None:
+            return
+
+        # Lazy import matplotlib to avoid blocking GUI startup
+        import matplotlib
+
+        matplotlib.use("Agg")  # non-interactive backend; we blit to Tk manually
+        from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+        from matplotlib.figure import Figure
+
+        try:
+            scale = self._get_screen_dpi_scale(self.app)
+        except Exception:
+            scale = 1.0
+        fig_dpi = max(72, round(100 * scale))
+
+        self.fig = Figure(figsize=(9, 1.7), dpi=fig_dpi)
+        self.fig.patch.set_facecolor("#2b2b2b")
+        self.ax = self.fig.add_subplot(111)
+        # y tick labels are back OUTSIDE the spine — left margin fits the
+        # GHz numbers ("0.5", "1.0") plus a little headroom so the digits
+        # never kiss the frame edge
+        self.fig.subplots_adjust(left=0.062, right=0.995, top=0.92, bottom=0.12)
+        self._style_axes()
+
+        # Placeholder text
+        self.ax.text(
+            0.5,
+            0.5,
+            'Click  "Refresh Curve"  to load VF data',
+            transform=self.ax.transAxes,
+            ha="center",
+            va="center",
+            color="#888888",
+            fontsize=9,
+        )
+
+        self.canvas = FigureCanvasTkAgg(self.fig, master=parent)
+        self.canvas.get_tk_widget().pack(fill="both", expand=True)
+
+        # Allow the canvas widget to receive keyboard events
+        tk_widget = self.canvas.get_tk_widget()
+        tk_widget.configure(takefocus=True)
+        tk_widget.bind("<Enter>", lambda e: tk_widget.focus_set())
+        tk_widget.bind("<space>", self._on_space_key)
+
+        # ── Keyboard navigation bindings ──
+        tk_widget.bind("<Left>", self._on_key_left)
+        tk_widget.bind("<Right>", self._on_key_right)
+        tk_widget.bind("<Up>", self._on_key_up)
+        tk_widget.bind("<Down>", self._on_key_down)
+        # Tab / Shift-Tab  (return "break" to prevent focus from leaving canvas)
+        tk_widget.bind("<Tab>", self._on_key_tab)
+        tk_widget.bind("<Shift-Tab>", self._on_key_shift_tab)
+        # ── Mouse wheel frequency adjustment ──
+        tk_widget.bind("<MouseWheel>", self._on_mousewheel)
+        tk_widget.bind("<Button-4>", self._on_mousewheel)
+        tk_widget.bind("<Button-5>", self._on_mousewheel)
+
+        # Resize figure width when the parent frame width changes.
+        # Height is kept fixed (3.5 in) so controls below are never squeezed out.
+        self._chart_configure_bind_id = parent.bind(
+            "<Configure>", self._on_chart_resize, add="+"
+        )
+
+        # Plot line references (created on first data load)
+        self._line_current = None
+        self._line_default = None
+        self._sel_rect = None  # selection highlight
+        self._sel_points = None  # selected point markers
+        self._key_redraw_after_id = None  # deferred full redraw after key/wheel edits
+
+        # Connect mouse events
+        self._mpl_connection_ids = [
+            self.canvas.mpl_connect("button_press_event", self._on_mouse_press),
+            self.canvas.mpl_connect("button_release_event", self._on_mouse_release),
+            self.canvas.mpl_connect("motion_notify_event", self._on_mouse_move),
+        ]
+
+        # Blitting: cache the static background after every full draw so
+        # per-second live-point updates and fast curve edits only repaint
+        # their own artists (~2x cheaper than a full-figure Agg render).
+        self._blit_bg = None
+        self._mpl_connection_ids.append(
+            self.canvas.mpl_connect("draw_event", self._on_canvas_draw)
+        )
+
+        # Data may have loaded before the chart existed — draw it now.
+        if self._pending_full_redraw or self._voltages:
+            self._pending_full_redraw = False
+            self._redraw()
+
+        # The selector row couldn't pack before the chart existed (its host
+        # uses after=self._chart_area, which needs the chart area mapped).
+        self._rebuild_selector()
+
+    def _animated_artists(self):
+        """Artists managed outside the static background (blit overlay)."""
+        artists = []
+        if self._line_current is not None:
+            artists.append(self._line_current)
+        if self._sel_rect is not None:
+            artists.append(self._sel_rect)
+        if self._sel_points is not None:
+            artists.append(self._sel_points)
+        for el in self._live_elements:
+            artists.append(el)
+        return artists
+
+    def _on_canvas_draw(self, _event):
+        if self._cleaned_up or self.ax is None:
+            return
+        # Skip the post-draw overlay blit while a mouse button is held: it
+        # contends with the drag's own blit over the cached background and, if
+        # it lands in the Tcl queue ahead of a pending press, delays the click.
+        # The drag/release path re-establishes the overlay as needed.
+        if self._mouse_pressed or self._dragging:
+            return
+        try:
+            # Full draw finished: static content is in the buffer; cache it,
+            # then paint the animated artists on top (they were skipped).
+            self._blit_bg = self.canvas.copy_from_bbox(self.ax.bbox)
+            overlay_changed = False
+            for artist in self._animated_artists():
+                if getattr(artist, "get_visible", lambda: True)():
+                    self.ax.draw_artist(artist)
+                    overlay_changed = True
+            if overlay_changed:
+                self.canvas.blit(self.ax.bbox)
+        except Exception:
+            self._blit_bg = None
+
+    def _blit_animated(self):
+        """Repaint only the animated artists over the cached background."""
+        if self._blit_bg is None or self._cleaned_up:
+            self.canvas.draw_idle()  # no valid background: full redraw
+            return
+        try:
+            self.canvas.restore_region(self._blit_bg)
+            for artist in self._animated_artists():
+                if getattr(artist, "get_visible", lambda: True)():
+                    self.ax.draw_artist(artist)
+            self.canvas.blit(self.ax.bbox)
+        except Exception:
+            self._blit_bg = None
+            self.canvas.draw_idle()
+
+    def _on_chart_resize(self, event):
+        """Debounce figure width updates to avoid geometry thrash during live resize."""
+        if not hasattr(self, "fig") or not hasattr(self, "canvas"):
+            return
+        if not self._chart_frame.winfo_ismapped():
+            return
+        w_px = max(1, int(event.width))
+        if self._last_chart_event_width == w_px:
+            return
+        self._last_chart_event_width = w_px
+        self._pending_chart_resize_width = w_px
+
+        if self._is_resize_active:
+            return
+
+        if self._chart_resize_after_id is not None:
+            try:
+                self.app.after_cancel(self._chart_resize_after_id)
+            except Exception:
+                pass
+
+        self._chart_resize_after_id = self.app.after(
+            60, lambda width=w_px: self._apply_chart_resize(width)
+        )
+
+    def _apply_chart_resize(self, width_px: int):
+        self._chart_resize_after_id = None
+        self._blit_bg = None  # stale background: size changed
+        if not hasattr(self, "fig") or not hasattr(self, "canvas"):
+            return
+        if width_px <= 0 or not self._chart_frame.winfo_ismapped():
+            return
+        if (
+            self._last_chart_resize_width is not None
+            and abs(width_px - self._last_chart_resize_width) < 8
+        ):
+            return
+
+        dpi = self.fig.get_dpi()
+        new_w = max(1.0, width_px / dpi)
+        cur_w, cur_h = self.fig.get_size_inches()
+        if abs(new_w - cur_w) * dpi < 2:
+            return
+
+        self._last_chart_resize_width = width_px
+        self.fig.set_size_inches(new_w, cur_h)
+        self.canvas.draw_idle()
+
+    def _style_axes(self):
+        from matplotlib.ticker import FuncFormatter
+
+        ax = self.ax
+        ax.set_facecolor("#1e1e1e")
+        # axis labels one size smaller; ticks relabeled in V / GHz so the
+        # numbers stay short (0.5 / 0.6 / ... and 0.5 / 1 / 1.5 / ...) —
+        # plot data itself stays in mV / MHz
+        # y-axis unit caption hugs the spine's RIGHT side at the axis top
+        # (extending left would push it out of the figure)
+        ax.text(
+            0.0,
+            1.02,
+            "f/GHz",
+            transform=ax.transAxes,
+            ha="left",
+            va="bottom",
+            color="#e08020",
+            fontsize=7,
+        )
+        # one decimal on BOTH axes (0.5 / 1.0 / 1.5 ...) — uniform columns.
+        # NOTE: with a FuncFormatter attached, matplotlib regenerates tick
+        # TEXT on every draw, so the "Volt/V" unit caption must come FROM
+        # the formatter itself — a later set_text() on the label would be
+        # silently overwritten (color survives, text doesn't).
+        def x_format(v, _pos):
+            if self._volt_unit_tick is not None and v == self._volt_unit_tick:
+                return "Volt/V"
+            return f"{v / 1000.0:.1f}"
+
+        ax.xaxis.set_major_formatter(FuncFormatter(x_format))
+        ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _pos: f"{v / 1000.0:.1f}"))
+        # tick marks grow INWARD from the spines (direction="in"); the
+        # numbers stay outside, so each axis reads number + inward bar
+        ax.tick_params(colors="#cccccc", labelsize=6, direction="in")
+        for spine in ax.spines.values():
+            spine.set_color("#555555")
+        ax.grid(True, color="#333333", linewidth=0.5, alpha=0.7)
+
+    # ────────────────────────────────────────────
+    # Data loading
+    # ────────────────────────────────────────────
+
+    def _start_auto_refresh(self) -> None:
+        if self._auto_refreshing:
+            return
+        self._auto_refreshing = True
+        if self._auto_toggle_btn is not None:
+            self._auto_toggle_btn.configure(text="⏸ Pause")
+        self._schedule_next_auto_refresh()
+
+    def _stop_auto_refresh(self) -> None:
+        self._auto_refreshing = False
+        if self._auto_toggle_btn is not None:
+            self._auto_toggle_btn.configure(text="▶ Auto")
+        if self._auto_refresh_job:
+            try:
+                self.app.after_cancel(self._auto_refresh_job)
+            except Exception:
+                pass
+            self._auto_refresh_job = None
+
+    def cleanup(self) -> None:
+        """Release matplotlib resources."""
+        self._cleaned_up = True
+
+        if self._chart_build_after_id is not None:
+            try:
+                self.app.after_cancel(self._chart_build_after_id)
+            except Exception:
+                # Best-effort cleanup: callback may already be canceled or app may be shutting down.
+                pass
+            self._chart_build_after_id = None
+
+        if self._chart_resize_after_id is not None:
+            try:
+                self.app.after_cancel(self._chart_resize_after_id)
+            except Exception:
+                # Best-effort cleanup: timer may already be canceled/destroyed during teardown.
+                pass
+            self._chart_resize_after_id = None
+
+        if self._key_redraw_after_id is not None:
+            try:
+                self.app.after_cancel(self._key_redraw_after_id)
+            except Exception:
+                pass
+            self._key_redraw_after_id = None
+
+        self._stop_auto_refresh()
+        self.stop_live_poll()
+
+        if self._chart_configure_bind_id is not None:
+            try:
+                self._chart_frame.unbind("<Configure>", self._chart_configure_bind_id)
+            except Exception:
+                # Best-effort teardown: widget/bind may already be gone during shutdown.
+                pass
+            self._chart_configure_bind_id = None
+
+        canvas = getattr(self, "canvas", None)
+        for cid in self._mpl_connection_ids:
+            try:
+                if canvas is not None:
+                    canvas.mpl_disconnect(cid)
+            except Exception:
+                # Best-effort cleanup: callback may already be disconnected or canvas invalid during shutdown.
+                pass
+        self._mpl_connection_ids.clear()
+
+        self._live_elements.clear()
+        self._live_hline = None
+        self._live_vline = None
+        self._live_marker = None
+        self._live_text = None
+
+        self._line_current = None
+        self._line_default = None
+        self._sel_rect = None
+        self._sel_points = None
+
+        if canvas is not None:
+            try:
+                canvas.get_tk_widget().destroy()
+            except Exception:
+                # Best-effort cleanup: widget may already be destroyed during shutdown.
+                pass
+            try:
+                canvas._tkphoto = None
+            except Exception:
+                # Best-effort teardown: ignore backend-specific cleanup failures.
+                pass
+            self.canvas = None
+
+        fig = getattr(self, "fig", None)
+        if fig is not None:
+            try:
+                fig.clear()
+            except Exception:
+                # Best-effort cleanup: figure may already be disposed during shutdown.
+                pass
+            self.fig = None
+        self.ax = None
+
+    def _toggle_auto_refresh(self) -> None:
+        if self._auto_refreshing:
+            self._stop_auto_refresh()
+        else:
+            self._start_auto_refresh()
+
+    def _on_auto_interval_changed(self, _event: object = None) -> None:
+        try:
+            secs = float(self._auto_interval_var.get())
+            secs = max(0.2, min(60.0, secs))
+            self._auto_refresh_interval_ms = int(secs * 1000)
+            self._auto_interval_var.set(f"{secs:.1f}")
+        except ValueError:
+            self._auto_interval_var.set(f"{self._auto_refresh_interval_ms / 1000:.1f}")
+
+        if self._auto_refreshing:
+            self._schedule_next_auto_refresh()
+
+    def _schedule_next_auto_refresh(self) -> None:
+        if not self._auto_refreshing:
+            return
+        if self._auto_refresh_job:
+            try:
+                self.app.after_cancel(self._auto_refresh_job)
+            except Exception:
+                pass
+        self._auto_refresh_job = self.app.after(
+            self._auto_refresh_interval_ms, self._auto_refresh_tick
+        )
+
+    def _auto_refresh_tick(self) -> None:
+        self._auto_refresh_job = None
+        if not self._auto_refreshing:
+            return
+
+        # Skip the VFP RM-escape query during a resize drag: it is a heavier
+        # sweep than the status poll and also contends with DWM at the driver
+        # level. Re-arm; resize end re-renders from cached points.
+        if self._is_resize_active:
+            self._schedule_next_auto_refresh()
+            return
+
+        if self.app.selected_gpu_target() is None:
+            self._schedule_next_auto_refresh()
+            return
+
+        if self._refresh_curve_inflight:
+            self._schedule_next_auto_refresh()
+            return
+
+        try:
+            current_tab = self.app.tabview.get()
+            if not str(current_tab).endswith("VF Curve"):
+                self._schedule_next_auto_refresh()
+                return
+        except Exception:
+            pass
+
+        self._refresh_curve(force=True)
+
+    def _refresh_curve(self, force: bool = False):
+        """Query VFP points (public GPC + private XBAR/HOST) then load+plot.
+
+        ``force`` bypasses the 2.5 s back-to-back dedup gate — the auto-refresh
+        timer uses it so a sub-2.5 s interval (the default is 1.0 s) keeps
+        ticking instead of stalling on the gate and never rescheduling.
+        """
+        # Teardown guard: after cleanup() the matplotlib canvas/figure are
+        # gone. An inflight worker may still complete and re-arm this chain
+        # via after(0,_refresh_curve) — short-circuit instead of touching
+        # freed resources or submitting new work to a shutting-down runner.
+        if self._cleaned_up:
+            self._refresh_curve_inflight = False
+            self._refresh_curve_pending = False
+            return
+        if self._refresh_curve_inflight:
+            self._refresh_curve_pending = True
+            return
+        # A just-loaded curve is still current: skip the duplicate query
+        # when two refresh chains fire back-to-back (e.g. tab entry +
+        # post-PPAB-enable refresh). Manual/auto timer passes force=True.
+        if not force and _time.monotonic() - self._last_load_ts < 2.5:
+            return
+
+        gpu = self.app.selected_gpu_target()
+        if gpu is None:
+            self.app.console.append("[GUI] No GPU selected.\n")
+            return
+
+        self._refresh_curve_inflight = True
+        if not self._auto_refreshing:
+            self.app.console.append("[GUI] Querying VF curve via pynvoc...\n")
+
+        # Epoch guard: a newer refresh must not be overwritten by a stale one.
+        epoch = self._curve_query_epoch + 1
+        self._curve_query_epoch = epoch
+
+        def _worker():
+            gpc_points = None
+            gpc_err = None
+            clk_data = None
+            try:
+                gpc_points = self.app.backend.query_public_vftable(gpu)
+            except Exception as exc:
+                gpc_err = str(exc)
+            try:
+                clk_data = self.app.backend.query_private_vftable(gpu)
+            except Exception:
+                clk_data = None
+            self.app.after(
+                0,
+                lambda: self._on_multi_query_done(
+                    epoch, gpu, gpc_points, gpc_err, clk_data
+                ),
+            )
+
+        self.app.run_background("vfcurve-refresh", _worker)
+
+    def _on_multi_query_done(self, epoch, gpu, gpc_points, gpc_err, clk_data):
+        self._refresh_curve_inflight = False
+        # After cleanup() the figure/canvas are gone — drop the result and
+        # do NOT re-arm the refresh chain, or a late worker would re-submit
+        # into a shutting-down GuiTaskRunner (RuntimeError / join extension).
+        if self._cleaned_up:
+            self._refresh_curve_pending = False
+            return
+        # Stale worker (a newer refresh superseded this one): drop silently.
+        if epoch != self._curve_query_epoch:
+            return
+
+        public_unsupported = gpc_err is not None and (
+            "not supported" in gpc_err.lower() or "no implementation" in gpc_err.lower()
+        )
+        built = self._build_curves(
+            gpu, gpc_points, gpc_err, public_unsupported, clk_data
+        )
+        if not built:
+            if gpc_err and not public_unsupported:
+                self.app.console.append(f"[GUI] VFP query failed: {gpc_err}\n")
+            else:
+                self.app.console.append("[GUI] VFP query failed.\n")
+        else:
+            self._last_load_ts = _time.monotonic()
+            if not self._auto_refreshing:
+                cur = self._curves.get(self._active_curve)
+                n = len(cur.voltages) if cur else 0
+                self.app.console.append(
+                    f"[GUI] VF curve loaded ({n} points on {self._active_curve.upper()}).\n"
+                )
+            self._load_active_curve()
+
+        if self._refresh_curve_pending:
+            self._refresh_curve_pending = False
+            self.app.after(0, self._refresh_curve)
+        elif self._auto_refreshing:
+            self._schedule_next_auto_refresh()
+
+    def _build_curves(
+        self, gpu, gpc_points, gpc_err, public_unsupported, clk_data
+    ) -> bool:
+        """Populate ``self._curves`` from public + private reads.
+
+        Returns False when no curve could be built at all. Per-curve
+        ``write_mode`` is set so ``_apply_adj`` / reset know how to reach the
+        GPU:
+
+        * GPC via the open VFP interface and no Fixed points  → ``"public"``
+        * any private segment, or GPC with Fixed points / public unsupported
+          → ``"private"`` (apply dynamically tries mode-0 then falls back to
+          raw-converted)
+
+        Point-id ranges (seg_start/seg_end, bank) come straight from the
+        private segment structure — never hardcoded.
+        """
+        curves: Dict[str, _CurveData] = {}
+        prev_visible = self._curve_visible or {}
+
+        # ── GPC: prefer the open interface; fall back to the private GPC
+        # segment when the public one is explicitly unsupported. ──
+        gpc_curve = None
+        if gpc_points:
+            gpc_curve = _CurveData("gpc")
+            gpc_curve.source = "public"
+            gpc_curve.voltages = [p["voltage_uv"] / 1000.0 for p in gpc_points]
+            gpc_curve.frequencies = [p["frequency_khz"] / 1000.0 for p in gpc_points]
+            gpc_curve.defaults = [
+                (p.get("default_frequency_khz") or p["frequency_khz"]) / 1000.0
+                for p in gpc_points
+            ]
+            gpc_curve.has_fixed = any(
+                p.get("point_type") == "fixed" for p in gpc_points
+            )
+            gpc_curve.seg_start = 0
+            gpc_curve.seg_end = len(gpc_points) - 1 if gpc_points else 0
+            # Public family present: traditional OC unless a point is Fixed.
+            gpc_curve.write_mode = "private" if gpc_curve.has_fixed else "public"
+        elif public_unsupported:
+            # Open family rejected — the private GPC segment (if any) is the
+            # only GPC source. Located below from clk_data.
+            pass
+
+        # ── Private segments: GPC (fallback), XBAR, HOST. ──
+        private_gpc: Optional[_CurveData] = None
+        if clk_data and clk_data.get("segments"):
+            segs = clk_data["segments"]
+            pts = clk_data.get("points", [])
+            for seg in segs:
+                if seg.get("kind") != "vf_curve":
+                    continue  # pstate_bins are not curves — never plotted
+                hint = seg.get("domain", "unknown")
+                bank = int(seg.get("bank", 0))
+                s = int(seg.get("start_index", 0))
+                e = int(seg.get("end_index", s))
+                seg_pts = [
+                    p
+                    for p in pts
+                    if int(p.get("bank", 0)) == bank
+                    and s <= int(p.get("index", -1)) <= e
+                ]
+                if not seg_pts:
+                    continue
+                cd = _CurveData(hint if hint in _CURVE_COLORS else "gpc")
+                cd.source = "private"
+                cd.bank = bank
+                cd.seg_start = s
+                cd.seg_end = e
+                cd.voltages = [p["voltage_uV"] / 1000.0 for p in seg_pts]
+                cd.frequencies = [p["freq_current_mhz"] for p in seg_pts]
+                cd.defaults = [p["freq_default_mhz"] for p in seg_pts]
+                cd.write_mode = "private"
+                if cd.curve_id == "gpc":
+                    private_gpc = cd
+                elif cd.curve_id in _CURVE_COLORS:
+                    curves[cd.curve_id] = cd
+                # unknown domains are skipped (only gpc/xbar/host displayed)
+
+        # Resolve GPC source: public preferred, private fallback.
+        if gpc_curve is not None:
+            curves["gpc"] = gpc_curve
+        elif private_gpc is not None:
+            curves["gpc"] = private_gpc
+
+        if not curves:
+            self._curves = {}
+            self._curve_visible = {}
+            return False
+
+        # Carry over visibility (default: every discovered curve visible), and
+        # keep the active curve valid (fallback to first visible).
+        self._curves = curves
+        self._curve_visible = {cid: prev_visible.get(cid, True) for cid in curves}
+        if (
+            not self._curve_visible.get(self._active_curve)
+            or self._active_curve not in curves
+        ):
+            self._active_curve = next(
+                (cid for cid in curves if self._curve_visible.get(cid)), "gpc"
+            )
+        return True
+
+    def _load_active_curve(self):
+        """灌 active curve 数据进 _voltages/_frequencies/_defaults 并重绘。
+
+        Keeps the legacy single-curve attributes as a live view of the active
+        curve so all existing call sites (drag/keyboard/lock/dashboard/tests)
+        keep working. Also rebuilds the per-curve selector row.
+        """
+        curve = self._curves.get(self._active_curve)
+        if curve is None:
+            return
+        # Refresh only the active curve's data identity check (auto-refresh
+        # short-circuit) before assigning.
+        if (
+            curve.voltages == self._voltages
+            and curve.frequencies == self._frequencies
+            and curve.defaults == self._defaults
+            and not getattr(self, "_pending_lock_mv", None)
+            and len(self._curves) <= 1
+        ):
+            # Single-curve no-op fast path (auto-refresh identity tick).
+            pass
+        self._voltages = curve.voltages
+        self._frequencies = curve.frequencies
+        self._defaults = curve.defaults
+        self._drag_orig_freqs = None
+        # Sync the curve's mutated frequencies back (same list refs, no-op).
+        self._rebuild_selector()
+        self._apply_curve_data(curve.voltages, curve.frequencies, curve.defaults)
+
+    def _switch_active_curve(self, curve_id: str):
+        """Select which curve drag/keyboard/apply target — point on rect btn."""
+        if curve_id not in self._curves or curve_id == self._active_curve:
+            return
+        if not self._curve_visible.get(curve_id):
+            return  # activating a hidden curve makes no sense
+        self._active_curve = curve_id
+        curve = self._curves[curve_id]
+        self._sel_start = None
+        self._sel_end = None
+        self._drag_orig_freqs = None
+        self._voltages = curve.voltages
+        self._frequencies = curve.frequencies
+        self._defaults = curve.defaults
+        self._rebuild_selector()
+        self._redraw()
+        # Live-point handoff: when leaving GPC the dashboard-fed (volt,freq)
+        # is stale; clear it and let the direct-read path repopulate for
+        # xbar/host. When switching back to GPC, clear so the dashboard poll's
+        # next tick refills it (don't show an xbar freq on the GPC curve).
+        self._live_pending = (None, None)
+        self._live_volt = None
+        self._live_freq = None
+        self._hide_live_point()
+        if curve_id in ("xbar", "host") and not self._direct_read_inflight:
+            self._kick_direct_read(curve_id)
+        self.app.console.append(
+            f"[GUI] Active curve: {curve_id.upper()} "
+            f"({curve.source}, {curve.write_mode}).\n"
+        )
+
+    def _toggle_curve_visible(self, curve_id: str):
+        """Toggle a curve's visibility (checkbox). Hidden curves are not drawn
+        and not queried on refresh. Always keeps at least the active curve
+        visible."""
+        if curve_id not in self._curves:
+            return
+        if self._curve_visible.get(curve_id) and curve_id == self._active_curve:
+            # Don't allow hiding the only visible / active curve.
+            visible_count = sum(1 for v in self._curve_visible.values() if v)
+            if visible_count <= 1:
+                return
+        self._curve_visible[curve_id] = not self._curve_visible.get(curve_id, True)
+        # If the hidden curve was feeding the live point (GPC via dashboard, or
+        # xbar/host via direct read), clear the crosshair so a hidden curve is
+        # never polled/drawn — including GPC.
+        if not self._curve_visible.get(curve_id):
+            if curve_id == "gpc":
+                # Stop accepting the dashboard feed until GPC is active again.
+                self._live_pending = (None, None)
+            if curve_id == self._active_curve:
+                self._live_volt = None
+                self._live_freq = None
+                self._pending_live_point = None
+        if not self._curve_visible.get(self._active_curve):
+            self._active_curve = next(
+                (c for c, v in self._curve_visible.items() if v), self._active_curve
+            )
+            curve = self._curves.get(self._active_curve)
+            if curve is not None:
+                self._voltages = curve.voltages
+                self._frequencies = curve.frequencies
+                self._defaults = curve.defaults
+                self._sel_start = None
+                self._sel_end = None
+                self._drag_orig_freqs = None
+            # New active curve's live point starts fresh; kick a direct read
+            # immediately if it's xbar/host (GPC will be refed by dashboard).
+            self._live_pending = (None, None)
+            self._live_volt = None
+            self._live_freq = None
+            self._hide_live_point()
+            if (
+                self._active_curve in ("xbar", "host")
+                and not self._direct_read_inflight
+            ):
+                self._kick_direct_read(self._active_curve)
+        self._rebuild_selector()
+        self._redraw()
+
+    def _rebuild_selector(self):
+        """Rebuild the per-curve selector row (rect buttons + checkboxes).
+
+        Only shown when more than one curve was discovered. Each curve gets a
+        rectangular button: clicking the box toggles visibility, clicking the
+        button body activates that curve for drag/keyboard/apply.
+        """
+        if getattr(self, "_chart_frame", None) is None or self._cleaned_up:
+            return
+        host = getattr(self, "_curve_selector_host", None)
+        if host is None:
+            return  # UI not built yet (selector host created in _build_chart)
+        for child in host.winfo_children():
+            child.destroy()
+        self._curve_selector_btns = {}
+        curves = list(self._curves.items())
+        if len(curves) <= 1:
+            host.pack_forget()
+            return
+        host.pack(fill="x", padx=10, pady=(2, 6), after=self._chart_area)
+        for cid, curve in curves:
+            btn = tk.Frame(
+                host,
+                bg=_PANEL_BG,
+                highlightthickness=2,
+                highlightcolor=_CURVE_COLORS[cid]["current"],
+                highlightbackground="#444444",
+                bd=0,
+            )
+            btn.pack(side="left", padx=6)
+            # Checkbox (left): toggles visibility. Stops propagation so the
+            # outer button's <Button-1> (activate) doesn't also fire.
+            var = tk.BooleanVar(value=self._curve_visible.get(cid, True))
+            ckb = ctk.CTkCheckBox(
+                btn,
+                text="",
+                variable=var,
+                width=20,
+                height=20,
+                command=lambda c=cid, v=var: self._on_selector_checkbox(c, v),
+            )
+            ckb.pack(side="left", padx=(4, 2), pady=4)
+            # Label (right): curve name + active indicator.
+            colors = _CURVE_COLORS[cid]
+            active = cid == self._active_curve
+            label_text = _CURVE_META[cid]["label"]
+            lbl = tk.Label(
+                btn,
+                text=label_text,
+                font=_FONT_BODY,
+                bg=_PANEL_BG,
+                fg=colors["current"],
+            )
+            lbl.pack(side="left", padx=(0, 6))
+            if active:
+                lbl.config(font=("Segoe UI", 11, "bold"))
+                btn.config(highlightbackground=colors["current"])
+            # Click anywhere on the button body (not the checkbox) activates.
+            btn.bind("<Button-1>", lambda e, c=cid: self._switch_active_curve(c))
+            lbl.bind("<Button-1>", lambda e, c=cid: self._switch_active_curve(c))
+            self._curve_selector_btns[cid] = btn
+
+    def _on_selector_checkbox(self, curve_id: str, var: tk.BooleanVar):
+        # The checkbox already toggled `var`. Route through the canonical
+        # toggle path so the "can't hide the only visible curve" guard and
+        # live-point clearing (no crosshair for hidden curves, incl. GPC) are
+        # applied consistently. If the guard vetoes, restore the checkbox.
+        before = self._curve_visible.get(curve_id, True)
+        self._toggle_curve_visible(curve_id)
+        if self._curve_visible.get(curve_id, True) == before:
+            var.set(before)  # vetoed (only-visible guard) — snap checkbox back
+
+    @staticmethod
+    def _write_vfp_points(path: str, points: List[dict]) -> None:
+        write_vfp_points(path, points)
+
+    @staticmethod
+    def _load_vfp_deltas(
+        path: str, reference_points: List[dict]
+    ) -> List[Tuple[int, int]]:
+        return load_vfp_deltas(path, reference_points)
+
+    def _load_points(self, points: List[dict]):
+        """Load VFP points (pynvoc dicts, µV/kHz) and redraw the chart.
+
+        Legacy single-curve entry — used by tests and any caller that hands a
+        flat public point list. Rebuilds a GPC-only curve set.
+        """
+        gpc = _CurveData("gpc")
+        gpc.source = "public"
+        for p in points:
+            gpc.voltages.append(p["voltage_uv"] / 1000.0)
+            freq_mhz = p["frequency_khz"] / 1000.0
+            gpc.frequencies.append(freq_mhz)
+            default_khz = p.get("default_frequency_khz")
+            gpc.defaults.append(
+                freq_mhz if default_khz is None else default_khz / 1000.0
+            )
+            if p.get("point_type") == "fixed":
+                gpc.has_fixed = True
+        gpc.write_mode = "private" if gpc.has_fixed else "public"
+        gpc.seg_end = len(points) - 1 if points else 0
+        self._curves = {"gpc": gpc}
+        self._curve_visible = {"gpc": True}
+        self._active_curve = "gpc"
+        self._voltages = gpc.voltages
+        self._frequencies = gpc.frequencies
+        self._defaults = gpc.defaults
+        self._apply_curve_data(gpc.voltages, gpc.frequencies, gpc.defaults)
+
+    def _load_csv(self, path: str):
+        """Parse CSV (Import button) and redraw chart."""
+        if not os.path.isfile(path):
+            self.app.console.append(f"[GUI] CSV not found: {path}\n")
+            return
+
+        voltages = []
+        frequencies = []
+        defaults = []
+
+        try:
+            with open(path, newline="", encoding="utf-8-sig") as f:
+                reader = csv.reader(f)
+                for row in reader:
+                    if not row or row[0].startswith("#"):
+                        continue
+                    # Detect header row
+                    if row[0].strip().lower() == "voltage":
+                        continue
+                    try:
+                        v = float(row[0])  # µV
+                        freq = float(row[1])  # kHz
+                        # delta in row[2]
+                        default = float(row[3]) if len(row) > 3 else freq
+                    except (ValueError, IndexError):
+                        continue
+                    # Convert: CSV values are in µV / kHz → display as mV / MHz
+                    voltages.append(v / 1000.0)  # µV → mV
+                    frequencies.append(freq / 1000.0)  # kHz → MHz
+                    defaults.append(default / 1000.0)
+        except Exception as e:
+            self.app.console.append(f"[GUI] Error reading CSV: {e}\n")
+            return
+
+        if (
+            voltages == self._voltages
+            and frequencies == self._frequencies
+            and defaults == self._defaults
+            and getattr(self, "_pending_lock_mv", None) is None
+        ):
+            return
+
+        self._apply_curve_data(voltages, frequencies, defaults)
+
+    def _apply_curve_data(
+        self,
+        voltages: List[float],
+        frequencies: List[float],
+        defaults: List[float],
+    ):
+        """Store curve data (mV/MHz), resolve pending lock, and redraw."""
+        previous_selection = (
+            (self._sel_start, self._sel_end)
+            if self._sel_start is not None and self._sel_end is not None
+            else None
+        )
+
+        self._voltages = voltages
+        self._frequencies = frequencies
+        self._defaults = defaults
+        self._sel_start = None
+        self._sel_end = None
+        self._drag_orig_freqs = None
+        if previous_selection is not None and voltages:
+            max_idx = len(voltages) - 1
+            start, end = previous_selection
+            self._sel_start = max(0, min(start, max_idx))
+            self._sel_end = max(0, min(end, max_idx))
+            self._sync_selection_to_adj()
+
+        # Apply any pending lock set before data was loaded
+        pending_mv = getattr(self, "_pending_lock_mv", None)
+        if pending_mv is not None:
+            self._pending_lock_mv = None
+            idx = self._find_closest_voltage_idx(pending_mv)
+            if idx is not None:
+                self._locked_points.clear()
+                self._locked_points.add(idx)
+                self.app.console.append(
+                    f"[GUI] Lock synced → point {idx} ({self._voltages[idx]:.1f} mV).\n"
+                )
+
+        # Check whether VF offsets are present and whether all points share one uniform offset.
+        has_vfp_offset, uniform_core_offset_mhz = analyze_vfp_offsets(
+            frequencies, defaults
+        )
+        apply_vfp_state = getattr(self.app, "_apply_vfp_offset_state", None)
+        if callable(apply_vfp_state):
+            apply_vfp_state(has_vfp_offset, uniform_core_offset_mhz)
+        elif getattr(self.app, "tab_overclock", None):
+            self.app.tab_overclock.set_vfp_state(
+                has_vfp_offset, uniform_core_offset_mhz
+            )
+
+        self.app.console.append(f"[GUI] Loaded {len(voltages)} VF points.\n")
+        self._redraw()
+
+    def _redraw(self):
+        """Redraw the chart with current data."""
+        if self._is_resize_active:
+            self._pending_full_redraw = True
+            return
+        if getattr(self, "ax", None) is None:
+            # Chart not built yet — retry once it is (build flushes pending).
+            self._pending_full_redraw = True
+            return
+
+        ax = self.ax
+        ax.clear()
+        self._style_axes()
+
+        if not self._voltages:
+            ax.text(
+                0.5,
+                0.5,
+                "No data",
+                transform=ax.transAxes,
+                ha="center",
+                va="center",
+                color="#888888",
+                fontsize=12,
+            )
+            self.canvas.draw_idle()
+            return
+
+        v = self._voltages
+        f = self._frequencies
+        d = self._defaults
+
+        # ── Draw every visible curve ──
+        # Non-active curves are static (baked into the cached background);
+        # the active curve's current line is animated (animated=True) so the
+        # drag/keyboard/wheel fast-edit path can blit just it.
+        self._curve_lines = {}
+        active_colors = _CURVE_COLORS.get(self._active_curve, _CURVE_COLORS["gpc"])
+        active_label = _CURVE_META.get(self._active_curve, _CURVE_META["gpc"])["label"]
+
+        # Non-active visible curves first (lower zorder, static).
+        for cid, curve in self._curves.items():
+            if cid == self._active_curve:
+                continue
+            if not self._curve_visible.get(cid):
+                continue
+            colors = _CURVE_COLORS.get(cid, _CURVE_COLORS["gpc"])
+            lbl = _CURVE_META.get(cid, {"label": cid.upper()})["label"]
+            ax.plot(
+                curve.voltages,
+                curve.defaults,
+                color=colors["default"],
+                linestyle="--",
+                linewidth=0.9,
+                label=f"{lbl} Default",
+                zorder=2,
+            )
+            (line_cur,) = ax.plot(
+                curve.voltages,
+                curve.frequencies,
+                color=colors["current"],
+                linestyle="-",
+                linewidth=1.1,
+                marker="s",
+                markersize=0.9,
+                markerfacecolor=colors["current"],
+                markeredgecolor=colors["current"],
+                label=f"{lbl} Current",
+                zorder=3,
+            )
+            self._curve_lines[cid] = {"current": line_cur, "default": None}
+
+        # Active curve (default dashed + current solid+marker, animated).
+        (self._line_default,) = ax.plot(
+            v,
+            d,
+            color=active_colors["default"],
+            linestyle="--",
+            linewidth=0.9,
+            label=f"{active_label} Default",
+            zorder=2,
+        )
+        (self._line_current,) = ax.plot(
+            v,
+            f,
+            color=active_colors["current"],
+            linestyle="-",
+            linewidth=1.1,
+            marker="s",
+            markersize=0.9,
+            markerfacecolor=active_colors["current"],
+            markeredgecolor=active_colors["current"],
+            label=f"{active_label} Current",
+            zorder=4,
+            animated=True,
+        )
+        self._curve_lines[self._active_curve] = {
+            "current": self._line_current,
+            "default": self._line_default,
+        }
+
+        # Selection highlight
+        if self._sel_start is not None and self._sel_end is not None:
+            s = min(self._sel_start, self._sel_end)
+            e = max(self._sel_start, self._sel_end)
+            sel_v = v[s : e + 1]
+            sel_f = f[s : e + 1]
+
+            # Shaded region — persistent animated artist so selection-range
+            # drags can update just the span (voltage-axis only, independent
+            # of the moving curve points) via _update_selection_span without
+            # a full _redraw. Re-created here on each full redraw.
+            self._sel_rect = ax.axvspan(
+                v[s], v[e], alpha=0.15, color="#ffcc00", zorder=1, animated=True
+            )
+
+            # Highlighted points
+            self._sel_points = ax.scatter(
+                sel_v,
+                sel_f,
+                color="#ffcc00",
+                s=14,
+                zorder=5,
+                edgecolors="#ff8800",
+                linewidths=0.6,
+                animated=True,
+            )
+
+            # ── Info popup (right side of axes) ──
+            if s == e:
+                # Single point: show V / default F / current F / ΔF vs default
+                cur_f = f[s]
+                ref_f = d[s]
+                delta = cur_f - ref_f
+                sign = "+" if delta >= 0 else ""
+                info = (
+                    f"  idx : {s}\n"
+                    f"  V   : {v[s]:.1f} mV\n"
+                    f"  F   : {cur_f:.1f} MHz\n"
+                    f"  dF  : {ref_f:.1f} MHz (default)\n"
+                    f"  ΔF  : {sign}{delta:.1f} MHz  "
+                )
+            else:
+                # Range: show idx range / V range / ΔF avg vs default
+                deltas = [f[i] - d[i] for i in range(s, e + 1)]
+                avg_delta = sum(deltas) / len(deltas)
+                sign = "+" if avg_delta >= 0 else ""
+                info = (
+                    f"  idx : {s} – {e}  ({e - s + 1} pts)\n"
+                    f"  V   : {v[s]:.1f} ~ {v[e]:.1f} mV\n"
+                    f"  ΔF  : {sign}{avg_delta:.1f} MHz (avg vs default)  "
+                )
+
+            ax.text(
+                0.99,
+                0.03,
+                info,
+                transform=ax.transAxes,
+                ha="right",
+                va="bottom",
+                fontsize=6.5,
+                fontfamily="monospace",
+                color="#ffe066",
+                zorder=10,
+                bbox=dict(
+                    boxstyle="round,pad=0.4",
+                    facecolor="#1a1a1a",
+                    edgecolor="#ffcc00",
+                    alpha=0.88,
+                    linewidth=0.8,
+                ),
+            )
+        else:
+            self._sel_points = None
+
+        ax.legend(
+            loc="upper left",
+            fontsize=6,
+            framealpha=0.5,
+            facecolor="#2b2b2b",
+            edgecolor="#555555",
+            labelcolor="#cccccc",
+        )
+
+        # Draw crosshairs for locked points
+        for idx in self._locked_points:
+            if 0 <= idx < len(v):
+                lv = v[idx]
+                lf = f[idx]
+                crosshair_kw = dict(
+                    color="#ff4444", linewidth=1.0, linestyle="--", alpha=0.85
+                )
+                ax.axvline(x=lv, zorder=6.5, **crosshair_kw)
+                ax.axhline(y=lf, zorder=5.5, **crosshair_kw)
+                # Center marker
+                ax.plot(
+                    lv,
+                    lf,
+                    marker="+",
+                    markersize=8,
+                    color="#ff4444",
+                    markeredgewidth=1.2,
+                    zorder=7.5,
+                    linestyle="none",
+                )
+                # Label - Using ASCII [L] instead of emoji to avoid UserWarning/Glyph missing issues
+                ax.annotate(
+                    f"Locked: {idx}",
+                    xy=(lv, lf),
+                    xytext=(6, 6),
+                    textcoords="offset points",
+                    color="#ff8888",
+                    fontsize=5,
+                    zorder=8,
+                )
+
+        # Axis range with some padding — span every visible curve so all fit.
+        v_min, v_max = min(v), max(v)
+        f_vals = list(f) + list(d)
+        for cid, curve in self._curves.items():
+            if cid == self._active_curve or not self._curve_visible.get(cid):
+                continue
+            if curve.voltages:
+                v_min = min(v_min, min(curve.voltages))
+                v_max = max(v_max, max(curve.voltages))
+            f_vals += list(curve.frequencies) + list(curve.defaults)
+        f_min, f_max = min(f_vals), max(f_vals) if f_vals else (0, 1)
+
+        # Adjust Y limits if freq lock is outside default range
+        if self._freq_core_lock is not None:
+            cmin, cmax = self._freq_core_lock
+            f_min = min(f_min, cmin)
+            f_max = max(f_max, cmax)
+
+        f_pad = max(150, (f_max - f_min) * 0.18)
+        ax.set_xlim(v_min - 1, v_max + 1)
+        ax.set_ylim(f_min - f_pad, f_max + f_pad)
+        # the LAST VISIBLE voltage tick number gives its slot to the unit
+        # caption — the raw tick list can end beyond xlim (e.g. a 1.3 tick
+        # past a 1.24 V max), so pick the last tick inside the view. Only
+        # stash the tick VALUE here: the formatter (see _style_axes) turns
+        # it into "Volt/V" at draw time; set_text would be overwritten.
+        self._volt_unit_tick = None
+        xlim = ax.get_xlim()
+        for tick in reversed(ax.get_xticks()):
+            if xlim[0] <= tick <= xlim[1]:
+                self._volt_unit_tick = tick
+                for label in ax.get_xticklabels():
+                    if label.get_position()[0] == tick:
+                        # match the f/GHz caption: orange, one size up from
+                        # the plain tick digits (survives formatter redraws
+                        # — only the TEXT is regenerated, not style)
+                        label.set_color("#e08020")
+                        label.set_fontsize(7)
+                break
+
+        # Draw frequency lock visualization (after limits are known)
+        if self._freq_core_lock is not None:
+            cmin, cmax = self._freq_core_lock
+            if cmin == cmax:
+                ax.axhline(
+                    y=cmin,
+                    color="#ffff00",
+                    linewidth=1.5,
+                    linestyle="-",
+                    alpha=0.6,
+                    zorder=4.5,
+                )
+                ax.text(
+                    v_min,
+                    cmin + (f_max - f_min) * 0.015,
+                    f" Freq Lock: {cmin} MHz",
+                    color="#ffff00",
+                    fontsize=7,
+                    alpha=0.8,
+                    zorder=5,
+                )
+            else:
+                ax.axhspan(cmin, cmax, color="#ffff00", alpha=0.15, zorder=1.5)
+                ax.axhline(
+                    y=cmin,
+                    color="#ffff00",
+                    linewidth=1.0,
+                    linestyle="--",
+                    alpha=0.5,
+                    zorder=4.5,
+                )
+                ax.axhline(
+                    y=cmax,
+                    color="#ffff00",
+                    linewidth=1.0,
+                    linestyle="--",
+                    alpha=0.5,
+                    zorder=4.5,
+                )
+                ax.text(
+                    v_min,
+                    cmax + (f_max - f_min) * 0.015,
+                    f" Freq Lock: {cmin}-{cmax} MHz",
+                    color="#ffff00",
+                    fontsize=7,
+                    alpha=0.8,
+                    zorder=5,
+                )
+
+        # Keep margins in sync with _create_chart (see the note there) —
+        # re-applying the old 0.13 here would re-create the left gutter
+        self.fig.subplots_adjust(left=0.062, right=0.995, top=0.92, bottom=0.12)
+
+        self._live_elements.clear()
+        self._live_hline = None
+        self._live_vline = None
+        self._live_marker = None
+        self._live_text = None
+        self._draw_live_point(call_draw_idle=False)
+        self.canvas.draw_idle()
+
+    # ────────────────────────────────────────────
+    # Mouse interaction
+    # ────────────────────────────────────────────
+    def _find_nearest_index(self, x_data: float) -> Optional[int]:
+        """Find the index of the VF point closest to x_data (mV)."""
+        if not self._voltages:
+            return None
+        arr = self._np().array(self._voltages)
+        idx = int(self._np().argmin(self._np().abs(arr - x_data)))
+        return idx
+
+    def _on_mouse_press(self, event):
+        if event.inaxes != self.ax or not self._voltages:
+            return
+
+        if event.button == 1:  # Left click = start selection / drag
+            self._mouse_pressed = True
+            idx = self._find_nearest_index(event.xdata)
+            if idx is None:
+                return
+
+            # If click inside existing selection → start drag
+            if self._sel_start is not None and self._sel_end is not None:
+                s = min(self._sel_start, self._sel_end)
+                e = max(self._sel_start, self._sel_end)
+                if s <= idx <= e:
+                    self._dragging = True
+                    self._drag_start_y = event.ydata
+                    self._drag_orig_freqs = self._np().array(
+                        self._frequencies, dtype=float
+                    )
+                    return
+
+            # Otherwise start new selection
+            self._sel_start = idx
+            self._sel_end = idx
+            self._dragging = False
+            self._redraw()
+
+        elif event.button == 3:  # Right click = clear selection
+            self._clear_selection()
+
+    def _on_mouse_release(self, event):
+        if event.button == 1:
+            if self._mouse_pressed:
+                self._mouse_pressed = False
+                # Apply any live-point update deferred during the interaction
+                # (the dashboard poll's crosshair blit would otherwise contend
+                # with the drag's blit over the cached background).
+                self._flush_pending_live_point()
+            if self._dragging:
+                self._dragging = False
+                self._drag_start_y = None
+                # Keep drag_orig_freqs for undo
+                self._redraw()
+                self._sync_selection_to_adj()
+                return
+
+            if event.inaxes != self.ax or not self._voltages:
+                return
+
+            idx = self._find_nearest_index(event.xdata)
+            if idx is not None and self._sel_start is not None:
+                self._sel_end = idx
+                self._redraw()
+                self._sync_selection_to_adj()
+
+    def _on_mouse_move(self, event):
+        if not self._voltages:
+            return
+
+        if (
+            self._dragging
+            and event.inaxes == self.ax
+            and self._drag_start_y is not None
+        ):
+            # Drag selected points up/down
+            dy = event.ydata - self._drag_start_y  # MHz
+            s = min(self._sel_start, self._sel_end)
+            e = max(self._sel_start, self._sel_end)
+
+            for i in range(s, e + 1):
+                self._frequencies[i] = float(self._drag_orig_freqs[i]) + dy
+
+            # Update only the line data for performance
+            if self._line_current is not None:
+                self._line_current.set_ydata(self._frequencies)
+            if self._sel_points is not None:
+                sel_f = self._frequencies[s : e + 1]
+                offsets = self._np().column_stack([self._voltages[s : e + 1], sel_f])
+                self._sel_points.set_offsets(offsets)
+            self._blit_animated()
+            return
+
+        # Selection drag (extending selection while mouse button held). The
+        # range is voltage-axis only, so update just the span overlay + blit —
+        # no full _redraw, keeping the selection smooth and immune to the
+        # per-second live-point blit. Point markers update on release.
+        if (
+            event.button == 1
+            and event.inaxes == self.ax
+            and self._sel_start is not None
+            and not self._dragging
+        ):
+            idx = self._find_nearest_index(event.xdata)
+            if idx is not None and idx != self._sel_end:
+                self._sel_end = idx
+                self._update_selection_span()
+
+    def sync_lock_from_voltage(self, voltage_mv: Optional[float]):
+        """Called at startup: sync VFP lock state from CLI into _locked_points.
+
+        Args:
+            voltage_mv: locked voltage in mV, or None if not locked.
+        """
+        self._locked_points.clear()
+        self._pending_lock_mv: Optional[float] = None
+
+        if voltage_mv is None:
+            return
+
+        if self._voltages:
+            # Data already loaded — find closest point immediately
+            idx = self._find_closest_voltage_idx(voltage_mv)
+            if idx is not None:
+                self._locked_points.add(idx)
+                self.app.console.append(
+                    f"[GUI] Lock synced → point {idx} ({self._voltages[idx]:.1f} mV).\n"
+                )
+                self._redraw()
+        else:
+            # Data not yet loaded — store pending voltage, applied in _load_csv
+            self._pending_lock_mv = voltage_mv
+
+    def sync_freq_locks_from_cache(self, limits: Optional[dict]):
+        """Sync frequency core/memory lock values from the app cache into UI controls."""
+        limits = limits or {}
+
+        def _to_int(value: object) -> Optional[int]:
+            try:
+                return int(str(value).strip())
+            except (TypeError, ValueError):
+                return None
+
+        core_min = _to_int(limits.get("vfp_lock_gpu_core_lowerbound_mhz"))
+        core_max = _to_int(limits.get("vfp_lock_gpu_core_upperbound_mhz"))
+        mem_min = _to_int(limits.get("vfp_lock_memory_lowerbound_mhz"))
+        mem_max = _to_int(limits.get("vfp_lock_memory_upperbound_mhz"))
+
+        if core_min is not None and core_max is not None and core_min > core_max:
+            core_min, core_max = core_max, core_min
+        if mem_min is not None and mem_max is not None and mem_min > mem_max:
+            mem_min, mem_max = mem_max, mem_min
+
+        new_core_lock = (
+            (core_min, core_max)
+            if core_min is not None and core_max is not None
+            else None
+        )
+        new_mem_lock = (
+            (mem_min, mem_max) if mem_min is not None and mem_max is not None else None
+        )
+        new_core_backend = "nvapi" if new_core_lock is not None else None
+        new_mem_backend = "nvapi" if new_mem_lock is not None else None
+        changed = (
+            new_core_lock != self._freq_core_lock
+            or new_core_backend != self._freq_core_lock_backend
+            or new_mem_lock != self._freq_mem_lock
+            or new_mem_backend != self._freq_mem_lock_backend
+        )
+
+        self._freq_core_lock = new_core_lock
+        self._freq_mem_lock = new_mem_lock
+        self._freq_core_lock_backend = new_core_backend
+        self._freq_mem_lock_backend = new_mem_backend
+        self.app._dashboard_gpu_lock_active = new_core_lock is not None
+        self.app._dashboard_mem_lock_active = new_mem_lock is not None
+        self.core_lock_min_var.set(str(core_min if core_min is not None else 0))
+        self.core_lock_max_var.set(str(core_max if core_max is not None else 0))
+        self.mem_lock_min_var.set(str(mem_min if mem_min is not None else 0))
+        self.mem_lock_max_var.set(str(mem_max if mem_max is not None else 0))
+
+        if changed and hasattr(self, "ax") and hasattr(self, "canvas"):
+            self._redraw()
+
+    def _find_closest_voltage_idx(self, voltage_mv: float) -> Optional[int]:
+        """Return the index of the VF point closest to the given voltage (mV)."""
+        if not self._voltages:
+            return None
+        best_idx = 0
+        best_dist = abs(self._voltages[0] - voltage_mv)
+        for i, v in enumerate(self._voltages):
+            d = abs(v - voltage_mv)
+            if d < best_dist:
+                best_dist = d
+                best_idx = i
+        return best_idx
+
+    def _resolve_vfp_lock_idx_from_input(self) -> Optional[int]:
+        """Resolve the lock panel input to a point index for UI updates."""
+        raw_value = self.lock_point_var.get().strip()
+        if not raw_value:
+            self.app.console.append("[GUI] No lock point specified.\n")
+            return None
+
+        try:
+            if self.lock_voltage_var.get():
+                voltage_mv = float(raw_value)
+                idx = self._find_closest_voltage_idx(voltage_mv)
+                if idx is None:
+                    self.app.console.append(
+                        "[GUI] No VF points loaded to resolve lock voltage.\n"
+                    )
+                    return None
+                return idx
+
+            idx = int(raw_value)
+        except ValueError:
+            mode = "voltage" if self.lock_voltage_var.get() else "index"
+            self.app.console.append(f"[GUI] Invalid lock {mode} value: {raw_value}\n")
+            return None
+
+        if not self._voltages:
+            return idx
+        if 0 <= idx < len(self._voltages):
+            return idx
+
+        self.app.console.append(f"[GUI] Lock point index out of range: {idx}\n")
+        return None
+
+    def _apply_vfp_lock_ui(self, idx: Optional[int]):
+        """Update UI state after a successful VFP point lock."""
+        self._clear_core_freq_lock_ui()
+        self._locked_points.clear()
+        if idx is not None:
+            self._locked_points.add(idx)
+        self._redraw()
+
+    def _apply_vfp_unlock_ui(self):
+        """Update UI state after a successful VFP unlock."""
+        self._locked_points.clear()
+        self._redraw()
+
+    def update_live_point(self, volt_mv: Optional[float], freq_mhz: Optional[float]):
+        """Update the real-time crosshair overlay for the current operating point."""
+        if self._cleaned_up:
+            return
+        self._live_volt = volt_mv
+        self._live_freq = freq_mhz
+        if (
+            self._is_resize_active
+            or self._mouse_pressed
+            or not self._chart_should_draw()
+        ):
+            self._pending_live_point = (volt_mv, freq_mhz)
+            return
+        self._draw_live_point()
+
+    def _flush_pending_live_point(self):
+        """Apply a deferred live-point update after resize/interaction ends."""
+        if self._pending_live_point is None:
+            return
+        self._live_volt, self._live_freq = self._pending_live_point
+        self._pending_live_point = None
+        if self._chart_should_draw():
+            self._draw_live_point()
+
+    # ── Live crosshair poller (independent of the dashboard poll) ──
+    _LIVE_POLL_MS = 1000
+
+    def set_live_pending(
+        self, volt_mv: Optional[float], freq_mhz: Optional[float]
+    ) -> None:
+        """Thread-safe sink for volt/freq from a background poll worker.
+
+        The dashboard poll feeds the crosshair through this instead of
+        scheduling an after(0) blit, so its completion cannot interpose a
+        blit ahead of a mouse-press in the Tcl event queue (which delayed
+        the first click on the curve). The live timer below drains it.
+
+        This feed is GPC-only (the dashboard polls gpu_clock / voltage for the
+        graphics domain). Accept it only when GPC is the active AND visible
+        curve — otherwise it would pollute the live point with GPC freq while
+        the user is looking at an XBAR/HOST curve (whose freq comes from the
+        direct-read path), and it would keep "polling" a GPC crosshair the user
+        has unchecked. XBAR/HOST live data is pushed here by the direct-read
+        completion callback instead.
+        """
+        if self._active_curve != "gpc" or not self._curve_visible.get("gpc"):
+            return
+        self._live_pending = (volt_mv, freq_mhz)
+
+    def start_live_poll(self) -> None:
+        """Begin the low-cadence crosshair refresh (VF Curve tab active)."""
+        if self._live_poll_job is None:
+            self._live_poll_job = self.app.after(
+                self._LIVE_POLL_MS, self._live_poll_tick
+            )
+
+    def stop_live_poll(self) -> None:
+        if self._live_poll_job is not None:
+            try:
+                self.app.after_cancel(self._live_poll_job)
+            except Exception:
+                pass
+            self._live_poll_job = None
+
+    def _live_poll_tick(self) -> None:
+        self._live_poll_job = None
+        if self._cleaned_up:
+            return
+        # Only the active+visible curve gets a live-point crosshair. A curve
+        # that's unchecked (not visible) is never polled — including GPC, whose
+        # dashboard feed is gated in set_live_pending. The active curve is
+        # always visible by construction, but guard anyway.
+        if not self._curve_visible.get(self._active_curve):
+            self._live_volt = None
+            self._live_freq = None
+            self._hide_live_point()
+            self._live_poll_job = self.app.after(
+                self._LIVE_POLL_MS, self._live_poll_tick
+            )
+            return
+
+        # When the active curve is XBAR/HOST, the operating point's frequency
+        # comes from the green-curve direct read (0x527FC458), not the GPC
+        # gpu_clock the dashboard poll feeds. Kick an async direct read each
+        # tick; the result lands in _live_pending and is drawn next tick (or
+        # immediately if idle and the read already completed).
+        curve = self._curves.get(self._active_curve)
+        if (
+            curve is not None
+            and self._active_curve in ("xbar", "host")
+            and not self._direct_read_inflight
+        ):
+            self._kick_direct_read(self._active_curve)
+
+        # Drain the latest volt/freq pushed by the background poll worker and
+        # blit — but only when idle. During a drag/press the value is held and
+        # flushed on release via _flush_pending_live_point.
+        volt, freq = self._live_pending
+        self._live_volt = volt
+        self._live_freq = freq
+        if (
+            not (self._is_resize_active or self._mouse_pressed)
+            and self._chart_should_draw()
+        ):
+            self._draw_live_point()
+        elif self._mouse_pressed or self._is_resize_active:
+            # hold for the release/resize-end flush
+            self._pending_live_point = (volt, freq)
+        self._live_poll_job = self.app.after(self._LIVE_POLL_MS, self._live_poll_tick)
+
+    def _kick_direct_read(self, curve_id: str) -> None:
+        """Async direct-read of the active xbar/host domain's physical clock.
+
+        On completion the worker reverse-looks-up the voltage on the active
+        curve (freq → voltage interpolation) and pushes (volt, freq_mhz) into
+        ``_live_pending`` for the next tick to blit. Direct read only gives
+        frequency; the voltage is recovered from the curve itself (xbar/host
+        have no pstate-off-curve excursion, so the reverse lookup is faithful).
+        """
+        gpu = self.app.selected_gpu_target()
+        if gpu is None:
+            return
+        domain_bit = _CURVE_META[curve_id]["domain_bit"]
+        curve = self._curves.get(curve_id)
+        if curve is None or not curve.voltages:
+            return
+        # Snapshot the curve points for the main-thread callback (the dict may
+        # be replaced by a refresh between submit and completion).
+        volts = list(curve.voltages)
+        freqs = list(curve.frequencies)
+        self._direct_read_inflight = True
+
+        def _worker():
+            result = self.app.backend.query_private_freq_domain_status(gpu, domain_bit)
+            self.app.after(
+                0, lambda: self._on_direct_read_done(result, curve_id, volts, freqs)
+            )
+
+        self.app.run_background("vfcurve-direct-read", _worker)
+
+    def _on_direct_read_done(self, result, curve_id, volts, freqs):
+        self._direct_read_inflight = False
+        if self._cleaned_up:
+            return
+        # Stale result for a different active curve than we're now showing,
+        # or the curve got unchecked (hidden) while the read was in flight —
+        # a hidden curve gets no crosshair, so drop the result.
+        if curve_id != self._active_curve or not self._curve_visible.get(curve_id):
+            return
+        if not isinstance(result, dict):
+            return
+        if result.get("supported") is False:
+            # Family absent — no live point for this domain.
+            self._live_pending = (None, None)
+            return
+        freq_khz = result.get("freq_khz")
+        if not freq_khz:
+            # 0 ⇒ driver refused / not measurable through this interface.
+            return
+        freq_mhz = freq_khz / 1000.0
+        volt = self._reverse_lookup_voltage(volts, freqs, freq_mhz)
+        if volt is None:
+            return
+        self._live_pending = (volt, freq_mhz)
+        # If idle, blit immediately rather than waiting for the next tick.
+        if (
+            not (self._is_resize_active or self._mouse_pressed)
+            and self._chart_should_draw()
+        ):
+            self._live_volt = volt
+            self._live_freq = freq_mhz
+            self._draw_live_point()
+
+    @staticmethod
+    def _reverse_lookup_voltage(
+        volts: List[float], freqs: List[float], target_freq: float
+    ) -> Optional[float]:
+        """Find the voltage on the curve whose frequency is closest to
+        ``target_freq``, linearly interpolating between the two nearest points.
+
+        xbar/host curves are monotonic in frequency vs voltage (no pstate
+        off-curve excursion), so the reverse lookup is single-valued. Returns
+        ``None`` when the curve is empty.
+        """
+        n = len(freqs)
+        if n == 0:
+            return None
+        if n == 1:
+            return volts[0]
+        # Find the segment [i, i+1] whose freq span contains target_freq, or
+        # the nearest end if target is outside the range (clamp to the closer
+        # end so the crosshair still marks the working point at the edge).
+        # Curve should be freq-ascending with voltage; handle either direction.
+        ascending = freqs[-1] >= freqs[0]
+        sfreqs = freqs
+        svolts = volts
+        if not ascending:
+            sfreqs = list(reversed(freqs))
+            svolts = list(reversed(volts))
+        if target_freq <= sfreqs[0]:
+            return svolts[0]
+        if target_freq >= sfreqs[-1]:
+            return svolts[-1]
+        for i in range(n - 1):
+            f0, f1 = sfreqs[i], sfreqs[i + 1]
+            if f0 <= target_freq <= f1:
+                v0, v1 = svolts[i], svolts[i + 1]
+                if f1 == f0:
+                    return v0
+                t = (target_freq - f0) / (f1 - f0)
+                return v0 + (v1 - v0) * t
+        return svolts[-1]
+
+    @property
+    def is_interacting(self) -> bool:
+        """True while the user is actively dragging points or extending a
+        selection on the curve. The dashboard poll pauses during interaction
+        so its per-second NVAPI sweep + main-thread completion callback
+        (parse/rows/snapshot/live-point) cannot interrupt the drag."""
+        return bool(self._mouse_pressed or self._dragging)
+
+    def _chart_should_draw(self) -> bool:
+        if not hasattr(self, "canvas") or not hasattr(self, "_chart_frame"):
+            return False
+        try:
+            if not self._chart_frame.winfo_ismapped():
+                return False
+            return str(self.app.tabview.get()).endswith("VF Curve")
+        except Exception:
+            return False
+
+    def on_resize_state_changed(self, resizing: bool, force_flush: bool = False):
+        self._is_resize_active = resizing
+        if resizing:
+            return
+
+        pending_w = self._pending_chart_resize_width
+        self._pending_chart_resize_width = None
+        if pending_w is not None:
+            self._apply_chart_resize(pending_w)
+
+        if self._pending_full_redraw:
+            self._pending_full_redraw = False
+            self._redraw()
+
+        self._flush_pending_live_point()
+
+    def _draw_live_point(self, call_draw_idle: bool = True):
+        if self._live_volt is None or self._live_freq is None or not self._voltages:
+            self._hide_live_point()
+            if call_draw_idle:
+                self._blit_animated()
+            return
+
+        lv = self._live_volt
+        lf = self._live_freq
+        ax = self.ax
+
+        if self._live_hline is not None:
+            self._live_hline.set_ydata([lf, lf])
+            self._live_vline.set_xdata([lv, lv])
+            self._live_marker.set_data([lv], [lf])
+            self._live_text.xy = (lv, lf)
+            self._live_text.set_text(f"Live: {lv:.1f} mV, {lf:.0f} MHz")
+            self._set_live_point_visible(True)
+            if call_draw_idle:
+                self._blit_animated()
+            return
+
+        crosshair_kw = dict(
+            color="#22cc44", linewidth=1.0, linestyle="--", alpha=0.85, animated=True
+        )
+        hline = ax.axhline(y=lf, zorder=6.0, **crosshair_kw)
+        vline = ax.axvline(x=lv, zorder=5.0, **crosshair_kw)
+
+        # Center marker
+        (marker,) = ax.plot(
+            lv,
+            lf,
+            marker="+",
+            markersize=8,
+            color="#22cc44",
+            markeredgewidth=1.2,
+            zorder=7.0,
+            linestyle="none",
+            animated=True,
+        )
+
+        # Label (placed slightly below to avoid overlapping with default lock markers)
+        # Using [Live] instead of emoji to avoid UserWarning/Glyph missing issues
+        text = ax.annotate(
+            f"Live: {lv:.1f} mV, {lf:.0f} MHz",
+            xy=(lv, lf),
+            xytext=(-70, 3),
+            textcoords="offset points",
+            color="#88ffaa",
+            fontsize=5,
+            zorder=8,
+            animated=True,
+        )
+
+        self._live_elements.extend([hline, vline, marker, text])
+        self._live_hline = hline
+        self._live_vline = vline
+        self._live_marker = marker
+        self._live_text = text
+
+        if call_draw_idle:
+            self._blit_animated()
+
+    def _hide_live_point(self) -> None:
+        self._set_live_point_visible(False)
+
+    def _update_selection_span(self) -> None:
+        """Lightweight selection-range repaint (no full _redraw).
+
+        The selection span (yellow band) is purely a voltage-axis range — it
+        does not depend on the curve points' frequencies, which only move
+        during a point drag, not a selection drag. So a selection-range drag
+        can rebuild just the span + the selected-point markers and blit,
+        instead of clearing the axes and rebuilding every artist. This keeps
+        the selection visual perfectly smooth and immune to the per-second
+        live-point blit (which restores the static background that no longer
+        contains the span or the markers — both are animated overlays now).
+
+        axvspan's Polygon uses a blended transform (x in data coords, y in
+        axes coords), so in-place set_xy can't be used; remove+recreate is
+        cheap and correct. The selected-point scatter's offsets are updated
+        in place from the current frequencies so the markers track the band.
+        """
+        if self.ax is None or self._cleaned_up:
+            return
+        if not self._voltages:
+            return
+        if self._sel_start is None or self._sel_end is None:
+            # Clear the span + markers if they exist.
+            changed = False
+            if self._sel_rect is not None:
+                self._sel_rect.set_visible(False)
+                changed = True
+            if self._sel_points is not None:
+                self._sel_points.set_visible(False)
+                changed = True
+            if changed:
+                self._blit_animated()
+            return
+        s = min(self._sel_start, self._sel_end)
+        e = max(self._sel_start, self._sel_end)
+        v = self._voltages
+        f = self._frequencies
+        x0, x1 = v[s], v[e]
+
+        # Recreate the span (blended transform makes set_xy unsafe).
+        if self._sel_rect is not None:
+            try:
+                self._sel_rect.remove()
+            except Exception:
+                pass
+        self._sel_rect = self.ax.axvspan(
+            x0, x1, alpha=0.15, color="#ffcc00", zorder=1, animated=True
+        )
+
+        # Update selected-point markers in place to track the band.
+        import numpy as _np
+
+        sel_v = v[s : e + 1]
+        sel_f = f[s : e + 1]
+        if self._sel_points is None:
+            self._sel_points = self.ax.scatter(
+                sel_v,
+                sel_f,
+                color="#ffcc00",
+                s=14,
+                zorder=5,
+                edgecolors="#ff8800",
+                linewidths=0.6,
+                animated=True,
+            )
+        else:
+            self._sel_points.set_offsets(_np.column_stack([sel_v, sel_f]))
+            self._sel_points.set_visible(True)
+
+        self._blit_animated()
+
+    def _set_live_point_visible(self, visible: bool) -> None:
+        for el in self._live_elements:
+            try:
+                el.set_visible(visible)
+            except Exception:
+                # Matplotlib artists can be stale or removed during redraw churn.
+                pass
+
+    # ────────────────────────────────────────────
+    # Keyboard navigation
+    # ────────────────────────────────────────────
+
+    # How many MHz one Up/Down key press shifts the selected point(s)
+    _KEY_FREQ_STEP_MHZ = 2.5  # one step ≈ 2.5 MHz (1 VF table row in kHz × 2.5)
+
+    def _is_single_point_sel(self) -> bool:
+        return (
+            self._sel_start is not None
+            and self._sel_end is not None
+            and self._sel_start == self._sel_end
+        )
+
+    def _is_range_sel(self) -> bool:
+        return (
+            self._sel_start is not None
+            and self._sel_end is not None
+            and self._sel_start != self._sel_end
+        )
+
+    def _selected_freq_lock_backend(self) -> str:
+        selected = self.freq_lock_api_var.get().strip().upper()
+        return "nvapi" if selected == "NVAPI" else "nvml"
+
+    def _selected_freq_lock_backend_label(self) -> str:
+        return self._selected_freq_lock_backend().upper()
+
+    def _backend_label(self, backend: str) -> str:
+        return backend.upper()
+
+    def _set_core_freq_lock_ui(self, min_mhz: int, max_mhz: int, backend: str) -> None:
+        self._freq_core_lock = (min_mhz, max_mhz)
+        self._freq_core_lock_backend = backend
+        self.core_lock_min_var.set(str(min_mhz))
+        self.core_lock_max_var.set(str(max_mhz))
+
+    def _clear_core_freq_lock_ui(self) -> None:
+        self._freq_core_lock = None
+        self._freq_core_lock_backend = None
+        self.core_lock_min_var.set("0")
+        self.core_lock_max_var.set("0")
+
+    def _set_mem_freq_lock_ui(self, min_mhz: int, max_mhz: int, backend: str) -> None:
+        self._freq_mem_lock = (min_mhz, max_mhz)
+        self._freq_mem_lock_backend = backend
+        self.mem_lock_min_var.set(str(min_mhz))
+        self.mem_lock_max_var.set(str(max_mhz))
+
+    def _clear_mem_freq_lock_ui(self) -> None:
+        self._freq_mem_lock = None
+        self._freq_mem_lock_backend = None
+        self.mem_lock_min_var.set("0")
+        self.mem_lock_max_var.set("0")
+
+    def _core_reset_backend(self, default_backend: str) -> str:
+        if self._freq_core_lock is not None and self._freq_core_lock_backend:
+            return self._freq_core_lock_backend
+        return default_backend
+
+    def _mem_reset_backend(self, default_backend: str) -> str:
+        if self._freq_mem_lock is not None and self._freq_mem_lock_backend:
+            return self._freq_mem_lock_backend
+        return default_backend
+
+    def _lock_core_native(
+        self, native, gpu: str, backend: str, min_mhz: int, max_mhz: int
+    ) -> None:
+        if backend == "nvapi":
+            native.set_vfp_frequency_lock(gpu, "core", max_mhz * 1000, min_mhz * 1000)
+        else:
+            native.set_locked_clocks(gpu, backend, "core", min_mhz, max_mhz)
+
+    def _reset_core_native(self, native, gpu: str, backend: str) -> None:
+        if backend == "nvapi":
+            native.reset_vfp_frequency_lock(gpu, "core")
+        else:
+            native.reset_core_clocks(gpu, backend)
+
+    def _lock_mem_native(
+        self, native, gpu: str, backend: str, min_mhz: int, max_mhz: int
+    ) -> None:
+        if backend == "nvapi":
+            native.set_vfp_frequency_lock(gpu, "memory", max_mhz * 1000, min_mhz * 1000)
+        else:
+            native.set_locked_clocks(gpu, backend, "memory", min_mhz, max_mhz)
+
+    def _reset_mem_native(self, native, gpu: str, backend: str) -> None:
+        if backend == "nvapi":
+            native.reset_vfp_frequency_lock(gpu, "memory")
+        else:
+            native.reset_mem_clocks(gpu, backend)
+
+    # ── Left / Shift-Tab : move selection left (lower index) ──
+    def _on_key_left(self, event=None):
+        if not self._voltages or self._sel_start is None:
+            return "break"
+        _n = len(self._voltages)
+        if self._is_single_point_sel():
+            new = max(0, self._sel_start - 1)
+            self._sel_start = self._sel_end = new
+        else:
+            # shift range left by 1, clamp at 0
+            s = min(self._sel_start, self._sel_end)
+            e = max(self._sel_start, self._sel_end)
+            span = e - s
+            new_s = max(0, s - 1)
+            self._sel_start = new_s
+            self._sel_end = new_s + span
+        self._sync_selection_to_adj()
+        self._redraw()
+        return "break"
+
+    def _on_key_shift_tab(self, event=None):
+        return self._on_key_left(event)
+
+    # ── Right / Tab : move selection right (higher index) ──
+    def _on_key_right(self, event=None):
+        if not self._voltages or self._sel_start is None:
+            return "break"
+        n = len(self._voltages)
+        if self._is_single_point_sel():
+            new = min(n - 1, self._sel_start + 1)
+            self._sel_start = self._sel_end = new
+        else:
+            s = min(self._sel_start, self._sel_end)
+            e = max(self._sel_start, self._sel_end)
+            span = e - s
+            new_e = min(n - 1, e + 1)
+            self._sel_end = new_e
+            self._sel_start = new_e - span
+        self._sync_selection_to_adj()
+        self._redraw()
+        return "break"
+
+    def _on_key_tab(self, event=None):
+        return self._on_key_right(event)
+
+    # ── Up : increase frequency of selected point(s) ──
+    def _on_key_up(self, event=None):
+        if not self._voltages or self._sel_start is None:
+            return "break"
+        self._key_shift_freq(+self._KEY_FREQ_STEP_MHZ)
+        return "break"
+
+    # ── Down : decrease frequency of selected point(s) ──
+    def _on_key_down(self, event=None):
+        if not self._voltages or self._sel_start is None:
+            return "break"
+        self._key_shift_freq(-self._KEY_FREQ_STEP_MHZ)
+        return "break"
+
+    # ── Mouse wheel : equivalent to Up / Down key ──
+    def _on_mousewheel(self, event):
+        """Handle mouse wheel to adjust frequency of selected point(s)."""
+        if not self._voltages or self._sel_start is None:
+            return "break"
+
+        event_num = getattr(event, "num", None)
+        if event_num == 4:
+            delta_mhz = +self._KEY_FREQ_STEP_MHZ  # Linux scroll up = increase freq
+        elif event_num == 5:
+            delta_mhz = -self._KEY_FREQ_STEP_MHZ  # Linux scroll down = decrease freq
+        else:
+            delta = int(getattr(event, "delta", 0) or 0)
+            if delta == 0:
+                return "break"
+            # Windows: positive delta = scroll up = increase, negative = scroll down = decrease
+            delta_mhz = (
+                self._KEY_FREQ_STEP_MHZ if delta > 0 else -self._KEY_FREQ_STEP_MHZ
+            )
+
+        self._key_shift_freq(delta_mhz)
+        return "break"
+
+    def _key_shift_freq(self, delta_mhz: float):
+        """Shift the frequency of the currently selected point(s) by delta_mhz."""
+        if self._sel_start is None or self._sel_end is None:
+            return
+        s = min(self._sel_start, self._sel_end)
+        e = max(self._sel_start, self._sel_end)
+
+        # Save undo snapshot before first edit in a batch
+        if self._drag_orig_freqs is None:
+            self._drag_orig_freqs = self._np().array(self._frequencies, dtype=float)
+
+        for i in range(s, e + 1):
+            self._frequencies[i] = round(self._frequencies[i] + delta_mhz, 3)
+
+        self._sync_selection_to_adj()
+        # Fast in-place update per event (drag path pattern); the full
+        # redraw (axes/limits/info text) is deferred until events settle.
+        self._fast_update_current_curve()
+        if self._key_redraw_after_id is not None:
+            self.app.after_cancel(self._key_redraw_after_id)
+        self._key_redraw_after_id = self.app.after(150, self._deferred_key_redraw)
+
+    def _deferred_key_redraw(self):
+        self._key_redraw_after_id = None
+        self._redraw()
+
+    def _fast_update_current_curve(self):
+        """Update the current-curve artist in place (no figure rebuild)."""
+        line = getattr(self, "_line_current", None)
+        if line is None or self.ax is None:
+            return
+        line.set_ydata(self._frequencies)
+        self._blit_animated()
+
+    def _on_space_key(self, event=None):
+        """Toggle lock state based on selection.
+        - Single point: Cycle Unlock -> VFP Lock -> Freq Lock -> Unlock.
+        - Range: Toggle Unlock <-> Freq Range Lock.
+        """
+        if getattr(self, "_is_toggling_lock", False):
+            self.app.console.append("[GUI] Operation in progress. Please wait...\n")
+            return "break"
+
+        if not self._voltages:
+            return "break"
+        if self._sel_start is None or self._sel_end is None:
+            return "break"
+
+        s = min(self._sel_start, self._sel_end)
+        e = max(self._sel_start, self._sel_end)
+        gpu = self.app.selected_gpu_target()
+        lock_backend = self._selected_freq_lock_backend()
+        lock_backend_label = self._selected_freq_lock_backend_label()
+
+        self._is_toggling_lock = True
+
+        # Capture current variables to pass into thread
+        idx = s
+        cur_f = int(round(self._frequencies[idx]))
+        min_f = int(round(min(self._frequencies[s : e + 1])))
+        max_f = int(round(max(self._frequencies[s : e + 1])))
+        vol = self._voltages[idx]
+
+        is_vfp_locked = idx in self._locked_points
+        is_freq_locked_single = (
+            self._freq_core_lock is not None and self._freq_core_lock == (cur_f, cur_f)
+        )
+        is_freq_locked_range = (
+            self._freq_core_lock is not None and self._freq_core_lock == (min_f, max_f)
+        )
+        has_vfp_locks = len(self._locked_points) > 0
+        active_freq_backend = self._core_reset_backend(lock_backend)
+        active_freq_backend_label = self._backend_label(active_freq_backend)
+
+        if s == e and is_vfp_locked:
+            description = "convert VFP lock to frequency lock"
+
+            def action(native) -> str:
+                native.reset_vfp_lock(gpu)
+                self._lock_core_native(native, gpu, lock_backend, cur_f, cur_f)
+                return (
+                    f"Successfully applied {lock_backend_label} lock for point {idx}."
+                )
+
+            def done(rc: int, local_f=cur_f, backend=lock_backend) -> None:
+                self._locked_points.clear()
+                if rc == 0:
+                    self._set_core_freq_lock_ui(local_f, local_f, backend)
+                self._redraw()
+                self.canvas.draw()
+                self._is_toggling_lock = False
+
+        elif s == e and is_freq_locked_single:
+            description = "reset frequency lock"
+
+            def action(native) -> str:
+                self._reset_core_native(native, gpu, active_freq_backend)
+                return f"Successfully reset {active_freq_backend_label} lock."
+
+            def done(rc: int) -> None:
+                if rc == 0:
+                    self._clear_core_freq_lock_ui()
+                self._redraw()
+                self.canvas.draw()
+                self._is_toggling_lock = False
+
+        elif s == e and lock_backend == "nvml":
+            description = "lock NVML frequency point"
+
+            def action(native) -> str:
+                if has_vfp_locks:
+                    native.reset_vfp_lock(gpu)
+                self._lock_core_native(native, gpu, lock_backend, cur_f, cur_f)
+                return (
+                    f"Successfully applied {lock_backend_label} lock for point {idx}."
+                )
+
+            def done(rc: int, local_f=cur_f, backend=lock_backend) -> None:
+                self._locked_points.clear()
+                if rc == 0:
+                    self._set_core_freq_lock_ui(local_f, local_f, backend)
+                self._redraw()
+                self.canvas.draw()
+                self._is_toggling_lock = False
+
+        elif s == e:
+            description = "lock VFP point"
+
+            def action(native) -> str:
+                self._reset_core_native(native, gpu, lock_backend)
+                native.set_vfp_voltage_lock(gpu, idx, None, False)
+                return f"Locked VFP point {idx}."
+
+            def done(rc: int, local_idx=idx) -> None:
+                self._clear_core_freq_lock_ui()
+                if rc == 0:
+                    self._locked_points.clear()
+                    self._locked_points.add(local_idx)
+                    self.app.console.append(
+                        f"[GUI] VFP Lock applied ({vol:.1f} mV / {cur_f} MHz).\n"
+                    )
+                self._redraw()
+                self.canvas.draw()
+                self._is_toggling_lock = False
+
+        elif is_freq_locked_range:
+            description = "reset frequency range lock"
+
+            def action(native) -> str:
+                self._reset_core_native(native, gpu, active_freq_backend)
+                return f"Successfully reset {active_freq_backend_label} range lock."
+
+            def done(rc: int) -> None:
+                if rc == 0:
+                    self._clear_core_freq_lock_ui()
+                self._redraw()
+                self.canvas.draw()
+                self._is_toggling_lock = False
+
+        else:
+            description = "apply frequency range lock"
+
+            def action(native) -> str:
+                if has_vfp_locks:
+                    native.reset_vfp_lock(gpu)
+                self._lock_core_native(native, gpu, lock_backend, min_f, max_f)
+                return (
+                    f"Successfully applied {lock_backend_label} lock for range {s}-{e} "
+                    f"({min_f}-{max_f} MHz)."
+                )
+
+            def done(rc: int, lf_min=min_f, lf_max=max_f, backend=lock_backend) -> None:
+                self._locked_points.clear()
+                if rc == 0:
+                    self._set_core_freq_lock_ui(lf_min, lf_max, backend)
+                self._redraw()
+                self.canvas.draw()
+                self._is_toggling_lock = False
+
+        self.app.run_native_action(description, action, on_finished=done)
+        return "break"
+
+    def _clear_selection(self):
+        self._sel_start = None
+        self._sel_end = None
+        self.adj_start_var.set("0")
+        self.adj_end_var.set("0")
+        self._redraw()
+
+    def _undo_drag(self):
+        """Undo the last drag edit by restoring original frequencies."""
+        if self._drag_orig_freqs is not None and len(self._drag_orig_freqs) == len(
+            self._frequencies
+        ):
+            self._frequencies = self._drag_orig_freqs.tolist()
+            self._drag_orig_freqs = None
+            self._redraw()
+            self.app.console.append("[GUI] Drag edit undone.\n")
+        else:
+            self.app.console.append("[GUI] Nothing to undo.\n")
+
+    def _sync_selection_to_adj(self):
+        """Sync chart selection range (and current avg delta) to the adjustment fields."""
+        if self._sel_start is None or self._sel_end is None:
+            return
+        s = min(self._sel_start, self._sel_end)
+        e = max(self._sel_start, self._sel_end)
+        self.adj_start_var.set(str(s))
+        self.adj_end_var.set(str(e))
+        # Show avg delta vs default in the delta field (for reference only)
+        if self._frequencies and self._defaults:
+            deltas = [
+                self._frequencies[i] - self._defaults[i]
+                for i in range(s, min(e + 1, len(self._frequencies)))
+            ]
+            if deltas:
+                avg = sum(deltas) / len(deltas)
+                self.adj_delta_var.set(f"{avg:+.1f}")
+
+    # ────────────────────────────────────────────
+    # Actions (CLI calls)
+    # ────────────────────────────────────────────
+    def _export_vfp(self):
+        gpu = self.app.selected_gpu_target()
+
+        path = filedialog.asksaveasfilename(
+            title="Export VF Curve",
+            defaultextension=".csv",
+            filetypes=[("CSV Files", "*.csv"), ("All Files", "*.*")],
+        )
+        if not path:
+            return
+
+        if not self.quick_export_var.get():
+            self.app.run_cli_display(self.app.get_gpu_args() + ["export-vfp", path])
+            return
+
+        def export(native, gpu=gpu, path=path) -> str:
+            points = native.query_public_vftable(gpu, "graphics", True)
+            self._write_vfp_points(path, points)
+            return f"Exported {len(points)} VFP point(s) to {path}."
+
+        self.app.run_native_action("export VFP curve", export)
+
+    def _import_vfp(self):
+        gpu = self.app.selected_gpu_target()
+
+        path = filedialog.askopenfilename(
+            title="Import VF Curve",
+            defaultextension=".csv",
+            filetypes=[("CSV Files", "*.csv"), ("All Files", "*.*")],
+        )
+        if not path:
+            return
+
+        def import_curve(native, gpu=gpu, path=path) -> str:
+            points = native.query_public_vftable(gpu, "graphics", True)
+            deltas = self._load_vfp_deltas(path, points)
+            native.set_domain_vfp_deltas(gpu, "graphics", deltas)
+            return f"Imported {len(deltas)} VFP point delta(s) from {path}."
+
+        self.app.run_native_action(
+            "import VFP curve",
+            import_curve,
+            on_finished=lambda _rc: self.app.after(0, self._refresh_curve),
+        )
+
+    def _on_core_lock_done(
+        self, rc: int, min_clk: int, max_clk: int, backend: str, backend_label: str
+    ):
+        def _update_ui():
+            if rc == 0:
+                self._set_core_freq_lock_ui(min_clk, max_clk, backend)
+                self.app.console.append(
+                    f"[GUI] {backend_label} core clock locked successfully.\n"
+                )
+            else:
+                self.app.console.append(
+                    f"[GUI] {backend_label} core clock lock failed.\n"
+                )
+            self._redraw()
+            self._is_toggling_lock = False
+
+        self.app.after(0, _update_ui)
+
+    def _on_core_reset_done(self, rc: int, backend_label: str):
+        def _update_ui():
+            if rc == 0:
+                self._clear_core_freq_lock_ui()
+                self.app.console.append(
+                    f"[GUI] {backend_label} core clock reset successfully.\n"
+                )
+            else:
+                self.app.console.append(
+                    f"[GUI] {backend_label} core clock reset failed.\n"
+                )
+            self._redraw()
+            self._is_toggling_lock = False
+
+        self.app.after(0, _update_ui)
+
+    def _on_mem_lock_done(
+        self, rc: int, min_clk: int, max_clk: int, backend: str, backend_label: str
+    ):
+        def _update_ui():
+            if rc == 0:
+                self._set_mem_freq_lock_ui(min_clk, max_clk, backend)
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock locked successfully.\n"
+                )
+            else:
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock lock failed.\n"
+                )
+            self._redraw()
+
+        self.app.after(0, _update_ui)
+
+    def _on_mem_reset_done(self, rc: int, backend_label: str):
+        def _update_ui():
+            if rc == 0:
+                self._clear_mem_freq_lock_ui()
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock reset successfully.\n"
+                )
+            else:
+                self.app.console.append(
+                    f"[GUI] {backend_label} memory clock reset failed.\n"
+                )
+            self._redraw()
+
+        self.app.after(0, _update_ui)
+
+    def _apply_adj(self):
+        """Apply the current frequency edits for the selected range to the GPU.
+
+        Routes by the active curve's ``write_mode``:
+
+        * ``public``  — open VFP ``set_vfp_range_delta`` (grouped, unchanged).
+        * ``private`` — try private mode-0 (kHz offset) per point; on
+          ArgumentRange (mode-0 rejected, e.g. CMP170HX / Fixed points) fall
+          back to raw-converted mode-1 via ``clk_vf_delta_for_target`` +
+          ``set_vfp_range_per_point_private``. Console-logs which path ran.
+        """
+        gpu = self.app.selected_gpu_target()
+        try:
+            start = int(self.adj_start_var.get())
+            end = int(self.adj_end_var.get())
+        except ValueError:
+            self.app.console.append("[GUI] Invalid start/end point values.\n")
+            return
+
+        if start > end:
+            start, end = end, start
+
+        if not self._frequencies or not self._defaults:
+            self.app.console.append("[GUI] No VF data loaded.\n")
+            return
+
+        try:
+            target_delta_mhz = float(self.adj_delta_var.get().strip())
+        except ValueError:
+            self.app.console.append("[GUI] Invalid Delta (MHz) value.\n")
+            return
+
+        n = len(self._frequencies)
+        start = max(0, min(start, n - 1))
+        end = max(0, min(end, n - 1))
+
+        if self._drag_orig_freqs is None or len(self._drag_orig_freqs) != len(
+            self._frequencies
+        ):
+            self._drag_orig_freqs = self._np().array(self._frequencies, dtype=float)
+
+        for i in range(start, end + 1):
+            self._frequencies[i] = round(self._defaults[i] + target_delta_mhz, 3)
+
+        self._redraw()
+
+        curve = self._curves.get(self._active_curve)
+        # Build per-point delta list (kHz, integer) vs default.
+        deltas_khz = [
+            round((self._frequencies[i] - self._defaults[i]) * 1000)
+            for i in range(start, end + 1)
+        ]
+
+        # ── Public path: GPC via the open VFP interface (unchanged). ──
+        if curve is not None and curve.write_mode == "public":
+            groups = []  # type: List[Tuple[int,int,int]]
+            g_start = start
+            g_delta = deltas_khz[0]
+            for offset, dkz in enumerate(deltas_khz[1:], start=1):
+                if dkz != g_delta:
+                    groups.append((g_start, start + offset - 1, g_delta))
+                    g_start = start + offset
+                    g_delta = dkz
+            groups.append((g_start, end, g_delta))
+
+            self.app.console.append(
+                f"[GUI] Applying {len(groups)} public VFP group(s) "
+                f"to {self._active_curve.upper()} {start}–{end}…\n"
+            )
+
+            def apply_groups(native, gpu=gpu, groups=groups) -> str:
+                applied = 0
+                failed = 0
+                messages = []
+                for frm, to, dkz in groups:
+                    try:
+                        native.set_vfp_range_delta(gpu, frm, to, dkz)
+                    except Exception as exc:
+                        failed += 1
+                        messages.append(
+                            f"Warning: failed VFP delta group {frm}-{to} ({dkz} kHz): {exc}"
+                        )
+                        continue
+                    applied += 1
+                messages.append(
+                    f"Applied {applied} VFP delta group(s); {failed} failed."
+                )
+                return "\n".join(messages)
+
+            self.app.run_native_action(
+                "apply VFP point deltas",
+                apply_groups,
+                on_finished=lambda _rc: self.app.after(0, self._refresh_curve),
+            )
+            return
+
+        # ── Private path: mode-0 first, raw-converted fallback. ──
+        if curve is None:
+            self.app.console.append("[GUI] Active curve missing — cannot apply.\n")
+            return
+        bank = curve.bank
+        base = curve.seg_start + start  # absolute private index of `start`
+        class_name = _CURVE_META[curve.curve_id]["class"]
+        defaults_mhz = list(self._defaults)
+        self.app.console.append(
+            f"[GUI] Applying private VFP to {curve.curve_id.upper()} "
+            f"{start}–{end} (bank {bank}, mode-0 → raw-converted fallback)…\n"
+        )
+
+        def apply_private(
+            native,
+            gpu=gpu,
+            bank=bank,
+            base=base,
+            class_name=class_name,
+            defaults_mhz=defaults_mhz,
+            deltas_khz=deltas_khz,
+            start=start,
+            curve_id=curve.curve_id,
+        ) -> str:
+            # 1) Try mode-0 (kHz frequency offset) per point.
+            try:
+                for offset, dkz in enumerate(deltas_khz):
+                    r = native.set_vfp_point_private(
+                        gpu, bank, base + offset, dkz, True
+                    )
+                    if isinstance(r, dict) and r.get("supported") is False:
+                        raise RuntimeError("private VFP family unsupported")
+                return (
+                    f"Successfully applied private mode-0 offsets to {curve_id.upper()} "
+                    f"({len(deltas_khz)} pts)."
+                )
+            except Exception as exc:
+                msg = str(exc).lower()
+                if "argument" not in msg and "unsupported" not in msg:
+                    raise
+                # mode-0 rejected at readback → fall through to raw-converted.
+            # 2) Raw-converted: translate each MHz offset to a raw mode-1
+            # f-offset control value via the universal g(def) prior.
+            raw_deltas = []
+            for offset in range(len(deltas_khz)):
+                def_mhz = int(round(defaults_mhz[start + offset]))
+                tgt_mhz = deltas_khz[offset] / 1000.0
+                r = native.clk_vf_delta_for_target_mhz(def_mhz, tgt_mhz, class_name)
+                d = r.get("delta") if isinstance(r, dict) else None
+                if d is None:
+                    return (
+                        f"raw-converted translation failed at def={def_mhz} MHz "
+                        f"({curve_id.upper()}); apply aborted."
+                    )
+                raw_deltas.append(int(d))
+            last = base + len(deltas_khz) - 1
+            r2 = native.set_vfp_range_per_point_private(
+                gpu, bank, base, last, raw_deltas
+            )
+            if isinstance(r2, dict) and r2.get("supported") is False:
+                return f"private VFP write unsupported on {curve_id.upper()}."
+            return (
+                f"Successfully applied private raw-converted offsets to {curve_id.upper()} "
+                f"({len(raw_deltas)} pts)."
+            )
+
+        self.app.run_native_action(
+            "apply VFP point deltas",
+            apply_private,
+            on_finished=lambda _rc: self.app.after(0, self._refresh_curve),
+        )
+
+    def _reset_vfp(self):
+        """Reset the active curve to default (selected-curve semantics).
+
+        Public GPC → open ``set_vfp_range_delta`` 0 over the segment. Private
+        (XBAR/HOST, or GPC when public is unsupported) → mode-0 clear per
+        point, raw-converted clear fallback (delta 0 → raw f-offset that
+        zeroes the effect). Never touches other curves' segments.
+        """
+        curve = self._curves.get(self._active_curve)
+        if curve is None:
+            self.app.console.append("[GUI] No active curve to reset.\n")
+            return
+        gpu = self.app.selected_gpu_target()
+        cid = curve.curve_id.upper()
+
+        if curve.write_mode == "public":
+            s, e = curve.seg_start, curve.seg_end
+
+            def reset_public(native, gpu=gpu, s=s, e=e, cid=cid) -> str:
+                native.set_vfp_range_delta(gpu, s, e, 0)
+                return f"Successfully reset {cid} curve to default ({s}–{e}, public)."
+
+            self.app.run_native_action(
+                "reset VFP deltas",
+                reset_public,
+                on_finished=lambda _rc: self.app.after(0, self._refresh_curve),
+            )
+            return
+
+        bank = curve.bank
+        base = curve.seg_start
+        end_idx = curve.seg_end
+        class_name = _CURVE_META[curve.curve_id]["class"]
+        defaults_mhz = list(curve.defaults)
+
+        def reset_private(
+            native,
+            gpu=gpu,
+            bank=bank,
+            base=base,
+            end_idx=end_idx,
+            class_name=class_name,
+            defaults_mhz=defaults_mhz,
+            cid=cid,
+        ) -> str:
+            # 1) mode-0 clear (value 0) per point in the segment.
+            try:
+                for idx in range(base, end_idx + 1):
+                    r = native.set_vfp_point_private(gpu, bank, idx, 0, True)
+                    if isinstance(r, dict) and r.get("supported") is False:
+                        raise RuntimeError("private VFP family unsupported")
+                return f"Successfully reset {cid} (private mode-0, {base}–{end_idx})."
+            except Exception as exc:
+                msg = str(exc).lower()
+                if "argument" not in msg and "unsupported" not in msg:
+                    raise
+            # 2) raw-converted clear: delta 0 → the raw f-offset that zeroes
+            # the effect (≈ D0 per the prior).
+            raw_deltas = []
+            for idx in range(base, end_idx + 1):
+                local = idx - base
+                def_mhz = (
+                    int(round(defaults_mhz[local])) if local < len(defaults_mhz) else 0
+                )
+                r = native.clk_vf_delta_for_target_mhz(def_mhz, 0.0, class_name)
+                d = r.get("delta") if isinstance(r, dict) else None
+                raw_deltas.append(int(d) if d is not None else 0)
+            r2 = native.set_vfp_range_per_point_private(
+                gpu, bank, base, end_idx, raw_deltas
+            )
+            if isinstance(r2, dict) and r2.get("supported") is False:
+                return f"private reset unsupported on {cid}."
+            return f"Successfully reset {cid} (private raw, {base}–{end_idx})."
+
+        self.app.run_native_action(
+            "reset VFP deltas",
+            reset_private,
+            on_finished=lambda _rc: self.app.after(0, self._refresh_curve),
+        )

--- a/gui/src/widgets/lightweight_controls.py
+++ b/gui/src/widgets/lightweight_controls.py
@@ -3,12 +3,63 @@ Lightweight Tk/CTk hybrid controls for high-density panels.
 """
 
 import tkinter as tk
+import tkinter.font as tk_font
 from typing import List, Optional, Tuple
 
 import customtkinter as ctk
 
 # Mouse-wheel scroll multiplier: canvas "units" per wheel notch.
 _WHEEL_STEP_UNITS = 6
+
+
+def ct_button_font(master, size_pt: int = 10):
+    """CTkFont that renders at the same physical height as the LiteButton
+    canvas typography (same family/point baseline).
+
+    CTk's font pipeline re-scales CTkFont on the widget (and behaves
+    differently from a standalone font object), so calibrate end-to-end:
+    create a throwaway real CTkButton, measure the font actually applied
+    on its canvas, and adjust the CTkFont size until the rendered
+    linespace matches the point font's.
+    """
+    import customtkinter as _ctk
+
+    probe_point = tk_font.Font(
+        root=master, family="Segoe UI", size=size_pt, weight="bold"
+    )
+    target = probe_point.metrics("linespace")
+
+    def applied_linespace(font_obj):
+        btn = _ctk.CTkButton(master, text=" ", width=10, height=10, font=font_obj)
+        try:
+            master.update_idletasks()
+            for item in btn._canvas.find_all():
+                if btn._canvas.type(item) == "text":
+                    applied = btn._canvas.itemcget(item, "font")
+                    if applied:
+                        return tk_font.Font(font=applied).metrics("linespace")
+        finally:
+            btn.destroy()
+        return None
+
+    # CTk applies roughly (target/2.8)px for Segoe UI; start from the
+    # measured proportion of a normal pixel font, then adjust on the
+    # REAL widget. Empirical starting point, refined below.
+    px = max(8, round(size_pt * 1.0))
+    best = px
+    for _ in range(4):
+        f = _ctk.CTkFont(family="Segoe UI", size=px, weight="bold")
+        ls = applied_linespace(f)
+        if ls is None:
+            break
+        if ls == target:
+            return f
+        if ls < target:
+            best = px
+            px += 1
+        else:
+            px -= 1
+    return _ctk.CTkFont(family="Segoe UI", size=max(8, best), weight="bold")
 
 
 def _is_descendant_widget(widget: tk.Misc, ancestor: tk.Misc) -> bool:
@@ -34,9 +85,9 @@ def install_mousewheel_support(scroll_frame: ctk.CTkScrollableFrame) -> None:
     ``<Button-4>/<Button-5>`` or ``<MouseWheel>`` with tiny deltas. We bind all
     variants and normalize them into canvas unit scrolling.
     """
-    # ``bind_all(..., add="+")`` installs handlers on the toplevel. Guarding
-    # each frame separately stacks three more global callbacks for every tab.
-    # Keep one toplevel dispatcher and register the frames it may target.
+    # bind_all 绑在 toplevel 上且 add="+"：旧实现守卫挂在 scroll_frame 上，
+    # 每个含滚动框的 tab 都会再叠 3 个全局 handler 且永不解绑。现在只装
+    # 一个 toplevel 级 handler，动态分派到指针所在滚动框。
     toplevel = scroll_frame.winfo_toplevel()
     frames = getattr(toplevel, "_nvoc_mousewheel_frames", None)
     if frames is None:
@@ -66,7 +117,6 @@ def install_mousewheel_support(scroll_frame: ctk.CTkScrollableFrame) -> None:
         frame = _frame_at_pointer()
         if frame is None:
             return None
-
         canvas = getattr(frame, "_parent_canvas", None)
         if canvas is None:
             return None
@@ -90,6 +140,8 @@ def install_mousewheel_support(scroll_frame: ctk.CTkScrollableFrame) -> None:
             return "break"
 
         try:
+            # One canvas "unit" is a tiny scroll increment on CTk's inner
+            # canvas — a single unit per notch feels glued; use a multiplier.
             canvas.yview_scroll(steps * _WHEEL_STEP_UNITS, "units")
         except Exception:
             return None
@@ -119,8 +171,10 @@ class CanvasSlider(ctk.CTkFrame):
         self._pending_command_value = None
         self._command_interval_ms = 16
 
+        # width=1: a bare tk.Canvas requests 378px by default, which grid
+        # treats as a hard minimum and clips sibling columns in narrow cards.
         self._canvas = tk.Canvas(
-            self, height=24, highlightthickness=0, bd=0, bg="#242424"
+            self, width=1, height=24, highlightthickness=0, bd=0, bg="#2b2b2b"
         )
         self._canvas.pack(fill="both", expand=True)
         self._canvas.bind("<Configure>", lambda _e: self._redraw())
@@ -162,7 +216,7 @@ class CanvasSlider(ctk.CTkFrame):
     def set(self, value):
         clamped = self._clamp(float(value))
         if abs(clamped - self._value) < 1e-9:
-            return
+            return  # no-op set: skip the canvas redraw
         self._value = clamped
         self._redraw()
 
@@ -326,8 +380,11 @@ class SegmentRangeSelector(ctk.CTkFrame):
 
         self.grid_columnconfigure(0, weight=1)
 
+        # Summary ("Lock target: P8") is drawn INSIDE the canvas at the same
+        # height as the toggle-selector's watt subtitles, centered — a separate
+        # label row sat lower and left-anchored.
         self._canvas = tk.Canvas(
-            self, height=56, highlightthickness=0, bd=0, bg="#242424"
+            self, width=1, height=70, highlightthickness=0, bd=0, bg="#2b2b2b"
         )
         self._canvas.grid(row=0, column=0, sticky="ew")
         self._canvas.bind("<Configure>", lambda _e: self._redraw())
@@ -335,14 +392,7 @@ class SegmentRangeSelector(ctk.CTkFrame):
         self._canvas.bind("<B1-Motion>", self._on_drag)
         self._canvas.bind("<ButtonRelease-1>", self._on_release)
 
-        self._summary = ctk.CTkLabel(
-            self,
-            text="No P-State data",
-            anchor="w",
-            font=("Segoe UI", 10),
-            text_color="#7e8da1",
-        )
-        self._summary.grid(row=1, column=0, sticky="ew", pady=(0, 2))
+        self._summary_text = "No P-State data"
 
         self.set_values(self._values)
 
@@ -480,14 +530,13 @@ class SegmentRangeSelector(ctk.CTkFrame):
 
     def _update_summary(self):
         if not self._values:
-            self._summary.configure(text="No P-State data")
+            self._summary_text = "No P-State data"
             return
         start, end = self.get_selection() or ("", "")
         if start == end:
-            text = f"Lock target: {start}"
+            self._summary_text = f"Lock target: {start}"
         else:
-            text = f"Lock range: {start} - {end}"
-        self._summary.configure(text=text)
+            self._summary_text = f"Lock range: {start} - {end}"
 
     def _redraw(self):
         c = self._canvas
@@ -564,6 +613,380 @@ class SegmentRangeSelector(ctk.CTkFrame):
                 font=("Segoe UI", 10, "bold"),
             )
 
+        # Centered summary at the subtitle height (matches the toggle
+        # selector's watt captions).
+        c.create_text(
+            w / 2,
+            h - 9,
+            text=self._summary_text,
+            fill="#7e8da1",
+            font=("Segoe UI", 8),
+        )
+
+
+class SegmentToggleSelector(ctk.CTkFrame):
+    """Discrete single-select segmented picker (click-to-select, no dragging).
+
+    Each segment shows a main label (e.g. ``D3``) and an optional subtitle
+    (e.g. ``40W``) rendered beneath it on a shared canvas track.
+    """
+
+    def __init__(
+        self,
+        parent,
+        values: Optional[List[str]] = None,
+        subtitles: Optional[List[Optional[str]]] = None,
+        command=None,
+    ):
+        super().__init__(parent, fg_color="transparent", height=62)
+        self._values = []  # type: List[str]
+        self._subtitles = []  # type: List[Optional[str]]
+        self._command = command
+        self._state = "normal"
+        self._selected_idx = None  # type: Optional[int]
+        self._pad_x = 18
+        # Track position mirrors the range selector: vertically centered in
+        # the canvas with room below for the labels + watt subtitles.
+        self._line_y = 20
+        self._node_r = 5
+
+        self.grid_columnconfigure(0, weight=1)
+
+        self._canvas = tk.Canvas(
+            self, width=1, height=62, highlightthickness=0, bd=0, bg="#2b2b2b"
+        )
+        self._canvas.grid(row=0, column=0, sticky="ew")
+        self._canvas.bind("<Configure>", lambda _e: self._redraw())
+        self._canvas.bind("<Button-1>", self._on_click)
+
+        self.set_values(values, subtitles)
+
+    def configure(self, **kwargs):
+        if "command" in kwargs:
+            self._command = kwargs.pop("command")
+        if "state" in kwargs:
+            self._state = kwargs.pop("state")
+        super().configure(**kwargs)
+        self._redraw()
+
+    def cget(self, key):
+        if key == "state":
+            return self._state
+        if key == "values":
+            return list(self._values)
+        return super().cget(key)
+
+    def set_values(
+        self,
+        values: Optional[List[str]],
+        subtitles: Optional[List[Optional[str]]] = None,
+    ):
+        old_selection = self.get_selection()
+        normalized = []
+        seen = set()
+        for value in values or []:
+            label = str(value).strip().upper()
+            if not label or label in seen:
+                continue
+            seen.add(label)
+            normalized.append(label)
+
+        subs = list(subtitles or [])
+        normalized_subs = []
+        for i in range(len(normalized)):
+            sub = subs[i] if i < len(subs) else None
+            normalized_subs.append(str(sub) if sub not in (None, "") else None)
+
+        self._values = normalized
+        self._subtitles = normalized_subs
+        if not self._values:
+            self._selected_idx = None
+            self._redraw()
+            return
+        if old_selection in self._values:
+            self._selected_idx = self._values.index(old_selection)
+        else:
+            self._selected_idx = 0
+        self._redraw()
+
+    def set_selection(self, value: Optional[str]):
+        if not self._values:
+            return
+        label = str(value).strip().upper() if value is not None else None
+        if label is None or label not in self._values:
+            self._selected_idx = None
+        else:
+            self._selected_idx = self._values.index(label)
+        self._redraw()
+
+    def get_selection(self) -> Optional[str]:
+        if not self._values or self._selected_idx is None:
+            return None
+        return self._values[self._selected_idx]
+
+    def _positions(self) -> List[float]:
+        width = max(1, self._canvas.winfo_width())
+        if len(self._values) <= 1:
+            return [width / 2.0]
+        x0 = self._pad_x
+        x1 = max(x0 + 1, width - self._pad_x)
+        step = (x1 - x0) / (len(self._values) - 1)
+        return [x0 + step * i for i in range(len(self._values))]
+
+    def _nearest_index(self, x: float) -> int:
+        positions = self._positions()
+        return min(range(len(positions)), key=lambda i: abs(positions[i] - x))
+
+    def _on_click(self, event):
+        if self._state == "disabled" or not self._values:
+            return
+        idx = self._nearest_index(float(event.x))
+        if idx == self._selected_idx:
+            return
+        self._selected_idx = idx
+        self._redraw()
+        if callable(self._command) and self._selected_idx is not None:
+            self._command(self._values[self._selected_idx])
+
+    def _redraw(self):
+        c = self._canvas
+        w = max(1, c.winfo_width())
+        h = max(1, c.winfo_height())
+        c.delete("all")
+
+        if not self._values:
+            c.create_text(
+                w / 2,
+                h / 2,
+                text="No data",
+                fill="#7e8da1",
+                font=("Segoe UI", 10),
+            )
+            return
+
+        positions = self._positions()
+        disabled = self._state == "disabled"
+        base_track = "#4a4a4a" if disabled else "#3a3a3a"
+        label_fill = "#7e8da1" if disabled else "#d6dfeb"
+        sub_fill = "#6b7684" if disabled else "#8a99ab"
+        node_fill = "#707070" if disabled else "#9aa7b5"
+
+        has_subtitle = any(self._subtitles)
+        label_y = self._line_y + 16
+        sub_y = label_y + 13
+
+        x0 = positions[0]
+        x1 = positions[-1]
+        c.create_line(
+            x0,
+            self._line_y,
+            x1,
+            self._line_y,
+            fill=base_track,
+            width=4,
+            capstyle=tk.ROUND,
+        )
+
+        for idx, (x, label) in enumerate(zip(positions, self._values)):
+            is_selected = idx == self._selected_idx
+            # Selected style matches the SegmentRangeSelector handles:
+            # white fill + blue outline (single-select: only ONE handle).
+            if is_selected:
+                radius = 9
+                fill = "#f5f7fb"
+                outline = "#59b0ff"
+                outline_w = 2
+            else:
+                radius = self._node_r
+                fill = node_fill
+                outline = ""
+                outline_w = 0
+            c.create_oval(
+                x - radius,
+                self._line_y - radius,
+                x + radius,
+                self._line_y + radius,
+                fill=fill,
+                outline=outline,
+                width=outline_w,
+            )
+            c.create_text(
+                x,
+                label_y,
+                text=label,
+                fill=label_fill if not is_selected else "#f5f7fb",
+                font=("Segoe UI", 9, "bold"),
+            )
+            if has_subtitle:
+                sub = self._subtitles[idx] if idx < len(self._subtitles) else None
+                c.create_text(
+                    x,
+                    sub_y,
+                    text=sub or "—",
+                    fill=sub_fill,
+                    font=("Segoe UI", 8),
+                )
+
+
+class LiteCheckbutton(tk.Frame):
+    """CTk-styled checkbox with the box drawn to the RIGHT of the text.
+
+    Mimics the default CTkCheckBox look (rounded box, border, blue check)
+    — CTk itself cannot render text-then-box.
+    """
+
+    def __init__(
+        self,
+        master,
+        text: str,
+        variable=None,
+        command=None,
+        font: Tuple[str, int] = ("Segoe UI", 12),
+        box: int = 24,
+        bg: str = "#2b2b2b",
+        fg: str = "#e5e5e5",
+    ):
+        super().__init__(master, bg=bg, bd=0, highlightthickness=0)
+        self._text = text
+        self._variable = variable
+        self._command = command
+        self._font = font
+        self._box = box
+        self._bg = bg
+        self._fg = fg
+        self._state = "normal"
+        self._hovered = False
+
+        self._canvas = tk.Canvas(
+            self, width=1, height=box + 8, highlightthickness=0, bd=0, bg=bg
+        )
+        self._canvas.pack(fill="both", expand=True)
+        self._canvas.bind("<Button-1>", self._on_click)
+        self._canvas.bind("<Enter>", lambda _e: self._set_hover(True))
+        self._canvas.bind("<Leave>", lambda _e: self._set_hover(False))
+        self._canvas.bind("<Configure>", lambda _e: self._redraw())
+        if variable is not None:
+            variable.trace_add("write", lambda *_: self._redraw())
+
+    def _set_hover(self, hovered: bool):
+        self._hovered = hovered
+        self._redraw()
+
+    def _on_click(self, _event):
+        if self._state == "disabled" or self._variable is None:
+            return
+        self._variable.set(not bool(self._variable.get()))
+        if callable(self._command):
+            self._command()
+
+    def configure(self, **kwargs):
+        if "state" in kwargs:
+            self._state = kwargs.pop("state")
+        super().configure(**kwargs)
+        self._redraw()
+
+    def _rounded_rect(self, c, x0, y0, x1, y1, r, **kw):
+        points = [
+            x0 + r,
+            y0,
+            x1 - r,
+            y0,
+            x1,
+            y0,
+            x1,
+            y0 + r,
+            x1,
+            y1 - r,
+            x1,
+            y1,
+            x1 - r,
+            y1,
+            x0 + r,
+            y1,
+            x0,
+            y1,
+            x0,
+            y1 - r,
+            x0,
+            y0 + r,
+            x0,
+            y0,
+        ]
+        return c.create_polygon(points, smooth=True, splinesteps=16, **kw)
+
+    def _redraw(self):
+        c = self._canvas
+        c.delete("all")
+        try:
+            text_w = tk_font.Font(root=self, font=self._font).measure(self._text)
+        except Exception:
+            text_w = 8 * len(self._text)
+        w = text_w + 10 + self._box
+        h = c.winfo_height() or self._box + 8
+        try:
+            c.configure(width=max(w, c.winfo_width()))
+        except Exception:
+            pass
+        b = self._box
+        x1 = w  # box at the far right
+        y0 = (h - b) // 2
+        checked = bool(self._variable.get()) if self._variable is not None else False
+        disabled = self._state == "disabled"
+
+        c.create_text(
+            x1 - b - 10,
+            h // 2,
+            text=self._text,
+            anchor="e",
+            fill="#8a8a8a" if disabled else self._fg,
+            font=self._font,
+        )
+        if checked:
+            self._rounded_rect(
+                c,
+                x1 - b,
+                y0,
+                x1,
+                y0 + b,
+                max(3, b // 5),
+                fill="#3B8ED0",
+                outline="",
+            )
+            m = b // 3
+            c.create_line(
+                x1 - b + m,
+                y0 + b // 2,
+                x1 - b // 2,
+                y0 + b - m,
+                fill="#ffffff",
+                width=2,
+                capstyle=tk.ROUND,
+            )
+            c.create_line(
+                x1 - b // 2,
+                y0 + b - m,
+                x1 - m,
+                y0 + m,
+                fill="#ffffff",
+                width=2,
+                capstyle=tk.ROUND,
+            )
+        else:
+            border = "#6f6f6f" if self._hovered else "#5c5c5c"
+            if disabled:
+                border = "#4a4a4a"
+            self._rounded_rect(
+                c,
+                x1 - b,
+                y0,
+                x1,
+                y0 + b,
+                max(3, b // 5),
+                fill="#3a3a3a" if not disabled else "#333333",
+                outline=border,
+                width=2,
+            )
+
 
 class LiteButton(ctk.CTkFrame):
     """Rounded canvas-backed button with lightweight rendering and CTk-like API."""
@@ -595,7 +1018,7 @@ class LiteButton(ctk.CTkFrame):
         self.grid_propagate(False)
         self.pack_propagate(False)
 
-        self._canvas = tk.Canvas(self, highlightthickness=0, bd=0, bg="#242424")
+        self._canvas = tk.Canvas(self, highlightthickness=0, bd=0, bg="#2b2b2b")
         self._canvas.pack(fill="both", expand=True)
         self._canvas.bind("<Configure>", lambda _e: self._redraw())
         self._canvas.bind("<Enter>", self._on_enter)

--- a/gui/src/widgets/output_console.py
+++ b/gui/src/widgets/output_console.py
@@ -4,6 +4,7 @@ Output Console Widget - A read-only scrollable text area for CLI output.
 
 import threading
 import sys
+
 import tkinter.font as tk_font
 
 import customtkinter as ctk
@@ -16,36 +17,21 @@ class OutputConsole(ctk.CTkFrame):
 
     def __init__(self, master, **kwargs) -> None:
         super().__init__(master, **kwargs)
-        self._expanded = False
+        # Standalone window console: body always expanded, no fold header.
+        self._expanded = True
         self._lock = threading.Lock()
 
-        # Header stays visible; clicking it toggles the console body.
-        self.header = ctk.CTkFrame(
-            self, height=30, fg_color="transparent", cursor="hand2"
-        )
-        self.header.pack(fill="x", padx=5, pady=(5, 0))
-
-        self.toggle_label = ctk.CTkLabel(
-            self.header,
-            text="[+] Output Console",
-            font=("", 13, "bold"),
-            cursor="hand2",
-        )
-        self.toggle_label.pack(side="left")
-        self.toggle_label.bind("<Button-1>", self.toggle)
-        self.header.bind("<Button-1>", self.toggle)
-
         self.clear_button = ctk.CTkButton(
-            self.header, text="Clear", width=60, height=24, command=self.clear
+            self, text="Clear", width=60, height=24, command=self.clear
         )
-        self.clear_button.pack(side="right")
+        self.clear_button.pack(anchor="e", padx=5, pady=(5, 0))
 
         self.textbox = ctk.CTkTextbox(
-            self, state="disabled", font=self._mono_font(), wrap="none", height=200
+            self, state="disabled", font=self._mono_font(), wrap="none"
         )
+        self.textbox.pack(fill="both", expand=True, padx=5, pady=(0, 5))
         self.textbox.tag_config("lime", foreground="lime")
         self.textbox.tag_config("red", foreground="red")
-        self._set_expanded(False)
 
     @staticmethod
     def _mono_font() -> tuple[str, int]:
@@ -75,7 +61,13 @@ class OutputConsole(ctk.CTkFrame):
         self.append_batch([text])
 
     def append_batch(self, texts: list[str]) -> None:
-        """Append multiple chunks with one text-widget update."""
+        """Append multiple chunks in ONE text-widget update.
+
+        Each per-chunk append costs several Tcl round-trips plus see("end")
+        (which forces scroll relayout); batching N chunks into a single
+        insert/trim/see is ~150x cheaper for large bursts (e.g. streaming
+        autoscan output).
+        """
         if not texts:
             return
         with self._lock:
@@ -104,6 +96,7 @@ class OutputConsole(ctk.CTkFrame):
             if line_count > self._MAX_LINES:
                 self.textbox.delete("1.0", f"{line_count - self._MAX_LINES}.0")
 
+            # Scrolling a folded console is wasted re-render work
             if self._expanded:
                 self.textbox.see("end")
             self.textbox.configure(state="disabled")

--- a/gui/tests/test_dashboard_visibility.py
+++ b/gui/tests/test_dashboard_visibility.py
@@ -28,6 +28,7 @@ def make_dashboard(
     dashboard._polling = True
     dashboard._poll_job = None
     dashboard._interval_ms = 1000
+    dashboard._is_resize_active = False
     dashboard._consecutive_offline = 0
     dashboard._in_offline_backoff = False
     return dashboard, app

--- a/gui/tests/test_fan_control.py
+++ b/gui/tests/test_fan_control.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 from src.backend.base import FanSettings
-from src.controllers.fan_control import (
-    FanControlController,
-    fan_settings_to_cli_args,
-)
+from src.tabs.dashboard.sections.fan import FanControlController
 
 
 class FakePane:
@@ -167,27 +164,3 @@ def test_entry_change_clamps_level() -> None:
     FanControlController(pane, FakeBackend()).on_entry_change()
 
     assert pane.level == 100
-
-
-def test_fan_settings_to_cli_args() -> None:
-    args = fan_settings_to_cli_args(
-        ["--gpu=0"],
-        FanSettings(
-            backend="nvml-cooler",
-            fan_id="2",
-            policy="manual",
-            level=55,
-        ),
-    )
-
-    assert args == [
-        "--gpu=0",
-        "set",
-        "nvml-cooler",
-        "--id",
-        "2",
-        "--policy",
-        "manual",
-        "--level",
-        "55",
-    ]

--- a/gui/tests/test_gpu_hotplug.py
+++ b/gui/tests/test_gpu_hotplug.py
@@ -38,6 +38,7 @@ def make_dashboard() -> tuple[DashboardTab, FakeApp]:
     dashboard._polling = True
     dashboard._poll_job = None
     dashboard._interval_ms = 1000
+    dashboard._is_resize_active = False
     dashboard._consecutive_offline = 0
     dashboard._in_offline_backoff = False
     dashboard._offline_hint_logged = False

--- a/gui/tests/test_native_refresh_coalescing.py
+++ b/gui/tests/test_native_refresh_coalescing.py
@@ -16,6 +16,7 @@ class RefreshHarness:
         self._refresh_chain_after_id = None
         self.scheduled: list[tuple[int, object, str]] = []
         self.cancelled: list[str] = []
+        self._invalidate_query_cache = Mock()
         self._query_gpu_get = Mock()
         self._query_overclock_status = Mock()
         self.tab_dashboard = Mock()
@@ -43,11 +44,12 @@ def test_native_refresh_burst_keeps_only_latest_timer() -> None:
 
 def test_deferred_native_refresh_runs_each_query_once() -> None:
     app = RefreshHarness()
-    app.refresh_after_native_action()
+    app.refresh_after_native_action(curve_affecting=True)
 
     app.scheduled[-1][1]()
 
     assert app._refresh_chain_after_id is None
+    app._invalidate_query_cache.assert_called_once_with()
     app._query_gpu_get.assert_called_once_with()
     app._query_overclock_status.assert_called_once_with()
     app.tab_dashboard._fetch_once.assert_called_once_with()

--- a/gui/tests/test_overclock.py
+++ b/gui/tests/test_overclock.py
@@ -4,7 +4,7 @@ import sys
 import types
 
 
-fan_control_stub = types.ModuleType("src.panes.fan_control")
+fan_control_stub = types.ModuleType("src.tabs.dashboard.sections.fan")
 
 
 class FanControlPane:
@@ -12,9 +12,9 @@ class FanControlPane:
 
 
 fan_control_stub.FanControlPane = FanControlPane
-sys.modules.setdefault("src.panes.fan_control", fan_control_stub)
+sys.modules.setdefault("src.tabs.dashboard.sections.fan", fan_control_stub)
 
-from src.tabs.overclock import OverclockTab  # noqa: E402
+from src.tabs.dashboard.sections.overclock import OverclockTab  # noqa: E402
 
 
 class FakeVar:
@@ -45,6 +45,44 @@ class FakeNative:
     ) -> None:
         self.calls.append(("set_clock_offset", gpu, backend, domain, offset, pstate))
 
+    def set_volt_rail_target(
+        self, gpu: str, rail_bit: int, target_mv: float, expect_type
+    ) -> dict:
+        # pynvoc's set_volt_rail_target always returns a dict (NOT None like
+        # the other setters), so the apply path must format the message from
+        # it rather than use `setter() or "msg"`. Mirror the real payload
+        # (target_uV is an i32 µV integer in the real binding).
+        self.calls.append((
+            "set_volt_rail_target",
+            gpu,
+            rail_bit,
+            target_mv,
+            expect_type,
+        ))
+        return {"applied": True, "effective_wall_uV": int(target_mv * 1000)}
+
+    def set_tgp_watt(self, gpu: str, watts: int, policy_index: int) -> None:
+        self.calls.append(("set_tgp_watt", gpu, watts, policy_index))
+
+    def set_clk_domain_offset(
+        self, gpu: str, domain_bit: int, offset_khz: int, slot, temporary
+    ) -> dict:
+        # Like set_volt_rail_target: always returns a dict (never None), so
+        # the apply paths must format the message from it. Mirror the real
+        # payload (applied_kHz is the driver readback).
+        self.calls.append((
+            "set_clk_domain_offset",
+            gpu,
+            domain_bit,
+            offset_khz,
+            slot,
+            temporary,
+        ))
+        return {"applied": True, "bit": domain_bit, "applied_kHz": offset_khz}
+
+    def set_target_temp(self, gpu: str, tlimit: float, policy_index: int) -> None:
+        self.calls.append(("set_target_temp", gpu, tlimit, policy_index))
+
 
 class FakeApp:
     def __init__(self) -> None:
@@ -68,7 +106,10 @@ class FakeApp:
             action(self.native)
 
 
-def make_tab() -> tuple[OverclockTab, FakeApp]:
+def make_tab(
+    xbar_supported: bool = False,
+    xbar_value: str = "10",
+) -> tuple[OverclockTab, FakeApp]:
     app = FakeApp()
     tab = OverclockTab.__new__(OverclockTab)
     tab.app = app
@@ -79,7 +120,12 @@ def make_tab() -> tuple[OverclockTab, FakeApp]:
     tab._vfp_uniform_offset_mhz = None
     tab.core_var = FakeVar("125")
     tab.mem_var = FakeVar("600")
+    tab.core_slider = FakeSlider("normal")
+    tab.mem_slider = FakeSlider("normal")
     tab.oc_api_var = FakeVar("NVAPI")
+    tab._xbar_supported = xbar_supported
+    tab.xbar_var = FakeVar(xbar_value)
+    tab.xbar_slider = FakeSlider("normal")
     return tab, app
 
 
@@ -116,3 +162,403 @@ def test_apply_offset_runs_core_and_memory_while_vfp_offset_exists() -> None:
         ("set_clock_offset", "GPU0", "nvapi", "core", 125, "P0"),
         ("set_clock_offset", "GPU0", "nvapi", "memory", 600, "P0"),
     ]
+
+
+# ── Volt Limit (mobile-only VoltRails target) ──────────────────────────────
+
+
+class FakeSlider:
+    """Minimal slider stub: only ``cget("state")`` is exercised by the
+    mobile apply paths."""
+
+    def __init__(self, state: str = "normal") -> None:
+        self._state = state
+
+    def cget(self, key: str) -> str:
+        if key == "state":
+            return self._state
+        return ""
+
+    def set(self, _value) -> None:
+        pass
+
+
+def make_mobile_tab(
+    vlimit_value: str = "1085",
+    vlimit_state: str = "normal",
+    tlimit_value: str = "85",
+    plimit_value: str = "30",
+) -> tuple[OverclockTab, FakeApp]:
+    """A mobile-mode tab with only the attrs the volt-rail apply paths touch."""
+    app = FakeApp()
+    tab = OverclockTab.__new__(OverclockTab)
+    tab.app = app
+    tab._syncing = False
+    tab._mobile_mode = True
+    tab._mobile_load_in_flight = (
+        True  # short-circuit _load_mobile_limits() in on_finished
+    )
+    tab._volt_rail_bit = 0
+    tab.vlimit_var = FakeVar(vlimit_value)
+    tab.vlimit_slider = FakeSlider(vlimit_state)
+    tab.tlimit_var = FakeVar(tlimit_value)
+    tab.tlimit_slider = FakeSlider("normal")
+    tab.plimit_var = FakeVar(plimit_value)
+    tab.plimit_slider = FakeSlider("normal")
+    tab._tgp_policy_index = 2
+    return tab, app
+
+
+def test_volt_limit_bounds_takes_min_of_walls() -> None:
+    p0 = {
+        "vbios_wall_uV": 1_210_000,
+        "vrm_max_wall_uV": 1_180_000,
+        "effective_wall_uV": 1_080_000,
+    }
+    assert OverclockTab._volt_limit_bounds_from_p0(p0) == (300.0, 1180.0, 1080.0)
+
+
+def test_volt_limit_bounds_ignores_zero_wall() -> None:
+    # VRM not reported (0) → ceiling is the VBIOS wall alone.
+    p0 = {
+        "vbios_wall_uV": 1_210_000,
+        "vrm_max_wall_uV": 0,
+        "effective_wall_uV": 1_080_000,
+    }
+    assert OverclockTab._volt_limit_bounds_from_p0(p0) == (300.0, 1210.0, 1080.0)
+
+
+def test_volt_limit_bounds_falls_back_to_1200mv_when_both_zero() -> None:
+    p0 = {"vbios_wall_uV": 0, "vrm_max_wall_uV": 0, "effective_wall_uV": 0}
+    assert OverclockTab._volt_limit_bounds_from_p0(p0) == (300.0, 1200.0, 1200.0)
+
+
+def test_volt_limit_bounds_clamps_position_into_range() -> None:
+    # effective wall above the ceiling → clamped down to max.
+    p0 = {
+        "vbios_wall_uV": 1_100_000,
+        "vrm_max_wall_uV": 1_100_000,
+        "effective_wall_uV": 1_250_000,
+    }
+    assert OverclockTab._volt_limit_bounds_from_p0(p0) == (300.0, 1100.0, 1100.0)
+
+
+def test_volt_limit_bounds_snaps_position_to_2_5mv_grid() -> None:
+    # effective wall not on the 2.5 mV slider grid → snapped to nearest so
+    # the one-decimal entry text and the canvas thumb agree (1083 mV → 1082.5).
+    p0 = {
+        "vbios_wall_uV": 1_210_000,
+        "vrm_max_wall_uV": 1_180_000,
+        "effective_wall_uV": 1_083_000,
+    }  # 1083 mV → snaps to 1082.5
+    assert OverclockTab._volt_limit_bounds_from_p0(p0) == (300, 1180, 1082.5)
+
+
+def test_volt_limit_bounds_snaps_ceiling_down_to_grid() -> None:
+    # A ceiling that is not on the 2.5 mV grid snaps DOWN so no offered slider
+    # position exceeds the actual wall (1186 mV → 1185, not 1187.5).
+    p0 = {
+        "vbios_wall_uV": 1_186_000,
+        "vrm_max_wall_uV": 0,
+        "effective_wall_uV": 1_080_000,
+    }
+    min_mv, max_mv, _pos = OverclockTab._volt_limit_bounds_from_p0(p0)
+    assert (min_mv, max_mv) == (300, 1185)
+
+
+def test_resolve_volt_rail_bit_from_descriptors() -> None:
+    vr = {"rail_descriptors": [{"rail_bit": 1, "type": 3}]}
+    assert (
+        OverclockTab._resolve_volt_rail_bit(OverclockTab.__new__(OverclockTab), vr) == 1
+    )
+
+
+def test_resolve_volt_rail_bit_falls_back_to_mask_lsb() -> None:
+    vr = {"rail_mask": "0x00000001"}
+    tab = OverclockTab.__new__(OverclockTab)
+    assert tab._resolve_volt_rail_bit(vr) == 0
+
+
+def test_apply_vlimit_only_calls_set_volt_rail_target() -> None:
+    tab, app = make_mobile_tab(vlimit_value="1085")
+
+    tab._apply_vlimit_only()
+
+    assert app.actions == ["apply volt-rail target"]
+    assert app.native.calls == [("set_volt_rail_target", "GPU0", 0, 1085.0, None)]
+
+
+def test_apply_vlimit_only_accepts_decimal_mv() -> None:
+    # 10/20-series rail step is 12.5 mV → one decimal (2.5 mV grid) must flow
+    # through to the pynvoc setter as a float.
+    tab, app = make_mobile_tab(vlimit_value="1082.5")
+
+    tab._apply_vlimit_only()
+
+    assert app.actions == ["apply volt-rail target"]
+    assert app.native.calls == [("set_volt_rail_target", "GPU0", 0, 1082.5, None)]
+
+
+def test_apply_vlimit_action_returns_str_not_dict() -> None:
+    # Regression: set_volt_rail_target returns a dict (not None), so the
+    # `setter() or "msg"` pattern yielded the dict and crashed the native
+    # worker at output.endswith(). The action MUST format a string.
+    tab, app = make_mobile_tab(vlimit_value="1085")
+    captured = {}
+
+    class CapturingApp(FakeApp):
+        def run_native_action(self, description, action, on_finished=None):
+            captured["output"] = action(self.native)
+            super().run_native_action(description, action, on_finished)
+
+    tab.app = CapturingApp()
+    tab.app.console = app.console
+    tab.app.native = app.native
+    tab.app.actions = []
+
+    tab._apply_vlimit_only()
+
+    assert isinstance(captured["output"], str)
+
+
+def test_apply_vlimit_only_skips_non_numeric() -> None:
+    tab, app = make_mobile_tab(vlimit_value="abc")
+
+    tab._apply_vlimit_only()
+
+    assert app.actions == []
+    assert app.native.calls == []
+
+
+def test_format_volt_rail_target_result_surfaces_effective_wall() -> None:
+    result = {"applied": True, "effective_wall_uV": 1_080_000}
+    msg = OverclockTab._format_volt_rail_target_result(1085.0, result)
+    assert "1085 mV" in msg
+    assert "effective wall 1080 mV" in msg
+
+
+def test_format_volt_rail_target_result_decimal_mv() -> None:
+    # A half-mV target and a half-mV effective wall both render with the
+    # decimal intact (not truncated to 1082 / 1083).
+    result = {"applied": True, "effective_wall_uV": 1_082_500}
+    msg = OverclockTab._format_volt_rail_target_result(1082.5, result)
+    assert "1082.5 mV" in msg
+    assert "effective wall 1082.5 mV" in msg
+
+
+def test_format_volt_rail_target_result_unsupported() -> None:
+    # set_volt_rail_target returns {"supported": False} when the driver
+    # exposes no VoltRails path. This MUST yield a string (not the dict),
+    # or the native worker's output.endswith() crashes.
+    msg = OverclockTab._format_volt_rail_target_result(1085.0, {"supported": False})
+    assert isinstance(msg, str)
+    assert "not supported" in msg
+
+
+def test_apply_limits_mobile_includes_volt_rail() -> None:
+    tab, app = make_mobile_tab(vlimit_value="1085")
+
+    tab._apply_limits()
+
+    # All three mobile limit actions are chained.
+    assert "apply volt-rail target" in app.actions
+    assert app.native.calls[-1] == ("set_volt_rail_target", "GPU0", 0, 1085.0, None)
+
+
+def test_apply_limits_mobile_skips_disabled_volt_slider() -> None:
+    tab, app = make_mobile_tab(vlimit_value="1085", vlimit_state="disabled")
+
+    tab._apply_limits()
+
+    assert not any(call[0] == "set_volt_rail_target" for call in app.native.calls)
+
+
+# ── Xbar (ClockClient domain offset, NVAPI-only) ───────────────────────────
+
+
+def test_xbar_supported_arch_chip_codes() -> None:
+    # pynvoc ArchInfo Display: chip codes, optionally ":rev"-suffixed.
+    f = OverclockTab._xbar_supported_arch
+    assert f("tu106") is True  # Turing: GTX 16系 + RTX 20系
+    assert f("tu117") is True
+    assert f("ad107m") is True  # Ada (40系 laptop)
+    assert f("AD107M:A1") is True
+    assert f("ga102") is True  # Ampere (30系)
+    assert f("gb202") is True  # Blackwell (50系)
+    assert f("gp104") is False  # Pascal (10系) — too old
+    assert f("gv100") is False  # Volta — too old
+    assert f("gm204") is False
+    assert f("") is False
+
+
+def test_xbar_supported_arch_friendly_names() -> None:
+    # CLI human output: friendly architecture names.
+    f = OverclockTab._xbar_supported_arch
+    assert f("Turing") is True
+    assert f("Ampere") is True
+    assert f("Ada") is True
+    assert f("Blackwell") is True
+    assert f("Pascal") is False
+    assert f("Maxwell") is False
+
+
+def test_apply_xbar_only_converts_mhz_to_khz() -> None:
+    # GUI speaks MHz; pynvoc takes kHz. xbar = ClockClient domain bit 1.
+    tab, app = make_tab(xbar_value="10")
+
+    tab._apply_xbar_only()
+
+    assert app.actions == ["apply xbar offset"]
+    assert app.native.calls == [
+        ("set_clk_domain_offset", "GPU0", 1, 10_000, None, None)
+    ]
+
+
+def test_apply_xbar_action_returns_str_not_dict() -> None:
+    # Regression: set_clk_domain_offset returns a dict (not None), so the
+    # action MUST format a string or the native worker's output.endswith()
+    # crashes (same class of bug as the volt-rail one).
+    tab, app = make_tab(xbar_value="10")
+    captured = {}
+
+    class CapturingApp(FakeApp):
+        def run_native_action(self, description, action, on_finished=None):
+            captured["output"] = action(self.native)
+            super().run_native_action(description, action, on_finished)
+
+    tab.app = CapturingApp()
+    tab.app.console = app.console
+    tab.app.native = app.native
+    tab.app.actions = []
+
+    tab._apply_xbar_only()
+
+    assert isinstance(captured["output"], str)
+    assert "10 MHz" in captured["output"]
+
+
+def test_format_xbar_offset_result_surfaces_readback() -> None:
+    result = {"applied": True, "applied_kHz": 15_000}
+    msg = OverclockTab._format_xbar_offset_result(15, result)
+    assert "+15 MHz" in msg
+    assert "readback +15 MHz" in msg
+
+
+def test_format_xbar_offset_result_unsupported() -> None:
+    msg = OverclockTab._format_xbar_offset_result(10, {"supported": False})
+    assert isinstance(msg, str)
+    assert "not supported" in msg
+
+
+def test_apply_oc_includes_xbar_when_supported() -> None:
+    tab, app = make_tab(xbar_supported=True, xbar_value="10")
+
+    tab._apply_oc()
+
+    assert "apply xbar offset" in app.actions
+    assert ("set_clk_domain_offset", "GPU0", 1, 10_000, None, None) in [
+        c for c in app.native.calls if c[0] == "set_clk_domain_offset"
+    ]
+
+
+def test_apply_oc_skips_xbar_when_unsupported() -> None:
+    tab, app = make_tab(xbar_supported=False)
+
+    tab._apply_oc()
+
+    assert not any(c[0] == "set_clk_domain_offset" for c in app.native.calls)
+
+
+def test_apply_oc_skips_xbar_when_disabled() -> None:
+    # NVML selection greys the row out -> Apply Section must skip it.
+    tab, app = make_tab(xbar_supported=True, xbar_value="10")
+    tab.xbar_slider = FakeSlider("disabled")
+
+    tab._apply_oc()
+
+    assert not any(c[0] == "set_clk_domain_offset" for c in app.native.calls)
+
+
+def test_reset_oc_resets_xbar_when_supported() -> None:
+    tab, app = make_tab(xbar_supported=True, xbar_value="10")
+
+    tab._reset_oc()
+
+    assert tab.xbar_var.get() == "0"
+    assert ("set_clk_domain_offset", "GPU0", 1, 0, None, None) in [
+        c for c in app.native.calls if c[0] == "set_clk_domain_offset"
+    ]
+
+
+def test_xbar_supported_from_info_prefers_payload_flag() -> None:
+    # The pynvoc query_info payload carries xbar_supported computed by core's
+    # detect_gpu_type — the single source of truth. It wins even when the
+    # arch string would confuse a heuristic (Ada reports 'Unknown:...').
+    f = OverclockTab._xbar_supported_from_info
+    info = {
+        "xbar_supported": True,
+        "gpu_architecture": "Unknown:400:7:161",
+        "codename": "AD107-B",
+        "gpu_name": "NVIDIA GeForce RTX 4060 Laptop GPU",
+    }
+    assert f(info) is True
+    # Flag False wins too (e.g. Pascal with a misleading name).
+    assert f({**info, "xbar_supported": False}) is False
+
+
+def test_xbar_supported_from_info_falls_back_without_flag() -> None:
+    # CLI-parsed / NVML-only / older-pynvoc payloads lack the flag → the
+    # local heuristic (codename first, then arch, then marketing name).
+    f = OverclockTab._xbar_supported_from_info
+    assert f({"codename": "AD107-B", "gpu_name": "RTX 4060 Laptop"}) is True
+    assert f({"gpu_architecture": "tu116"}) is True
+    assert f({"gpu_name": "NVIDIA GeForce GTX 1080"}) is False
+    assert f({}) is False
+
+
+def test_core_apply_accepts_decimal_mhz() -> None:
+    # 2.5 MHz grid: one decimal flows through to pynvoc as a float
+    # (7.5/12.5 MHz hardware steps both divide the grid).
+    tab, app = make_tab()
+    tab.core_var = FakeVar("122.5")
+
+    tab._apply_core_only()
+
+    assert app.actions == ["apply core offset"]
+    assert app.native.calls == [
+        ("set_clock_offset", "GPU0", "nvapi", "core", 122.5, "P0")
+    ]
+
+
+def test_apply_oc_core_decimal_survives_section_apply() -> None:
+    tab, app = make_tab()
+    tab.core_var = FakeVar("122.5")
+
+    tab._apply_oc()
+
+    assert ("set_clock_offset", "GPU0", "nvapi", "core", 122.5, "P0") in (
+        app.native.calls
+    )
+
+
+def test_fmt_slider_value_signs_decimals_rows_and_zero() -> None:
+    # Core offset row: signed + decimals=1 → explicit sign on positives AND
+    # zero (+0.0), matching the integer signed rows' +0.
+    class SignedDecimalSlider:
+        _oc_decimals = 1
+        _oc_signed = True
+
+    class SignedIntSlider:
+        _oc_decimals = 0
+        _oc_signed = True
+
+    class PlainSlider:
+        _oc_decimals = 0
+        _oc_signed = False
+
+    f = OverclockTab._fmt_slider_value
+    assert f(SignedDecimalSlider(), 122.5) == "+122.5"
+    assert f(SignedDecimalSlider(), 0) == "+0.0"
+    assert f(SignedDecimalSlider(), -25.0) == "-25.0"
+    assert f(SignedIntSlider(), 0) == "+0"
+    assert f(PlainSlider(), 0) == "0"

--- a/gui/tests/test_parsing.py
+++ b/gui/tests/test_parsing.py
@@ -9,7 +9,6 @@ from src.parsing import (
     native_query_payload,
     normalize_native_vfp_lock_bounds,
     parse_dashboard_status,
-    parse_gpu_list_output,
     parse_info_limits,
     parse_legacy_overvolt_bounds,
     parse_status_current_values,
@@ -17,20 +16,6 @@ from src.parsing import (
     parse_vfp_lock_bounds,
     write_vfp_points,
 )
-
-
-def test_parse_gpu_list_output_keeps_first_name_and_uuid() -> None:
-    output = """
-    GPU 0: NVIDIA GeForce RTX 3060 UUID=GPU-1234-5678
-    GPU 0: ID:0x0800 bus:12345678
-    """
-
-    short, long, names, uuid_map = parse_gpu_list_output(output)
-
-    assert short == {0: "GPU 0: NVIDIA GeForce RTX 3060"}
-    assert long == {0: "GPU 0: NVIDIA GeForce RTX 3060  [GPU-1234-5678]"}
-    assert names == {0: "NVIDIA GeForce RTX 3060"}
-    assert uuid_map == {0: "GPU-1234-5678"}
 
 
 def test_parse_info_limits_text_output() -> None:

--- a/gui/tests/test_vfcurve_space_lock.py
+++ b/gui/tests/test_vfcurve_space_lock.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from src.tabs.vfcurve import VFCurveTab
+from src.tabs.vfcurve.tab import VFCurveTab
 
 
 class FakeVar:


### PR DESCRIPTION
Restores the nested GUI dashboard/VF-curve modules and associated backend wiring removed by 046b74b18e19aa9a48ac15b2e5fb21f5e7cc37e4. This is the complete tree from the physicsdolphin recovery line, including its GUI tests and follow-up curve layout fixes.

The previous 70acbdd recovery was incomplete: it deleted flat modules without adding the nested modules, leaving gui/src/app.py imports broken.

Validation on a stack with #313/#314:
- uv sync --locked
- uv run pytest (98 passed)

Related: #267; depends on #313 and #314.