### PR TITLE
fix(tui): restore physicsdolphin monitoring and control surfaces

### DIFF
--- a/tui/AGENTS.md
+++ b/tui/AGENTS.md
@@ -42,9 +42,9 @@ This repository contains `nvoc-tui`, a Textual-based terminal UI for the externa
   - `info`
   - `status`
   - `settings`
-  - `vf_curve_path`
+  - `vf_curve_points` (in-memory VFP points; no disk round-trip)
 - GPU selection is derived from `#gpu-select`; command helpers should go through `gpu_args()` instead of re-implementing `--gpu=...`.
-- VF curve exports are cached under `vfp_cache/` in the repo root, keyed by GPU UUID when available.
+- VF curve refresh happens fully in memory; CSV files are only written/read by the explicit export/import actions.
 
 ## Concurrency Notes
 

--- a/tui/nvoc_tui/app.py
+++ b/tui/nvoc_tui/app.py
@@ -17,7 +17,7 @@ from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container
-from textual.widgets import Button, Label, Select, TabbedContent
+from textual.widgets import Button, Checkbox, Label, Select, TabbedContent
 
 from .config import ConfigStore
 from .controllers.console import ConsoleController
@@ -35,7 +35,13 @@ from .panes.vfcurve import compose_vfcurve
 
 
 def _is_offline_error(output: str) -> bool:
-    """Return whether a query failed because the NVIDIA GPU disappeared."""
+    """True when a failed query's error indicates the dGPU is gone/unreachable.
+
+    Matches the signatures seen when the user disables the dGPU (stale NVAPI
+    handle → ApiNotInitialized) or when enumeration finds no GPU
+    (NoImplementation / NvidiaDeviceNotFound). Used to suppress per-tick error
+    spam and trigger backoff instead of flooding the console.
+    """
     if not output:
         return False
     lowered = output.lower()
@@ -107,6 +113,8 @@ class NVOCApp(App[None]):
         self.native_service = NativeService(self.root_dir)
         self.gpus: list[GpuDescriptor] = []
         self.cache = GpuCache()
+        # Background GPU re-probe timer (scenario A: dGPU disabled at startup).
+        # Re-runs discovery until a GPU lands, then stops itself.
         self._gpu_reprobe_timer = None
 
         self.header_controller = HeaderController(self)
@@ -208,7 +216,12 @@ class NVOCApp(App[None]):
         start_next()
 
     def run_query(
-        self, command_name: str, callback, *, log_output: bool = True
+        self,
+        command_name: str,
+        callback,
+        *,
+        log_output: bool = True,
+        allow_wake: bool = True,
     ) -> None:
         gpu = self.selected_gpu_target()
         if gpu is None:
@@ -218,6 +231,10 @@ class NVOCApp(App[None]):
             return
 
         def finish_query(code: int, output: str, parsed: dict) -> None:
+            # Suppress per-tick error spam when the dGPU is offline: the
+            # dashboard controller counts these and enters a backoff that
+            # logs a single hint + re-probes. Logging every failed tick
+            # (every second) flooded the console with ApiNotInitialized.
             if code != 0 and _is_offline_error(output):
                 callback(code, output, parsed)
                 return
@@ -226,15 +243,31 @@ class NVOCApp(App[None]):
             callback(code, output, parsed)
 
         def worker() -> None:
-            code, output, parsed = self.native_service.run_query(gpu, command_name)
+            code, output, parsed = self.native_service.run_query(
+                gpu, command_name, allow_wake=allow_wake
+            )
             self.call_from_thread(finish_query, code, output, parsed)
 
         self.native_service.submit_query(worker)
 
+    def refresh_gpu_list(self) -> None:
+        def worker() -> None:
+            code, output, gpus = self.native_service.list_gpus()
+            self.call_from_thread(
+                self.header_controller.on_gpu_list_loaded, code, output, gpus
+            )
+
+        self.native_service.submit_query(worker)
+
     def start_gpu_reprobe(self) -> None:
-        """Retry discovery until an NVIDIA GPU becomes available."""
-        if self._gpu_reprobe_timer is None:
-            self._gpu_reprobe_timer = self.set_interval(5.0, self._gpu_reprobe_tick)
+        """Begin background GPU rediscovery (scenario A: no GPU at startup).
+
+        Re-runs discovery every few seconds until a non-empty GPU list lands,
+        then stops itself. Lets the TUI pick up the dGPU when re-enabled.
+        """
+        if self._gpu_reprobe_timer is not None:
+            return
+        self._gpu_reprobe_timer = self.set_interval(5.0, self._gpu_reprobe_tick)
 
     def _gpu_reprobe_tick(self) -> None:
         if not self.gpus:
@@ -246,15 +279,6 @@ class NVOCApp(App[None]):
         if self._gpu_reprobe_timer is not None:
             self._gpu_reprobe_timer.stop()
             self._gpu_reprobe_timer = None
-
-    def refresh_gpu_list(self) -> None:
-        def worker() -> None:
-            code, output, gpus = self.native_service.list_gpus()
-            self.call_from_thread(
-                self.header_controller.on_gpu_list_loaded, code, output, gpus
-            )
-
-        self.native_service.submit_query(worker)
 
     def focus_dashboard_tab_switcher(self) -> None:
         self.switch_to_tab("dashboard")
@@ -367,6 +391,35 @@ class NVOCApp(App[None]):
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id == "gpu-select":
             self.header_controller.on_gpu_selected(event.value)
+        elif event.select.id == "vf-active-curve":
+            if self.vfcurve_controller._syncing:
+                # Echo of a programmatic sync write — acting on it resonates
+                # into a switch ping-pong (render storm + leaked workers).
+                return
+            if event.value is Select.BLANK:
+                # set_options() transiently blanks the Select; treating the
+                # blank as a real switch would re-enter the sync path and
+                # can resonate into an event echo loop.
+                return
+            curve_id = str(event.value)
+            # Programmatic sync echoes arrive with the value already active —
+            # the controller ignores no-op switches.
+            self.vfcurve_controller._switch_active_curve(curve_id)
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        checkbox_id = event.checkbox.id or ""
+        if not checkbox_id.startswith("vf-curve-"):
+            return
+        if self.vfcurve_controller._syncing:
+            return  # programmatic sync echo — not a user toggle
+        curve_id = checkbox_id[len("vf-curve-") :]
+        # Only act when the requested state differs from the current one —
+        # programmatic syncs and veto snap-backs echo through here.
+        if bool(event.value) == self.vfcurve_controller._curve_visible.get(
+            curve_id, True
+        ):
+            return
+        self.vfcurve_controller._toggle_curve_visible(curve_id, event.checkbox)
 
     def on_resize(self, event) -> None:
         del event

--- a/tui/nvoc_tui/controllers/dashboard.py
+++ b/tui/nvoc_tui/controllers/dashboard.py
@@ -9,6 +9,13 @@ from .base import PaneController
 
 
 class DashboardController(PaneController):
+    # First sample may wake the GPU; later polls never block GC6 sleep.
+    _first_success = False
+    # dGPU-offline backoff: consecutive failed polls whose error looks like a
+    # dead/disappearing GPU (ApiNotInitialized after the user disabled the
+    # dGPU, NoImplementation when enumeration finds no GPU) trigger a slow
+    # re-probe cadence. Each backoff tick re-runs GPU discovery so the dGPU is
+    # auto-detected when it returns; one successful poll exits backoff.
     _OFFLINE_FAIL_THRESHOLD = 3
     _OFFLINE_BACKOFF_S = 5.0
     _OFFLINE_BACKOFF_CAP_S = 15.0
@@ -27,12 +34,12 @@ class DashboardController(PaneController):
         self._user_interval = interval
         self.app.config_data.dashboard.refresh_interval = interval
         self.app.save_config()
+        # In backoff we ignore the user interval and use the slow re-probe rate.
+        effective = self._effective_interval()
         if self.poll_timer is not None:
             self.poll_timer.stop()
         self._timer_paused = False
-        self.poll_timer = self.app.set_interval(
-            self._effective_interval(), self.tick, pause=False
-        )
+        self.poll_timer = self.app.set_interval(effective, self.tick, pause=False)
 
     def _effective_interval(self) -> float:
         if not self._in_offline_backoff:
@@ -43,10 +50,19 @@ class DashboardController(PaneController):
     def tick(self) -> None:
         if self.app.native_service.action_state.running:
             return
+        # In offline backoff, re-probe GPU discovery instead of a doomed NVAPI
+        # status sweep. discover re-enumerates from the driver, so the dGPU is
+        # picked up the moment it returns; the next status poll then succeeds
+        # and exits backoff.
         if self._in_offline_backoff:
             self.app.refresh_gpu_list()
             return
-        self.app.run_query("status", self.on_status_loaded, log_output=False)
+        self.app.run_query(
+            "status",
+            self.on_status_loaded,
+            log_output=False,
+            allow_wake=not self._first_success,
+        )
 
     @staticmethod
     def _looks_like_offline_error(output: str) -> bool:
@@ -74,17 +90,27 @@ class DashboardController(PaneController):
         self._in_offline_backoff = True
         if not self._offline_hint_logged:
             self._offline_hint_logged = True
-            self.app.write_log(
-                "dGPU probably offline — polling paused, re-probing for the "
-                "GPU to come back."
-            )
+            try:
+                self.app.write_log(
+                    "dGPU probably offline — polling paused, re-probing for the "
+                    "GPU to come back."
+                )
+            except Exception:
+                pass
+        # Re-arm the timer at the backoff cadence and kick a rediscovery now.
         self.set_poll_timer(self._user_interval)
-        self.app.refresh_gpu_list()
+        try:
+            self.app.refresh_gpu_list()
+        except Exception:
+            pass
 
     def _exit_offline_backoff(self) -> None:
         if self._in_offline_backoff:
             self._in_offline_backoff = False
-            self.app.write_log("dGPU back online — resuming polling.")
+            try:
+                self.app.write_log("dGPU back online — resuming polling.")
+            except Exception:
+                pass
             self.set_poll_timer(self._user_interval)
         self._consecutive_offline = 0
         self._offline_hint_logged = False
@@ -98,16 +124,20 @@ class DashboardController(PaneController):
 
     def on_status_loaded(self, code: int, output: str, parsed: dict) -> None:
         if code == 0:
+            self._first_success = True
             self._exit_offline_backoff()
         elif self._looks_like_offline_error(output):
+            # Suppress the per-second error spam; backoff handles re-probing.
             self._record_offline_failure()
             return
         if code != 0 and not parsed:
             return
         self.app.cache.status = parsed
         self.update_metrics()
-        if self.app.cache.vf_curve_points:
-            self.app.vfcurve_controller.render_plot()
+        if self.app.cache.vf_curve_points or self.app.cache.vf_curves:
+            # Re-render the GPC live point (status feed) and kick the
+            # direct-read poll when the active curve is xbar/host.
+            self.app.vfcurve_controller.poll_live()
 
     def on_get_loaded(self, code: int, output: str, parsed: dict) -> None:
         if code != 0:
@@ -156,9 +186,9 @@ class DashboardController(PaneController):
             self.app.run_query("info", self.on_info_loaded)
             return True
         if button_id == "dashboard-status":
-            self.app.run_query("status", self.on_status_loaded)
+            self.app.run_query("status", self.on_status_loaded, allow_wake=False)
             return True
         if button_id == "dashboard-get":
-            self.app.run_query("get", self.on_get_loaded)
+            self.app.run_query("get", self.on_get_loaded, allow_wake=False)
             return True
         return False

--- a/tui/nvoc_tui/controllers/header.py
+++ b/tui/nvoc_tui/controllers/header.py
@@ -7,7 +7,14 @@ from .base import PaneController
 
 
 def _is_discovery_offline_error(output: str) -> bool:
-    """Return whether discovery failed because the NVIDIA GPU disappeared."""
+    """True when a failed GPU discovery's error indicates the dGPU is gone.
+
+    Discovery re-runs on the offline-backoff cadence (after the user disabled
+    the dGPU), and `NvAPI_EnumPhysicalGPUs` returns ApiNotInitialized /
+    NoImplementation / NvidiaDeviceNotFound while the dGPU is off. Suppressing
+    these per-tick errors keeps the console quiet during backoff; the dashboard
+    already logged a single "dGPU probably offline" hint.
+    """
     if not output:
         return False
     lowered = output.lower()
@@ -54,15 +61,25 @@ class HeaderController(PaneController):
     def on_gpu_list_loaded(
         self, code: int, output: str, gpus: list[GpuDescriptor]
     ) -> None:
-        if code == 0 or not _is_discovery_offline_error(output):
+        # Suppress per-tick discovery-error spam during offline backoff: the
+        # dashboard logged one "dGPU probably offline" hint and is re-probing
+        # on a slow cadence. Logging every failed re-probe (each producing
+        # "NvAPI_EnumPhysicalGPUs failed: API_NOT_INITIALIZED") floods the
+        # console. A successful detection always logs "GPU detection finished."
+        if code != 0 and _is_discovery_offline_error(output):
+            pass  # silent — backoff hint already logged
+        else:
             self.app.write_log(output or "GPU detection finished.")
         self.app.gpus = gpus
         select = self.app.query_one("#gpu-select", Select)
         if not gpus:
             select.set_options([("(no GPUs found)", "-1")])
             select.value = "-1"
+            # No GPU detected (dGPU disabled at launch or just removed) —
+            # re-probe in the background until one appears.
             self.app.start_gpu_reprobe()
             return
+        # A GPU landed — stop the background re-probe.
         self.app._stop_gpu_reprobe()
         select.set_options([(gpu.long_label, str(gpu.index)) for gpu in gpus])
         target = self.app.config_data.last_gpu_idx

--- a/tui/nvoc_tui/controllers/overclock.py
+++ b/tui/nvoc_tui/controllers/overclock.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
+import re
+import threading
+
 from textual.widgets import Input, Select
 
 from .base import PaneController
 
 
 class OverclockController(PaneController):
+    def __init__(self, app) -> None:
+        super().__init__(app)
+        self._mobile_limits_gpu: str | None = None
+        self._mobile_load_lock = threading.Lock()
+        self._tgp_policy_index = 2
+        self._tgp_range = (5, 140)
+        self._target_temp_range = (75, 87)
+        # VoltRails state for the mobile Volt Limit row (GUI dashboard parity).
+        self._volt_rail_bit = 0  # rail bit (0 on single-rail mobile GPUs)
+        self._volt_limit_range = (300.0, 1200.0)  # mV, walls refine the ceiling
+        self._volt_limit_supported = False
+
     def available_pstates(self) -> list[str]:
         pstates = self.app.cache.settings.get("supported_pstates", [])
         if not isinstance(pstates, list):
@@ -91,6 +106,16 @@ class OverclockController(PaneController):
                 self.app.query_one(selector, Input).value = value
             except Exception:
                 pass
+        # Xbar is NVAPI-only; grey the row out under NVML or on pre-Turing
+        # archs (GUI hides the row entirely — the TUI keeps layout stable
+        # and disables instead).
+        try:
+            self.app.query_one("#xbar-offset", Input).disabled = not (
+                self.xbar_supported()
+            )
+        except Exception:
+            pass
+        self.load_mobile_limits()
 
     def apply_oc(
         self,
@@ -99,10 +124,192 @@ class OverclockController(PaneController):
         backend: str,
         core_offset: int,
         mem_offset: int,
+        xbar_offset: int | None = None,
     ) -> str:
+        messages = []
         native.set_clock_offset(gpu, backend, "core", core_offset, "P0")
         native.set_clock_offset(gpu, backend, "memory", mem_offset, "P0")
-        return f"Successfully applied {backend} overclock."
+        messages.append(f"Successfully applied {backend} overclock.")
+        if xbar_offset is not None:
+            messages.append(
+                self._format_xbar_offset_result(
+                    xbar_offset,
+                    native.set_clk_domain_offset(
+                        gpu, 1, xbar_offset * 1000, None, None
+                    ),
+                )
+            )
+        return "\n".join(messages)
+
+    def xbar_supported(self) -> bool:
+        """Xbar support verdict (port of the GUI dashboard gate).
+
+        Primary signal: the query_info payload's ``xbar_supported`` flag,
+        computed in Rust by core's gpu_type.rs detect_gpu_type — the single
+        source of truth for generation detection (the ArchInfo enum has no
+        AD variant, so Ada reports ``Unknown:400:7:161`` and only the
+        codename/flag carry the real chip). Fallback: the architecture
+        heuristic below for payloads without the flag.
+        """
+        flag = self.app.cache.info.get("xbar_supported")
+        if isinstance(flag, bool):
+            return flag
+        return self._xbar_supported_arch(
+            str(self.app.cache.info.get("gpu_architecture", "") or ""),
+            str(self.app.cache.info.get("codename", "") or ""),
+            str(self.app.cache.info.get("gpu_name", "") or ""),
+        )
+
+    @staticmethod
+    def _xbar_supported_arch(
+        arch_id: str, codename: str = "", gpu_name: str = ""
+    ) -> bool:
+        """True for Turing (the GTX 16-series) and every newer architecture.
+
+        Three signals, in priority order:
+        1. Chip codes from the codename or the arch string (tu106, ga102,
+           ad107, gb202 — optionally suffixed ":rev", "-B", " (process)").
+           The codename matters: on Ada the pynvoc ArchInfo enum has no AD
+           variant and reports ``gpu_architecture = 'Unknown:400:7:161'``,
+           while ``codename = 'AD107-B'`` carries the real chip code.
+        2. Friendly architecture names (Turing, Ampere, Ada, Blackwell).
+        3. Marketing-name fallback: RTX/GTX + model number, 1600 = 16-series
+           floor (GTX 1080/10-series and below stay hidden).
+        Pascal (gp), Volta (gv) and older return False — the XBAR
+        ClockClient domain postdates them.
+        """
+        for raw in (codename, arch_id):
+            head = (
+                raw.lower().split("(", 1)[0].split(":", 1)[0].split("-", 1)[0].strip()
+            )
+            if head.startswith(("tu", "ga", "ad", "gb")):
+                return True
+        if any(
+            name in arch_id.lower() for name in ("turing", "ampere", "ada", "blackwell")
+        ):
+            return True
+        match = re.search(r"\b(?:rtx|gtx)\s*(\d{3,4})", gpu_name.lower())
+        if match:
+            return int(match.group(1)) >= 1600
+        return False
+
+    @staticmethod
+    def _format_xbar_offset_result(offset_mhz: int, result: object) -> str:
+        """Build the log message from a ``set_clk_domain_offset`` result.
+
+        The pynvoc call returns a dict (the applied payload with the
+        driver's readback ``applied_kHz``, or ``{"supported": False}``) —
+        never ``None`` — so the message is formatted here.
+        """
+        if isinstance(result, dict):
+            if result.get("applied"):
+                applied = result.get("applied_kHz")
+                if isinstance(applied, (int, float)):
+                    return (
+                        f"Successfully applied Xbar offset {offset_mhz:+d} MHz "
+                        f"(driver readback {applied / 1000.0:+g} MHz)."
+                    )
+                return f"Successfully applied Xbar offset {offset_mhz:+d} MHz."
+            if result.get("supported") is False:
+                return "Xbar clock-domain offset not supported by this driver."
+        return f"Applied Xbar offset {offset_mhz:+d} MHz."
+
+    @staticmethod
+    def _format_volt_rail_result(target_mv: float, result: object) -> str:
+        """Build the log message from a ``set_volt_rail_target`` result.
+
+        Like ``set_clk_domain_offset``, the pynvoc call returns a dict —
+        either the applied payload (with the post-clamp
+        ``effective_wall_uV``) or ``{"supported": False}`` — never ``None``,
+        so the message is formatted here. ``target_mv`` may carry one
+        decimal (2.5 mV grid); :g drops the trailing .0.
+        """
+        if isinstance(result, dict):
+            if result.get("applied"):
+                eff = result.get("effective_wall_uV")
+                if isinstance(eff, (int, float)) and eff:
+                    return (
+                        f"Successfully applied Volt Limit {target_mv:g} mV "
+                        f"(effective wall {eff / 1000.0:g} mV)."
+                    )
+                return f"Successfully applied Volt Limit {target_mv:g} mV."
+            if result.get("supported") is False:
+                return "Volt-rail target not supported by this driver."
+        return f"Applied Volt Limit {target_mv:g} mV."
+
+    @staticmethod
+    def _resolve_volt_rail_bit(volt_rail: dict) -> int:
+        """Pick the VoltRails rail bit to target (GUI dashboard port).
+
+        First rail descriptor's ``rail_bit`` when descriptors are exposed;
+        otherwise the lowest set bit of ``rail_mask``. Single-rail mobile
+        GPUs (e.g. 4060 Laptop, mask 0x1) resolve to 0.
+        """
+        descs = volt_rail.get("rail_descriptors")
+        if isinstance(descs, list) and descs:
+            first = descs[0]
+            if isinstance(first, dict) and first.get("rail_bit") is not None:
+                try:
+                    return int(first["rail_bit"])
+                except (TypeError, ValueError):
+                    pass
+        mask = volt_rail.get("rail_mask")
+        if isinstance(mask, str) and mask:
+            try:
+                value = int(mask, 16)
+                return (value & -value).bit_length() - 1
+            except ValueError:
+                pass
+        return 0
+
+    @staticmethod
+    def _volt_limit_bounds_from_p0(p0: dict) -> tuple[float, float, float]:
+        """Compute (min_mV, max_mV, pos_mV) for the Volt Limit input.
+
+        - min is a hard 300 mV floor
+        - max is min(VBIOS wall, VRM max wall); 0 = 'not reported' is
+          skipped; both 0 falls back to 1200 mV (the ~1.2 V domain ceiling
+          observed on Ada mobile)
+        - pos is the effective voltage wall (post-clamp) — the analog of
+          TGP positioning at the enforced power limit, NOT the live core
+          voltage. Both max and pos snap to the 2.5 mV grid (LCM of the
+          5 mV rail step on 30/40-series and 12.5 mV on 10/20-series); max
+          snaps DOWN so no offered position exceeds the actual wall.
+        """
+        step = 2.5
+        vbios = int(p0.get("vbios_wall_uV", 0) or 0)
+        vrm = int(p0.get("vrm_max_wall_uV", 0) or 0)
+        walls = [w for w in (vbios, vrm) if w > 0]
+        ceiling_uV = min(walls) if walls else 1_200_000
+        max_mv = max(300.0, ceiling_uV / 1000.0)
+        max_mv = int(max_mv / step) * step
+        eff = int(p0.get("effective_wall_uV", 0) or 0)
+        pos_mv = eff / 1000.0 if eff > 0 else max_mv
+        pos_mv = max(300.0, min(max_mv, pos_mv))
+        pos_mv = round(pos_mv / step) * step
+        return 300.0, max_mv, max(300.0, pos_mv)
+
+    def is_legacy_voltage(self) -> bool:
+        """Legacy-voltage verdict (Maxwell / GTX 900 series and older).
+
+        Primary signal: the query_info payload's ``is_legacy_voltage`` flag
+        (core gpu_type.rs). Fallback heuristic: GTX model < 1000, or a
+        Maxwell/Kepler/Fermi arch string / gm/gk/gf chip prefix.
+        """
+        flag = self.app.cache.info.get("is_legacy_voltage")
+        if isinstance(flag, bool):
+            return flag
+        gpu_name = str(self.app.cache.info.get("gpu_name", "")).lower()
+        arch = str(self.app.cache.info.get("gpu_architecture", "") or "").lower()
+        codename = str(self.app.cache.info.get("codename", "") or "").lower()
+        if "gtx" in gpu_name:
+            match = re.search(r"gtx\s*(\d+)", gpu_name)
+            if match and int(match.group(1)) < 1000:
+                return True
+        if any(x in arch for x in ("maxwell", "kepler", "fermi")):
+            return True
+        head = codename.split("(", 1)[0].split(":", 1)[0].split("-", 1)[0].strip()
+        return head.startswith(("gm", "gk", "gf"))
 
     def apply_pstate_limits(
         self,
@@ -140,8 +347,208 @@ class OverclockController(PaneController):
         native.set_power_limit(gpu, backend, power_limit)
         if backend == "nvapi":
             native.set_thermal_limit(gpu, thermal_limit)
-            native.set_voltage_boost(gpu, voltage_boost)
+            if self.is_legacy_voltage():
+                # Maxwell/900-series and older: the boost input is an
+                # Overvolt value in mV, routed to the legacy delta path.
+                native.set_legacy_voltage_delta(gpu, voltage_boost * 1000, "P0")
+            else:
+                native.set_voltage_boost(gpu, voltage_boost)
         return f"Successfully applied {backend} limits."
+
+    def is_mobile(self) -> bool:
+        """Mobile-GPU verdict for the Mobile Power pane.
+
+        Primary signal: the query_info payload's ``is_mobile`` flag computed
+        in Rust by core's gpu_type.rs detect_gpu_type (name + codename — the
+        single source of truth). Fallback: the name-keyword heuristic for
+        payloads without the flag (older pynvoc, CLI-parsed info).
+        """
+        flag = self.app.cache.info.get("is_mobile")
+        if isinstance(flag, bool):
+            return flag
+        gpu_name = str(self.app.cache.info.get("gpu_name", "")).lower()
+        return (
+            "mobile" in gpu_name
+            or "laptop" in gpu_name
+            or " m " in gpu_name
+            or gpu_name.endswith(" m")
+            or " mx " in gpu_name
+            or gpu_name.endswith(" mx")
+        )
+
+    def load_mobile_limits(self, force: bool = False) -> None:
+        """Background-load the mobile control surface via pynvoc (NVAPI)."""
+        gpu = self.app.selected_gpu_target()
+        if gpu is None or not self.is_mobile():
+            return
+        if not force and gpu == self._mobile_limits_gpu:
+            return
+        if not self._mobile_load_lock.acquire(blocking=False):
+            return
+
+        def worker() -> None:
+            try:
+                data = self.app.native_service.query_mobile_limits(gpu)
+            except Exception as exc:
+                data = {"error": str(exc)}
+            finally:
+                self._mobile_load_lock.release()
+            try:
+                self.app.call_from_thread(self._on_mobile_limits, gpu, data)
+            except Exception:
+                pass
+
+        threading.Thread(
+            target=worker, daemon=True, name="nvoc-tui-mobile-limits"
+        ).start()
+
+    def _on_mobile_limits(self, gpu: str, data: dict) -> None:
+        first_load = self._mobile_limits_gpu != gpu
+        self._mobile_limits_gpu = gpu
+        tgp = data.get("tgp") if isinstance(data.get("tgp"), dict) else None
+        dnotifier = (
+            data.get("dnotifier") if isinstance(data.get("dnotifier"), dict) else None
+        )
+        policies = data.get("temp_policies") or []
+        notes: list[str] = []
+
+        if tgp and tgp.get("min_watt") is not None and tgp.get("max_watt") is not None:
+            self._tgp_policy_index = int(tgp.get("policy_index", 2))
+            self._tgp_range = (
+                int(round(float(tgp["min_watt"]))),
+                int(round(float(tgp["max_watt"]))),
+            )
+            default = int(round(float(tgp.get("default_watt") or tgp["min_watt"])))
+            self.set_input("#mobile-tgp", str(default))
+        else:
+            notes.append("TGP range unavailable")
+
+        if dnotifier and dnotifier.get("levels"):
+            options = []
+            for item in dnotifier["levels"]:
+                label = str(item.get("level", "")).upper()
+                try:
+                    level_num = int(label.lstrip("D"))
+                except ValueError:
+                    continue
+                watts = item.get("watts")
+                display = (
+                    f"{label} · {float(watts):.0f}W" if watts is not None else label
+                )
+                options.append((display, level_num))
+            select = self.app.query_one("#mobile-dnotifier", Select)
+            select.set_options(options)
+            active = dnotifier.get("active")
+            if active:
+                try:
+                    select.value = int(str(active).upper().lstrip("D"))
+                except ValueError:
+                    pass
+        else:
+            notes.append("D-Notifier unavailable")
+
+        target = None
+        for policy in policies:
+            if (
+                isinstance(policy, dict)
+                and policy.get("min") is not None
+                and policy.get("max") is not None
+                and float(policy["max"]) > float(policy["min"])
+            ):
+                target = policy
+                break
+        if target is not None:
+            self._target_temp_range = (
+                int(round(float(target["min"]))),
+                int(round(float(target["max"]))),
+            )
+            self.set_input(
+                "#mobile-target-temp", str(int(round(float(target.get("celsius", 87)))))
+            )
+        else:
+            notes.append("Target Temp range unavailable")
+
+        # Volt Limit (private VoltRails P0 bounds; GUI dashboard parity).
+        vr = data.get("volt_rail") if isinstance(data.get("volt_rail"), dict) else None
+        p0 = vr.get("p0") if vr and isinstance(vr.get("p0"), dict) else None
+        if p0:
+            self._volt_rail_bit = self._resolve_volt_rail_bit(vr)
+            min_mv, max_mv, pos_mv = self._volt_limit_bounds_from_p0(p0)
+            self._volt_limit_range = (min_mv, max_mv)
+            self._volt_limit_supported = True
+            # Strip the trailing .0 of whole-mV positions (:g-style).
+            self.set_input(
+                "#mobile-volt-limit",
+                f"{pos_mv:g}",
+            )
+        else:
+            self._volt_limit_supported = False
+            notes.append("Volt Limit unavailable")
+        try:
+            self.app.query_one("#mobile-volt-limit", Input).disabled = not (
+                self._volt_limit_supported
+            )
+        except Exception:
+            pass
+
+        if notes:
+            self.app.write_log("Mobile power: " + ", ".join(notes) + ".")
+
+        # PPAB has no read-back API; enable it once per GPU on load.
+        # Only attempt when the private NVAPI surface actually resolved —
+        # on Linux (libnvidia-api stub) / older drivers the setter is
+        # NO_IMPLEMENTATION and auto-enabling would just log an error.
+        if first_load and (tgp or dnotifier):
+            self.app.run_native_action(
+                "enable dynamic boost",
+                lambda native, gpu=gpu: (
+                    native.set_ppab_status(gpu, True)
+                    or "Dynamic Boost (PPAB) enabled."
+                ),
+            )
+
+    def set_input(self, selector: str, value: str) -> None:
+        try:
+            self.app.query_one(selector, Input).value = value
+        except Exception:
+            pass
+
+    def apply_mobile(
+        self,
+        native,
+        gpu: str,
+        ppab: bool,
+        d_level: int,
+        tgp_watts: int,
+        target_temp: int,
+        volt_limit_mv: float | None = None,
+        volt_rail_bit: int | None = None,
+    ) -> str:
+        native.set_ppab_status(gpu, ppab)
+        native.set_dnotifier(gpu, d_level)
+        native.set_tgp_watt(gpu, tgp_watts, self._tgp_policy_index)
+        native.set_target_temp(gpu, float(target_temp), 2)
+        message = (
+            f"Successfully applied mobile power: PPAB {'on' if ppab else 'off'}, "
+            f"D{d_level}, TGP {tgp_watts} W, target {target_temp} C."
+        )
+        if volt_limit_mv is not None:
+            # set_volt_rail_target returns a dict (never None), so the
+            # message is appended rather than ``or``-chained.
+            message += "\n" + self._format_volt_rail_result(
+                volt_limit_mv,
+                native.set_volt_rail_target(
+                    gpu,
+                    self._volt_rail_bit if volt_rail_bit is None else volt_rail_bit,
+                    volt_limit_mv,
+                    None,
+                ),
+            )
+        return message
+
+    def reset_mobile(self, native, gpu: str) -> str:
+        native.reset_tgp_watt(gpu, self._tgp_policy_index)
+        return "Successfully reset TGP to default."
 
     def apply_fan(
         self,
@@ -166,6 +573,13 @@ class OverclockController(PaneController):
             backend = str(self.app.query_one("#oc-api", Select).value or "nvapi")
             core_offset = self.get_int("#core-offset")
             mem_offset = self.get_int("#mem-offset")
+            # Xbar rides the NVAPI-only ClockClient path — skipped under NVML
+            # and on pre-Turing archs (row is disabled, input stays 0).
+            xbar_offset = (
+                self.get_int("#xbar-offset")
+                if backend == "nvapi" and self.xbar_supported()
+                else None
+            )
 
             def apply_oc(
                 native,
@@ -173,8 +587,11 @@ class OverclockController(PaneController):
                 backend=backend,
                 core_offset=core_offset,
                 mem_offset=mem_offset,
+                xbar_offset=xbar_offset,
             ) -> str:
-                return self.apply_oc(native, gpu, backend, core_offset, mem_offset)
+                return self.apply_oc(
+                    native, gpu, backend, core_offset, mem_offset, xbar_offset
+                )
 
             self.app.run_native_action(
                 "apply overclock",
@@ -226,7 +643,7 @@ class OverclockController(PaneController):
             if gpu is None:
                 self.app.write_log("No GPU selected.")
                 return True
-            self.app.run_action_chain([
+            resets = [
                 (
                     "reset core offset",
                     lambda native, gpu=gpu, backend=str(backend): (
@@ -241,7 +658,15 @@ class OverclockController(PaneController):
                         or "Successfully reset memory offset."
                     ),
                 ),
-            ])
+            ]
+            if str(backend) == "nvapi" and self.xbar_supported():
+                resets.append((
+                    "reset xbar offset",
+                    lambda native, gpu=gpu: self._format_xbar_offset_result(
+                        0, native.set_clk_domain_offset(gpu, 1, 0, None, None)
+                    ),
+                ))
+            self.app.run_action_chain(resets)
             return True
         if button_id == "limits-apply":
             gpu = self.app.selected_gpu_target()
@@ -332,5 +757,87 @@ class OverclockController(PaneController):
                 "reset fan",
                 reset_fan,
             )
+            return True
+        if button_id == "mobile-apply":
+            gpu = self.app.selected_gpu_target()
+            if gpu is None:
+                self.app.write_log("No GPU selected.")
+                return True
+            ppab = str(self.app.query_one("#mobile-ppab", Select).value or "on") == "on"
+            try:
+                d_level = int(
+                    self.app.query_one("#mobile-dnotifier", Select).value or 1
+                )
+            except (TypeError, ValueError):
+                d_level = 1
+            if not 1 <= d_level <= 5:
+                self.app.write_log("D-Notifier level must be D1-D5.")
+                return True
+            tgp_watts = self.get_int("#mobile-tgp", 100)
+            lo, hi = self._tgp_range
+            tgp_watts = max(lo, min(hi, tgp_watts))
+            target_temp = self.get_int("#mobile-target-temp", 87)
+            tlo, thi = self._target_temp_range
+            target_temp = max(tlo, min(thi, target_temp))
+            # Volt Limit rides along when the VoltRails surface resolved;
+            # empty input = leave the wall untouched.
+            volt_limit = None
+            if self._volt_limit_supported:
+                raw = self.app.query_one("#mobile-volt-limit", Input).value.strip()
+                if raw:
+                    try:
+                        volt_limit = float(raw)
+                    except ValueError:
+                        self.app.write_log(
+                            f"Invalid Volt Limit value: {raw!r} (expected mV)."
+                        )
+                        return True
+                    vlo, vhi = self._volt_limit_range
+                    volt_limit = max(vlo, min(vhi, volt_limit))
+
+            def apply_mobile(
+                native,
+                gpu=gpu,
+                ppab=ppab,
+                d_level=d_level,
+                tgp_watts=tgp_watts,
+                target_temp=target_temp,
+                volt_limit=volt_limit,
+                reload_after=volt_limit is not None,
+            ) -> str:
+                result = self.apply_mobile(
+                    native, gpu, ppab, d_level, tgp_watts, target_temp, volt_limit
+                )
+                if reload_after:
+                    # The driver clamps the effective wall to min(target,
+                    # VBIOS, VRM); re-load so the input reflects the real
+                    # wall (the GUI reloads after its Volt Limit apply for
+                    # the same reason). Scheduled via call_from_thread so
+                    # it runs on the UI thread AFTER the SET completed.
+                    try:
+                        self.app.call_from_thread(self.load_mobile_limits, True)
+                    except Exception:
+                        pass
+                return result
+
+            self.app.run_native_action(
+                "apply mobile power",
+                apply_mobile,
+            )
+            return True
+        if button_id == "mobile-reset":
+            gpu = self.app.selected_gpu_target()
+            if gpu is None:
+                self.app.write_log("No GPU selected.")
+                return True
+
+            def reset_mobile(native, gpu=gpu) -> str:
+                return self.reset_mobile(native, gpu)
+
+            self.app.run_native_action(
+                "reset mobile power",
+                reset_mobile,
+            )
+            self.load_mobile_limits(force=True)
             return True
         return False

--- a/tui/nvoc_tui/controllers/overclock.py
+++ b/tui/nvoc_tui/controllers/overclock.py
@@ -502,8 +502,7 @@ class OverclockController(PaneController):
             self.app.run_native_action(
                 "enable dynamic boost",
                 lambda native, gpu=gpu: (
-                    native.set_ppab_status(gpu, True)
-                    or "Dynamic Boost (PPAB) enabled."
+                    native.set_ppab_status(gpu, True) or "Dynamic Boost (PPAB) enabled."
                 ),
             )
 

--- a/tui/nvoc_tui/controllers/vfcurve.py
+++ b/tui/nvoc_tui/controllers/vfcurve.py
@@ -6,15 +6,27 @@ from rich.text import Text
 from textual.widgets import Button, Checkbox, Input, Select
 from textual_plotext import PlotextPlot
 
+from ..models import CurveData
 from ..parsing import (
-    compute_vf_plot_bounds,
+    CURVE_META,
+    build_vf_curves,
+    compute_vf_plot_bounds_multi,
     find_curve_point_for_voltage,
     load_vf_curve_deltas,
-    vf_curve_points_to_series,
+    public_vfp_unsupported,
+    reverse_lookup_voltage,
     write_vf_curve_points,
 )
 from ..widgets import mnemonic_text
 from .base import PaneController
+
+# Per-curve plotext colors: (current line, default scatter).
+_CURVE_COLORS = {
+    "gpc": ("cyan+", "white"),
+    "xbar": ("orange+", "gray+"),
+    "host": ("magenta+", "gray+"),
+}
+_CURVE_ORDER = ("gpc", "xbar", "host")
 
 
 class VFCurveController(PaneController):
@@ -23,6 +35,23 @@ class VFCurveController(PaneController):
         self.poll_timer = None
         self.refresh_inflight = False
         self._refresh_lock = threading.Lock()
+        # Multi-curve state (TUI port of the GUI selector, minus editing).
+        self._curves: dict[str, CurveData] = {}
+        self._active_curve = "gpc"
+        self._curve_visible: dict[str, bool] = {}
+        self._direct_read_inflight = False
+        # Last option list pushed to the curve Select (suppresses no-op
+        # set_options calls — each one posts Changed events).
+        self._synced_options: list | None = None
+        # True while (and shortly after) _sync_curve_widgets writes widget
+        # state programmatically. Select/Checkbox Changed events posted by
+        # those writes are processed while this is still set (queue order:
+        # they precede the call_after_refresh that clears it), so the app
+        # handlers can drop them as echoes. Without this, a stale echo can
+        # be mistaken for a real switch and re-write the widgets, resonating
+        # into an unbounded switch ping-pong (each hop = full plot render +
+        # a Log thread worker that never completes under load).
+        self._syncing = False
 
     def auto_refresh_label(self) -> Text:
         state = "On" if self.app.config_data.vfcurve.auto_refresh else "Off"
@@ -103,16 +132,21 @@ class VFCurveController(PaneController):
             return
 
         def worker() -> None:
-            output = ""
-            code = 0
-            points: list[dict] | None = None
+            gpc_points: list[dict] | None = None
+            gpc_err: str | None = None
+            clk_data: dict | None = None
             try:
-                points = self.app.native_service.query_domain_vfp_points(gpu)
+                gpc_points = self.app.native_service.query_public_vftable(gpu)
             except Exception as exc:
-                output = f"pynvoc VFP curve query failed: {exc}"
-                code = -1
+                gpc_err = str(exc)
             try:
-                self.app.call_from_thread(self.on_curve_loaded, output, points, code)
+                clk_data = self.app.native_service.query_private_vftable(gpu)
+            except Exception:
+                clk_data = None
+            try:
+                self.app.call_from_thread(
+                    self.on_curve_loaded, gpc_points, gpc_err, clk_data
+                )
             except Exception:
                 self._end_refresh()
                 raise
@@ -124,19 +158,49 @@ class VFCurveController(PaneController):
             raise
 
     def on_curve_loaded(
-        self, output: str, points: list[dict] | None, code: int
+        self,
+        gpc_points: "list[dict] | None",
+        gpc_err: str | None,
+        clk_data: dict | None,
     ) -> None:
         self._end_refresh()
-        if output:
-            self.app.write_log(output)
-        self.app.cache.vf_curve_points = points if code == 0 else None
-        if code == 0:
-            self.render_plot()
-        else:
+        curves = build_vf_curves(gpc_points, gpc_err, clk_data)
+        self.app.cache.vf_curve_points = gpc_points if curves else None
+        self.app.cache.vf_curves = curves
+        if curves is None:
+            self._curves = {}
+            self._curve_visible = {}
+            self.app.cache.curve_visible = {}
+            self.app.cache.vf_live_point = None
+            if gpc_err and not public_vfp_unsupported(gpc_err):
+                self.app.write_log(f"pynvoc VFP curve query failed: {gpc_err}")
             self.clear_plot("VF curve query failed.")
+            self._sync_curve_widgets()
+            return
+        # Carry over visibility (default: every discovered curve visible) and
+        # keep the active curve valid (must exist and be visible).
+        prev_visible = self._curve_visible or {}
+        self._curves = curves
+        self._curve_visible = {cid: prev_visible.get(cid, True) for cid in curves}
+        if self._active_curve not in curves or not self._curve_visible.get(
+            self._active_curve
+        ):
+            self._active_curve = next(
+                (cid for cid in curves if self._curve_visible.get(cid)), "gpc"
+            )
+        self.app.cache.curve_visible = dict(self._curve_visible)
+        self.app.cache.active_curve = self._active_curve
+        self.app.cache.vf_live_point = None
+        self.render_plot()
+        self._sync_curve_widgets()
+        if self._active_curve in ("xbar", "host") and not self._direct_read_inflight:
+            self._kick_direct_read(self._active_curve)
 
     def clear_plot(self, title: str) -> None:
-        widget = self.app.query_one("#vf-plot", PlotextPlot)
+        try:
+            widget = self.app.query_one("#vf-plot", PlotextPlot)
+        except Exception:
+            return  # pane not composed / being torn down
         plt = widget.plt
         plt.clear_figure()
         plt.clear_data()
@@ -147,47 +211,81 @@ class VFCurveController(PaneController):
         widget.refresh()
 
     def render_plot(self) -> None:
-        points = self.app.cache.vf_curve_points
-        if not points:
+        curves = self._curves or {}
+        if not curves:
             self.clear_plot("No VF curve loaded.")
             return
-        voltages, freqs, defaults = vf_curve_points_to_series(points)
-        if not voltages:
-            self.clear_plot("VF curve cache is empty.")
+        visible = [
+            curves[cid]
+            for cid in _CURVE_ORDER
+            if cid in curves and self._curve_visible.get(cid, True)
+        ]
+        if not visible:
+            self.clear_plot("No VF curve visible.")
             return
-        widget = self.app.query_one("#vf-plot", PlotextPlot)
+        active_id = self._active_curve if self._active_curve in curves else "gpc"
+        active = curves.get(active_id) if self._curve_visible.get(active_id) else None
+        try:
+            widget = self.app.query_one("#vf-plot", PlotextPlot)
+        except Exception:
+            return  # pane not composed / being torn down
         plt = widget.plt
         plt.clear_figure()
         plt.clear_data()
         plt.clear_color()
-        plt.plot(voltages, freqs, marker="braille", color="cyan+", label="Current")
-        plt.scatter(
-            voltages, defaults, marker="braille", color="white", label="Default"
-        )
-        live_voltage = self.app.cache.status.get("voltage_mv")
-        live_clock = self.app.cache.status.get("gpu_clock_mhz")
-        lock_voltage = self.app.cache.status.get("vfp_lock_mv")
+        for curve in visible:
+            current_color, default_color = _CURVE_COLORS.get(
+                curve.curve_id, _CURVE_COLORS["gpc"]
+            )
+            label = CURVE_META.get(curve.curve_id, CURVE_META["gpc"])["label"]
+            plt.plot(
+                curve.voltages,
+                curve.frequencies,
+                marker="braille",
+                color=current_color,
+                label=label,
+            )
+            plt.scatter(
+                curve.voltages, curve.defaults, marker="braille", color=default_color
+            )
+        # Live crosshair only on the active curve: GPC from the dashboard
+        # status feed, XBAR/HOST from the direct-read poll path. Hidden
+        # curves are neither plotted nor polled.
         live_point: tuple[float, float] | None = None
-        lock_point: tuple[float, float] | None = None
-        if isinstance(live_voltage, (int, float)) and isinstance(
-            live_clock, (int, float)
-        ):
-            live_point = (float(live_voltage), float(live_clock))
+        live_color = "yellow+"
+        live_voltage: float | None = None
+        if active is not None:
+            if active_id == "gpc":
+                live_voltage = self.app.cache.status.get("voltage_mv")
+                live_clock = self.app.cache.status.get("gpu_clock_mhz")
+                if isinstance(live_voltage, (int, float)) and isinstance(
+                    live_clock, (int, float)
+                ):
+                    live_point = (float(live_voltage), float(live_clock))
+            else:
+                live_color = "green+"
+                cached_point = self.app.cache.vf_live_point
+                if cached_point is not None:
+                    live_point = cached_point
+        if live_point is not None:
             plt.scatter(
                 [live_point[0]],
                 [live_point[1]],
                 marker="braille",
-                color="yellow+",
+                color=live_color,
                 label="Live Point",
             )
-            plt.vline(live_point[0], color="yellow+")
-            plt.hline(live_point[1], color="yellow+")
+            plt.vline(live_point[0], color=live_color)
+            plt.hline(live_point[1], color=live_color)
+        # Lock + working-point markers stay on the active curve (the public
+        # lock concepts only apply to one curve at a time).
+        lock_point: tuple[float, float] | None = None
         lock_voltage_mv: float | None = None
-        if isinstance(lock_voltage, (int, float)):
+        lock_voltage = self.app.cache.status.get("vfp_lock_mv")
+        if active is not None and isinstance(lock_voltage, (int, float)):
             lock_voltage_mv = float(lock_voltage)
-        if lock_voltage_mv is not None:
             lock_curve_point = find_curve_point_for_voltage(
-                voltages, freqs, lock_voltage_mv
+                active.voltages, active.frequencies, lock_voltage_mv
             )
             if lock_curve_point is not None:
                 lock_point = (lock_voltage_mv, lock_curve_point[1])
@@ -201,17 +299,17 @@ class VFCurveController(PaneController):
                 color="orange+",
                 alignment="right",
             )
-        working_point = find_curve_point_for_voltage(
-            voltages,
-            freqs,
-            float(live_voltage) if isinstance(live_voltage, (int, float)) else None,
-        )
+        working_point = None
+        if active is not None:
+            working_point = find_curve_point_for_voltage(
+                active.voltages,
+                active.frequencies,
+                float(live_voltage) if isinstance(live_voltage, (int, float)) else None,
+            )
         if working_point is not None:
             plt.hline(working_point[1], color="green+")
-        bounds = compute_vf_plot_bounds(
-            voltages,
-            freqs,
-            defaults,
+        bounds = compute_vf_plot_bounds_multi(
+            visible,
             live_point=live_point,
             lock_point=lock_point,
             working_point=working_point,
@@ -224,6 +322,181 @@ class VFCurveController(PaneController):
         plt.xlabel("mV")
         plt.ylabel("MHz")
         widget.refresh()
+
+    # ── Curve selector: active switch + visibility (TUI subtraction) ──
+
+    def poll_live(self) -> None:
+        """Dashboard 1 Hz hook: re-render + kick a direct read for xbar/host."""
+        if not self._curves:
+            return
+        self.render_plot()
+        if self._active_curve in ("xbar", "host") and not self._direct_read_inflight:
+            self._kick_direct_read(self._active_curve)
+
+    def _sync_curve_widgets(self) -> None:
+        """Reflect curve discovery/active/visibility into the selector row.
+
+        Tolerates a missing selector (bare-app tests, pre-compose) like
+        ``set_poll_timer`` does. Every programmatic ``set_options``/
+        ``value`` write posts Changed events back into the app handlers —
+        mutating reactives from inside those same handlers can resonate
+        into an unbounded event echo loop (pegged core + runaway memory).
+        So each write happens only when the widget state actually differs
+        from the target, and ``set_options`` (which resets the Select to
+        blank — another Changed) only when the discovered set changed.
+        """
+        try:
+            select = self.app.query_one("#vf-active-curve", Select)
+        except Exception:
+            return
+        discovered = [cid for cid in _CURVE_ORDER if cid in self._curves]
+        options = [(CURVE_META[cid]["label"], cid) for cid in discovered] or [
+            ("GPC", "gpc")
+        ]
+        if self._synced_options != options:
+            self._synced_options = options
+            select.set_options(options)
+        self._syncing = True
+        if select.value != self._active_curve:
+            select.value = self._active_curve
+        for cid in _CURVE_ORDER:
+            try:
+                checkbox = self.app.query_one(f"#vf-curve-{cid}", Checkbox)
+            except Exception:
+                continue
+            checkbox.disabled = cid not in self._curves
+            want = cid in self._curves and self._curve_visible.get(cid, True)
+            if checkbox.value != want:
+                checkbox.value = want
+        # Echoes posted above are drained before this runs (queue order),
+        # so the sync window closes only after they have been ignored.
+        self.app.call_after_refresh(self._end_widget_sync)
+
+    def _end_widget_sync(self) -> None:
+        self._syncing = False
+
+    def _switch_active_curve(self, curve_id: str) -> None:
+        """Select which curve apply/reset and the live crosshair target."""
+        if curve_id not in self._curves or curve_id == self._active_curve:
+            return
+        if not self._curve_visible.get(curve_id, True):
+            return  # activating a hidden curve makes no sense
+        self._active_curve = curve_id
+        self.app.cache.active_curve = curve_id
+        self.app.cache.vf_live_point = None
+        self.render_plot()
+        self._sync_curve_widgets()
+        if curve_id in ("xbar", "host") and not self._direct_read_inflight:
+            self._kick_direct_read(curve_id)
+        curve = self._curves[curve_id]
+        self.app.write_log(
+            f"Active curve: {CURVE_META[curve_id]['label']} "
+            f"({curve.source}, {curve.write_mode})."
+        )
+
+    def _toggle_curve_visible(self, curve_id: str, checkbox=None) -> None:
+        """Toggle a curve's visibility. Hidden curves are not drawn and not
+        polled. Never leaves zero visible curves; vetoes snap the checkbox
+        back."""
+        if curve_id not in self._curves:
+            return
+        currently = self._curve_visible.get(curve_id, True)
+        if currently and curve_id == self._active_curve:
+            if sum(1 for v in self._curve_visible.values() if v) <= 1:
+                if checkbox is not None:
+                    # Vetoed — snap the checkbox back OUTSIDE this Changed
+                    # handler: mutating the reactive reentrantly from inside
+                    # its own callback is what can resonate into an event
+                    # echo loop (pegged core + runaway memory).
+                    self.app.call_after_refresh(setattr, checkbox, "value", True)
+                return
+        self._curve_visible[curve_id] = not currently
+        if not self._curve_visible.get(curve_id):
+            if curve_id == self._active_curve:
+                self.app.cache.vf_live_point = None
+        if not self._curve_visible.get(self._active_curve, True):
+            self._active_curve = next(
+                (c for c, v in self._curve_visible.items() if v), self._active_curve
+            )
+            self.app.cache.vf_live_point = None
+        self.app.cache.curve_visible = dict(self._curve_visible)
+        self.app.cache.active_curve = self._active_curve
+        self.render_plot()
+        self._sync_curve_widgets()
+        if self._active_curve in ("xbar", "host") and not self._direct_read_inflight:
+            self._kick_direct_read(self._active_curve)
+
+    def _kick_direct_read(self, curve_id: str) -> None:
+        """Direct physical clock read (0x527FC458) for the live crosshair."""
+        curve = self._curves.get(curve_id)
+        if curve is None or not self._curve_visible.get(curve_id, True):
+            return
+        if curve_id != self._active_curve or self._direct_read_inflight:
+            return
+        try:
+            gpu = self.app.selected_gpu_target()
+        except Exception:
+            return
+        if gpu is None:
+            return
+        domain_bit = CURVE_META[curve_id]["domain_bit"]
+        # Snapshot for the completion callback (a refresh may replace the
+        # curve dicts while the read is in flight).
+        volts = list(curve.voltages)
+        freqs = list(curve.frequencies)
+        self._direct_read_inflight = True
+
+        def worker() -> None:
+            try:
+                result = self.app.native_service.query_private_freq_domain_status(
+                    gpu, domain_bit
+                )
+            except Exception:
+                # _on_direct_read_done resets the inflight flag; without this
+                # guard a raised escape leaves it stuck True forever and the
+                # live crosshair silently dies (or retry logic spins).
+                result = None
+            try:
+                self.app.call_from_thread(
+                    self._on_direct_read_done, result, curve_id, volts, freqs
+                )
+            except Exception:
+                self._direct_read_inflight = False
+                raise
+
+        try:
+            self.app.native_service.submit_query(worker)
+        except Exception:
+            self._direct_read_inflight = False
+            raise
+
+    def _on_direct_read_done(
+        self,
+        result: dict | None,
+        curve_id: str,
+        volts: list[float],
+        freqs: list[float],
+    ) -> None:
+        self._direct_read_inflight = False
+        # Stale (different active curve now) or hidden while in flight — a
+        # hidden curve gets no crosshair, so drop the result.
+        if curve_id != self._active_curve or not self._curve_visible.get(curve_id):
+            return
+        if not isinstance(result, dict):
+            return
+        if result.get("supported") is False:
+            self.app.cache.vf_live_point = None
+            return
+        freq_khz = result.get("freq_khz")
+        if not freq_khz:
+            # 0 ⇒ driver refused / not measurable through this interface.
+            return
+        freq_mhz = freq_khz / 1000.0
+        volt = reverse_lookup_voltage(volts, freqs, freq_mhz)
+        if volt is None:
+            return
+        self.app.cache.vf_live_point = (volt, freq_mhz)
+        self.render_plot()
 
     def handle_button(self, button_id: str) -> bool:
         if button_id == "vf-refresh":
@@ -243,7 +516,7 @@ class VFCurveController(PaneController):
             gpu = self.app.selected_gpu_target()
 
             def export(native, gpu=gpu, path=path) -> str:
-                points = native.query_domain_vfp_points(gpu, "graphics", True)
+                points = native.query_public_vftable(gpu, "graphics", True)
                 write_vf_curve_points(path, points)
                 return f"Exported {len(points)} VFP point(s) to {path}."
 
@@ -258,7 +531,7 @@ class VFCurveController(PaneController):
             gpu = self.app.selected_gpu_target()
 
             def import_curve(native, gpu=gpu, path=path) -> str:
-                points = native.query_domain_vfp_points(gpu, "graphics", True)
+                points = native.query_public_vftable(gpu, "graphics", True)
                 deltas = load_vf_curve_deltas(path, points)
                 native.set_domain_vfp_deltas(gpu, "graphics", deltas)
                 return f"Imported {len(deltas)} VFP point delta(s) from {path}."
@@ -266,16 +539,82 @@ class VFCurveController(PaneController):
             self.app.run_native_action("import VFP curve", import_curve)
             return True
         if button_id == "vf-reset":
+            # Active-curve semantics: public GPC resets its own segment via
+            # the open interface; private curves (XBAR/HOST, or GPC when the
+            # public family is unsupported) clear per point with a
+            # raw-converted fallback. Never touches other curves' segments.
+            curve = self._curves.get(self._active_curve)
+            if curve is None:
+                self.app.write_log("No active curve to reset.")
+                return True
             gpu = self.app.selected_gpu_target()
+            cid = curve.curve_id.upper()
 
-            def reset_vfp(native, gpu=gpu) -> str:
-                native.reset_vfp_deltas(gpu, "all")
-                return "Successfully reset VFP deltas."
+            if curve.write_mode == "public":
+                seg_start, seg_end = curve.seg_start, curve.seg_end
 
-            self.app.run_native_action(
-                "reset VFP deltas",
-                reset_vfp,
-            )
+                def reset_public(
+                    native, gpu=gpu, seg_start=seg_start, seg_end=seg_end, cid=cid
+                ) -> str:
+                    native.set_vfp_range_delta(gpu, seg_start, seg_end, 0)
+                    return (
+                        f"Successfully reset {cid} curve to default "
+                        f"({seg_start}-{seg_end}, public)."
+                    )
+
+                self.app.run_native_action("reset VFP deltas", reset_public)
+                return True
+
+            bank = curve.bank
+            base = curve.seg_start
+            end_idx = curve.seg_end
+            class_name = CURVE_META[curve.curve_id]["class"]
+            defaults_mhz = list(curve.defaults)
+
+            def reset_private(
+                native,
+                gpu=gpu,
+                bank=bank,
+                base=base,
+                end_idx=end_idx,
+                class_name=class_name,
+                defaults_mhz=defaults_mhz,
+                cid=cid,
+            ) -> str:
+                # 1) mode-0 clear (value 0) per point in the segment.
+                try:
+                    for idx in range(base, end_idx + 1):
+                        r = native.set_vfp_point_private(gpu, bank, idx, 0, True)
+                        if isinstance(r, dict) and r.get("supported") is False:
+                            raise RuntimeError("private VFP family unsupported")
+                    return (
+                        f"Successfully reset {cid} (private mode-0, {base}-{end_idx})."
+                    )
+                except Exception as exc:
+                    msg = str(exc).lower()
+                    if "argument" not in msg and "unsupported" not in msg:
+                        raise
+                # 2) raw-converted clear: delta 0 → the raw f-offset that
+                # zeroes the effect (≈ D0 per the g(def) prior).
+                raw_deltas = []
+                for idx in range(base, end_idx + 1):
+                    local = idx - base
+                    def_mhz = (
+                        int(round(defaults_mhz[local]))
+                        if local < len(defaults_mhz)
+                        else 0
+                    )
+                    r = native.clk_vf_delta_for_target_mhz(def_mhz, 0.0, class_name)
+                    d = r.get("delta") if isinstance(r, dict) else None
+                    raw_deltas.append(int(d) if d is not None else 0)
+                r2 = native.set_vfp_range_per_point_private(
+                    gpu, bank, base, end_idx, raw_deltas
+                )
+                if isinstance(r2, dict) and r2.get("supported") is False:
+                    return f"private reset unsupported on {cid}."
+                return f"Successfully reset {cid} (private raw, {base}-{end_idx})."
+
+            self.app.run_native_action("reset VFP deltas", reset_private)
             return True
         if button_id == "vf-unlock":
             gpu = self.app.selected_gpu_target()
@@ -295,17 +634,97 @@ class VFCurveController(PaneController):
             delta = self.get_int("#vf-delta")
             if start > end:
                 start, end = end, start
+            curve = self._curves.get(self._active_curve)
+            if curve is None or not curve.frequencies or not curve.defaults:
+                self.app.write_log("No VF data loaded for the active curve.")
+                return True
+            n = len(curve.frequencies)
+            start = max(0, min(start, n - 1))
+            end = max(0, min(end, n - 1))
             gpu = self.app.selected_gpu_target()
 
-            def apply_vfp_delta(
-                native, gpu=gpu, start=start, end=end, delta=delta
+            if curve.write_mode == "public":
+                # Open VFP interface (public GPC, unchanged).
+                def apply_vfp_delta(
+                    native, gpu=gpu, start=start, end=end, delta=delta
+                ) -> str:
+                    native.set_vfp_range_delta(gpu, start, end, delta * 1000)
+                    return (
+                        f"Successfully applied {delta} MHz VFP delta "
+                        f"to points {start}-{end}."
+                    )
+
+                self.app.run_native_action(
+                    "apply VFP range delta",
+                    apply_vfp_delta,
+                )
+                return True
+
+            # Private path: mode-0 first, raw-converted fallback (port of the
+            # GUI apply_private closure).
+            bank = curve.bank
+            base = curve.seg_start + start  # absolute private index of `start`
+            class_name = CURVE_META[curve.curve_id]["class"]
+            defaults_mhz = list(curve.defaults)
+            cid = curve.curve_id.upper()
+            # TUI range inputs apply a uniform delta over the range.
+            deltas_khz = [delta * 1000] * (end - start + 1)
+
+            def apply_private(
+                native,
+                gpu=gpu,
+                bank=bank,
+                base=base,
+                class_name=class_name,
+                defaults_mhz=defaults_mhz,
+                deltas_khz=deltas_khz,
+                start=start,
+                cid=cid,
             ) -> str:
-                native.set_vfp_range_delta(gpu, start, end, delta * 1000)
-                return f"Successfully applied {delta} MHz VFP delta to points {start}-{end}."
+                # 1) mode-0 (kHz frequency offset) per point.
+                try:
+                    for offset, dkz in enumerate(deltas_khz):
+                        r = native.set_vfp_point_private(
+                            gpu, bank, base + offset, dkz, True
+                        )
+                        if isinstance(r, dict) and r.get("supported") is False:
+                            raise RuntimeError("private VFP family unsupported")
+                    return (
+                        f"Successfully applied private mode-0 offsets to {cid} "
+                        f"({len(deltas_khz)} pts)."
+                    )
+                except Exception as exc:
+                    msg = str(exc).lower()
+                    if "argument" not in msg and "unsupported" not in msg:
+                        raise
+                # 2) raw-converted: translate each MHz offset to a raw
+                # mode-1 f-offset via the g(def) prior.
+                raw_deltas = []
+                for offset in range(len(deltas_khz)):
+                    def_mhz = int(round(defaults_mhz[start + offset]))
+                    tgt_mhz = deltas_khz[offset] / 1000.0
+                    r = native.clk_vf_delta_for_target_mhz(def_mhz, tgt_mhz, class_name)
+                    d = r.get("delta") if isinstance(r, dict) else None
+                    if d is None:
+                        return (
+                            f"raw-converted translation failed at "
+                            f"def={def_mhz} MHz ({cid}); apply aborted."
+                        )
+                    raw_deltas.append(int(d))
+                last = base + len(deltas_khz) - 1
+                r2 = native.set_vfp_range_per_point_private(
+                    gpu, bank, base, last, raw_deltas
+                )
+                if isinstance(r2, dict) and r2.get("supported") is False:
+                    return f"private VFP write unsupported on {cid}."
+                return (
+                    f"Successfully applied private raw-converted offsets "
+                    f"to {cid} ({len(raw_deltas)} pts)."
+                )
 
             self.app.run_native_action(
-                "apply VFP range delta",
-                apply_vfp_delta,
+                "apply VFP point deltas",
+                apply_private,
             )
             return True
         if button_id == "vf-lock-voltage":

--- a/tui/nvoc_tui/metrics_format.py
+++ b/tui/nvoc_tui/metrics_format.py
@@ -15,15 +15,118 @@ def _temp_c_str(value) -> str:
 
 
 def _effective_clocks_text(status: dict) -> str:
-    """Format effective, actually-running clocks when the driver exposes them."""
+    """Format the effective (actually-running) clocks line.
+
+    Falls back to ``---`` when the GPU/driver doesn't expose the GetAllClocks
+    V2 layout.
+    """
     gpu = status.get("eff_gpu_clock_mhz")
-    memory = status.get("eff_mem_clock_mhz")
+    mem = status.get("eff_mem_clock_mhz")
+    if not isinstance(gpu, (int, float)) and not isinstance(mem, (int, float)):
+        return "---"
     parts = []
     if isinstance(gpu, (int, float)):
         parts.append(f"GPU {round(float(gpu))}")
-    if isinstance(memory, (int, float)):
-        parts.append(f"MEM {round(float(memory))}")
-    return " | ".join(parts) + " MHz" if parts else "---"
+    if isinstance(mem, (int, float)):
+        parts.append(f"MEM {round(float(mem))}")
+    return " | ".join(parts) + " MHz"
+
+
+def _format_mibps(mibps: float) -> str:
+    """Format a MiB/s value with a sensible unit (MiB/s or GiB/s)."""
+    if mibps >= 1024.0:
+        return f"{mibps / 1024.0:.1f} GiB/s"
+    if mibps >= 10.0:
+        return f"{mibps:.0f} MiB/s"
+    return f"{mibps:.1f} MiB/s"
+
+
+# Internal fabric clock domains (from GetAllClocks V2 `all_clocks_mhz`) to surface
+# on a dedicated FCLK line — the "crossbar clock" GPU-Z shows plus the other
+# structurally-interesting fabric clocks. Ordered for stable display.
+_FABRIC_CLOCK_DOMAINS = ["Xbar", "Sys", "Hub", "Host", "Gpc", "Disp", "Hotclk"]
+
+
+def _fabric_clocks_text(status: dict) -> str:
+    """Format the internal-fabric clocks line (Xbar/crossbar, Sys, Hub, ...).
+
+    Reads the per-domain MHz from ``all_clocks_mhz`` (GetAllClocks V2's full
+    32-domain breakdown). Returns ``""`` when no fabric domains are present so
+    the line is omitted entirely.
+    """
+    all_clocks = status.get("all_clocks_mhz")
+    if not isinstance(all_clocks, dict):
+        return ""
+    parts = []
+    for domain in _FABRIC_CLOCK_DOMAINS:
+        mhz = all_clocks.get(domain)
+        if isinstance(mhz, (int, float)) and float(mhz) > 0:
+            parts.append(f"{domain.upper()} {round(float(mhz))}")
+    return " | ".join(parts) + " MHz" if parts else ""
+
+
+def _power_rails_text(status: dict) -> str:
+    """Per-rail power breakdown (NVAPI PowerMonitor, descriptor-driven).
+
+    Reads ``power_rails_w`` — a { "<RailName>": <watts> } map keyed by the
+    descriptor's rail identity (correct on every GPU: a laptop shows
+    InputTotalBoard/InputNvvdd/..., a desktop shows InputPex12v1/PCIe slot/
+    InputExt12v8pin*/InputTotalBoard). Renders each rail as ``<short> <W>``;
+    board total is omitted (it's on the PWR line via NVML). Returns ``""`` when
+    no rails are present so the line is omitted.
+    """
+    rails = status.get("power_rails_w")
+    if not isinstance(rails, dict):
+        return ""
+    # Short labels for common rails; others use the full rail name. Map keys may
+    # carry a confidence suffix (`~` Inferred, `?` Ambiguous) — strip it before
+    # the lookup and re-append so the marker survives in the rendered label.
+    short = {
+        "InputTotalBoard": "BOARD",
+        "InputNvvdd": "CHIP",
+        "InputFbvdd": "MEM",
+        "InputPwrSrcPp": "SRC",
+        "InputPex12v1": "PCIE",
+        "InputPex12v": "PCIE12V",
+        "InputPex3v3": "PEX3V3",
+    }
+    parts = []
+    for name, val in rails.items():
+        if not isinstance(val, (int, float)):
+            continue
+        marker = ""
+        base = name
+        # Strip a trailing confidence marker (~ inferred, ? ambiguous).
+        if base and base[-1] in "~?":
+            marker = base[-1]
+            base = base[:-1]
+        label = short.get(base, base)
+        # Skip the board-total duplicate (already on the PWR line).
+        if label == "BOARD" and not marker:
+            continue
+        parts.append(f"{label}{marker} {val:.1f}")
+    return " | ".join(parts) + " W" if parts else ""
+
+
+def _pcie_bandwidth_text(status: dict) -> str:
+    """Bidirectional real-time PCIe bandwidth, nvitop-style (``↑Tx ↓Rx``).
+
+    Reads ``pcie_tx_mibps`` / ``pcie_rx_mibps`` (NVML
+    ``nvmlDeviceGetPcieThroughput``, KB/s over a ~20ms interval → MiB/s). Empty
+    string when the GPU/driver doesn't expose it.
+    """
+    tx = status.get("pcie_tx_mibps")
+    rx = status.get("pcie_rx_mibps")
+    has_tx = isinstance(tx, (int, float))
+    has_rx = isinstance(rx, (int, float))
+    if not has_tx and not has_rx:
+        return ""
+    parts = []
+    if has_tx:
+        parts.append(f"↑{_format_mibps(float(tx))}")
+    if has_rx:
+        parts.append(f"↓{_format_mibps(float(rx))}")
+    return " ".join(parts)
 
 
 # NVAPI PerfFlags bit -> reason name. Bit semantics mirror nvapi-rs
@@ -51,15 +154,6 @@ def _perf_limits_text(perf) -> str:
     bits = int(limits)
     reasons = [name for bit, name in _PERF_LIMIT_BITS if bits & bit]
     return ", ".join(reasons) if reasons else "none"
-
-
-def _format_mibps(value: float) -> str:
-    """Format PCIe throughput using MiB/s or GiB/s."""
-    if value >= 1024.0:
-        return f"{value / 1024.0:.1f} GiB/s"
-    if value >= 10.0:
-        return f"{value:.0f} MiB/s"
-    return f"{value:.1f} MiB/s"
 
 
 def _format_metric_lines(status: dict, architecture: str) -> list[str]:
@@ -125,54 +219,83 @@ def _format_metric_lines(status: dict, architecture: str) -> list[str]:
 
     lanes = status.get("pcie_lanes")
     pcie_text = f"x{int(lanes)}" if isinstance(lanes, (int, float)) else "---"
-
-    current_gen = status.get("pcie_link_gen")
+    # Prepend the PCIe link generation as "Gen<cur>/<max>" (NVML
+    # nvmlDeviceGetCurr/MaxPcieLinkGeneration) when exposed, e.g. "Gen4/4".
+    cur_gen = status.get("pcie_link_gen")
     max_gen = status.get("pcie_max_link_gen")
-    if isinstance(current_gen, (int, float)) and isinstance(max_gen, (int, float)):
-        generation = f"Gen{int(current_gen)}/{int(max_gen)}"
+    gen_text = ""
+    if isinstance(cur_gen, (int, float)) and isinstance(max_gen, (int, float)):
+        gen_text = f"Gen{int(float(cur_gen))}/{int(float(max_gen))} "
     elif isinstance(max_gen, (int, float)):
-        generation = f"Gen?/{int(max_gen)}"
-    else:
-        generation = ""
-
-    tx = status.get("pcie_tx_mibps")
-    rx = status.get("pcie_rx_mibps")
-    bandwidth = []
-    if isinstance(tx, (int, float)):
-        bandwidth.append(f"↑{_format_mibps(float(tx))}")
-    if isinstance(rx, (int, float)):
-        bandwidth.append(f"↓{_format_mibps(float(rx))}")
-
-    parts = [
-        part for part in (generation, pcie_text if pcie_text != "---" else "") if part
-    ]
-    parts.extend(bandwidth)
+        gen_text = f"Gen?/{int(float(max_gen))} "
+    # Append bidirectional real-time PCIe bandwidth (nvitop-style) when the GPU
+    # exposes it via NVML nvmlDeviceGetPcieThroughput. ↑ = TX (GPU->host),
+    # ↓ = RX (host->GPU). Omitted entirely on unsupported GPUs.
+    bw = _pcie_bandwidth_text(status)
+    if bw:
+        pcie_text = f"{pcie_text} {bw}" if pcie_text != "---" else bw
+    # Append the PCIe replay counter (NVML nvmlDeviceGetPcieReplayCounter) when
+    # it is non-zero — a rising count indicates link-quality problems. Zero is
+    # the normal steady state, so it is omitted to keep the line quiet.
     replay = status.get("pcie_replay_counter")
-    if isinstance(replay, (int, float)) and replay > 0:
-        parts.append(f"⚠replay {int(replay)}")
-    pcie_text = " ".join(parts) if parts else "---"
+    if isinstance(replay, (int, float)) and float(replay) > 0:
+        pcie_text = f"{pcie_text} ⚠replay {int(float(replay))}".strip()
+    # Prepend the PCIe generation once everything else is assembled.
+    if gen_text and pcie_text != "---":
+        pcie_text = f"{gen_text}{pcie_text}"
+    elif gen_text:
+        pcie_text = gen_text.strip()
 
     perf = status.get("perf") or {}
     perf_text = _perf_limits_text(perf)
 
     # Thermal sensors: core (GPU_AVG) is always shown; hot spot (GPU_MAX) and
     # memory/VRAM are appended only when the GPU exposes them, so the line
-    # adapts to whatever channels are available.
-    temp_parts = [f"CORE {_temp_c_str(status.get('temperature_c'))} C"]
-    if isinstance(status.get("temp_hotspot"), (int, float)):
-        temp_parts.append(f"HOTSPOT {_temp_c_str(status['temp_hotspot'])} C")
+    # adapts to whatever channels are available. The core reading is paired
+    # with the target-temperature wall (policy 2 = nvidia-smi "GPU Target
+    # Temperature" / NVML GpsCurr) and the hot-spot reading with the max
+    # operating temp (policy 1 = NVML GpuMax), in `live / limit` form.
+    core_live = _temp_c_str(status.get("temperature_c"))
+    target_temp = status.get("target_temp_c")
+    core_part = (
+        f"CORE {core_live} / {_temp_c_str(target_temp)} C"
+        if isinstance(target_temp, (int, float))
+        else f"CORE {core_live} C"
+    )
+    temp_parts = [core_part]
+    hotspot_live = status.get("temp_hotspot")
+    if isinstance(hotspot_live, (int, float)):
+        max_temp = status.get("max_temp_c")
+        hotspot_part = (
+            f"HOTSPOT {_temp_c_str(hotspot_live)} / {_temp_c_str(max_temp)} C"
+            if isinstance(max_temp, (int, float))
+            else f"HOTSPOT {_temp_c_str(hotspot_live)} C"
+        )
+        temp_parts.append(hotspot_part)
     if isinstance(status.get("temp_memory"), (int, float)):
         temp_parts.append(f"MEM {_temp_c_str(status['temp_memory'])} C")
     temp_text = " | ".join(temp_parts)
+
+    # PWR line: live board power draw (watts), followed by the current enforced
+    # power limit (the live TGP cap, e.g. nvidia-smi's "Current Power Limit")
+    # when the backend reports it — mirrors nvidia-smi's `1W / 30W` form.
+    power_draw = status.get("power_w", "---")
+    power_limit = status.get("power_limit_w")
+    if isinstance(power_limit, (int, float)):
+        power_text = f"{power_draw} W / {power_limit:g} W"
+    else:
+        power_text = f"{power_draw} W"
 
     return [
         f"GPU: {status.get('gpu_clock_mhz', '---')} MHz",
         f"MEM: {status.get('mem_clock_mhz', '---')} MHz",
         f"ECLK: {_effective_clocks_text(status)}",
+        f"FCLK: {_fabric_clocks_text(status) or '---'}",
         f"VOLT: {status.get('voltage_mv', '---')} mV",
         f"VFP LOCK: {vfp_lock_text}",
         f"TEMP: {temp_text}",
-        f"PWR: {status.get('power_w', '---')} W",
+        f"PWR: {power_text}",
+        f"RAILS: {_power_rails_text(status) or '---'}",
         f"LOAD: {load_text}",
         f"VRAM: {vram_text}",
         f"FAN: {fan_text}",

--- a/tui/nvoc_tui/models.py
+++ b/tui/nvoc_tui/models.py
@@ -65,11 +65,34 @@ class AppConfig:
 
 
 @dataclass(slots=True)
+class CurveData:
+    """One plotted V/F curve (GPC public / XBAR / HOST private)."""
+
+    curve_id: str
+    source: str = "public"  # "public" | "private"
+    write_mode: str = "public"  # "public" | "private"
+    bank: int = 0
+    seg_start: int = 0
+    seg_end: int = 0
+    voltages: list[float] = field(default_factory=list)  # mV
+    frequencies: list[float] = field(default_factory=list)  # MHz (current)
+    defaults: list[float] = field(default_factory=list)  # MHz (default)
+    has_fixed: bool = False
+
+
+@dataclass(slots=True)
 class GpuCache:
     info: dict[str, Any] = field(default_factory=dict)
     status: dict[str, Any] = field(default_factory=dict)
     settings: dict[str, Any] = field(default_factory=dict)
     vf_curve_points: list[dict[str, Any]] | None = None
+    # Multi-curve state (controller-owned; cache is the cross-pane view).
+    vf_curves: dict[str, CurveData] | None = None
+    curve_visible: dict[str, bool] = field(default_factory=dict)
+    active_curve: str = "gpc"
+    # Live crosshair for the active private curve (xbar/host), set by the
+    # direct-read poll path (voltage mV, frequency MHz).
+    vf_live_point: tuple[float, float] | None = None
 
 
 @dataclass(slots=True)

--- a/tui/nvoc_tui/native.py
+++ b/tui/nvoc_tui/native.py
@@ -68,7 +68,33 @@ class NativeService:
         ]
         return 0, f"Detected {len(gpus)} GPU(s) via pynvoc.", gpus
 
-    def run_query(self, gpu: str, command_name: str) -> tuple[int, str, dict]:
+    def _force_wake(self, gpu: str) -> bool:
+        """Native GC6 wake (force_gc6_exit) via pynvoc.
+
+        Mobile dGPUs drop to GCOFF after a few idle seconds; NVAPI reads then
+        fail and get misreported as 'unsupported'. Best-effort: desktop GPUs
+        return False, and an older pynvoc without force_wake is tolerated.
+        """
+        try:
+            wake = getattr(self._pynvoc(), "force_wake", None)
+            return bool(wake(gpu)) if callable(wake) else False
+        except Exception:
+            return False
+
+    def run_query(
+        self, gpu: str, command_name: str, *, allow_wake: bool = True
+    ) -> tuple[int, str, dict]:
+        retcode, output, parsed = self._run_query_once(gpu, command_name)
+        if retcode != 0 and allow_wake:
+            # A failed read on a mobile GPU is often just GCOFF (idle dGPU
+            # powered down) — wake it and retry once before giving up. Only
+            # the first sample / manual buttons opt in; steady-state polls
+            # pass allow_wake=False so monitoring never blocks GC6 sleep.
+            self._force_wake(gpu)
+            retcode, output, parsed = self._run_query_once(gpu, command_name)
+        return retcode, output, parsed
+
+    def _run_query_once(self, gpu: str, command_name: str) -> tuple[int, str, dict]:
         try:
             native = self._pynvoc()
             if command_name == "info":
@@ -83,8 +109,98 @@ class NativeService:
         except Exception as exc:
             return -1, f"pynvoc {command_name} query failed: {exc}", {}
 
-    def query_domain_vfp_points(self, gpu: str, domain: str = "graphics") -> list[dict]:
-        return self._pynvoc().query_domain_vfp_points(gpu, domain, True)
+    def query_public_vftable(self, gpu: str, domain: str = "graphics") -> list[dict]:
+        try:
+            return self._pynvoc().query_public_vftable(gpu, domain, True)
+        except Exception:
+            self._force_wake(gpu)
+            return self._pynvoc().query_public_vftable(gpu, domain, True)
+
+    def query_private_vftable(self, gpu: str) -> dict | None:
+        """Private ClockClient V/F-POINTS table (segments + points).
+
+        Returns ``None`` when the private family is absent (the open VFP
+        interface is the only source for that GPU). Best-effort wake like
+        the public read. Mirrors the GUI backend adapter.
+        """
+        try:
+            return self._pynvoc().query_private_vftable(gpu)
+        except Exception:
+            self._force_wake(gpu)
+            try:
+                return self._pynvoc().query_private_vftable(gpu)
+            except Exception:
+                return None
+
+    def query_private_freq_domain_status(self, gpu: str, domain_bit: int) -> dict | None:
+        """Direct physical clock for one domain (green-curve MEASURE 0x527FC458).
+
+        Returns ``{"domain_bit", "freq_khz"}`` (``freq_khz == 0`` ⇒ driver
+        refused / not measurable — caller should not draw a live point),
+        ``{"supported": false}`` when the family is absent, or ``None`` on a
+        transient error. Preferred over the counter-based read for XBAR/HOST
+        live-point polling: one call, no 50 ms sleep.
+        """
+        try:
+            return self._pynvoc().query_private_freq_domain_status(gpu, int(domain_bit))
+        except Exception:
+            self._force_wake(gpu)
+            try:
+                return self._pynvoc().query_private_freq_domain_status(gpu, int(domain_bit))
+            except Exception:
+                return None
+
+    def query_mobile_limits(self, gpu: str) -> dict:
+        """Fetch the mobile power/thermal control surface (all NVAPI).
+
+        Returns ``{"tgp": dict|None, "dnotifier": dict|None,
+        "temp_policies": list, "volt_rail": dict|None}``; ``None`` sub-dicts
+        mean the private interface isn't exposed by this driver.
+        """
+        data = self._query_mobile_limits_once(gpu)
+        if (
+            data["tgp"] is None
+            and data["dnotifier"] is None
+            and not data["temp_policies"]
+            and data["volt_rail"] is None
+        ):
+            # All three failed at once is the GCOFF signature — wake and retry.
+            self._force_wake(gpu)
+            data = self._query_mobile_limits_once(gpu)
+        return data
+
+    def _query_mobile_limits_once(self, gpu: str) -> dict:
+        native = self._pynvoc()
+        tgp = None
+        dnotifier = None
+        policies: Any = []
+        volt_rail = None
+        try:
+            tgp = native.query_tgp_watt_range(gpu)
+        except Exception:
+            tgp = None
+        try:
+            dnotifier = native.query_dnotifier(gpu)
+        except Exception:
+            dnotifier = None
+        try:
+            policies = native.query_target_temp_policies(gpu)
+        except Exception:
+            policies = []
+        if not isinstance(policies, list):
+            policies = []
+        try:
+            volt_rail = native.query_volt_rails(gpu)
+        except Exception:
+            volt_rail = None
+        if not isinstance(volt_rail, dict):
+            volt_rail = None
+        return {
+            "tgp": tgp,
+            "dnotifier": dnotifier,
+            "temp_policies": policies,
+            "volt_rail": volt_rail,
+        }
 
     def run_action(
         self,

--- a/tui/nvoc_tui/native.py
+++ b/tui/nvoc_tui/native.py
@@ -132,7 +132,9 @@ class NativeService:
             except Exception:
                 return None
 
-    def query_private_freq_domain_status(self, gpu: str, domain_bit: int) -> dict | None:
+    def query_private_freq_domain_status(
+        self, gpu: str, domain_bit: int
+    ) -> dict | None:
         """Direct physical clock for one domain (green-curve MEASURE 0x527FC458).
 
         Returns ``{"domain_bit", "freq_khz"}`` (``freq_khz == 0`` ⇒ driver
@@ -146,7 +148,9 @@ class NativeService:
         except Exception:
             self._force_wake(gpu)
             try:
-                return self._pynvoc().query_private_freq_domain_status(gpu, int(domain_bit))
+                return self._pynvoc().query_private_freq_domain_status(
+                    gpu, int(domain_bit)
+                )
             except Exception:
                 return None
 

--- a/tui/nvoc_tui/panes/overclock.py
+++ b/tui/nvoc_tui/panes/overclock.py
@@ -56,6 +56,14 @@ def compose_overclock() -> ComposeResult:
                             yield ShortcutInput(
                                 value="0", id="mem-offset", compact=True
                             )
+                        with Horizontal(classes="row"):
+                            # Fabric-clock offset (NVAPI-only ClockClient path,
+                            # xbar = domain bit 1). Arch-gated: the controller
+                            # disables this row for pre-Turing GPUs.
+                            yield Label("Xbar Offset")
+                            yield ShortcutInput(
+                                value="0", id="xbar-offset", compact=True
+                            )
                     with Grid(id="clock-actions"):
                         yield Button(
                             "Apply OC", id="oc-apply", classes="red", compact=True
@@ -102,6 +110,66 @@ def compose_overclock() -> ComposeResult:
                         yield Button(
                             "Reset Limits",
                             id="reset-limits",
+                            classes="green",
+                            compact=True,
+                        )
+
+                with Vertical(classes="subpane") as mobile_pane:
+                    mobile_pane.border_title = mnemonic_text("M", "obile Power")
+                    with Grid(id="mobile-controls"):
+                        with Horizontal(classes="row"):
+                            yield Label("PPAB")
+                            yield Select(
+                                options=[("On", "on"), ("Off", "off")],
+                                value="on",
+                                id="mobile-ppab",
+                                allow_blank=False,
+                                compact=True,
+                            )
+                        with Horizontal(classes="row"):
+                            yield Label("D-Notifier")
+                            yield Select(
+                                options=[
+                                    ("D1", 1),
+                                    ("D2", 2),
+                                    ("D3", 3),
+                                    ("D4", 4),
+                                    ("D5", 5),
+                                ],
+                                value=1,
+                                id="mobile-dnotifier",
+                                allow_blank=False,
+                                compact=True,
+                            )
+                        with Horizontal(classes="row"):
+                            yield Label("TGP (W)")
+                            yield ShortcutInput(
+                                value="100", id="mobile-tgp", compact=True
+                            )
+                        with Horizontal(classes="row"):
+                            yield Label("Target Temp (C)")
+                            yield ShortcutInput(
+                                value="87", id="mobile-target-temp", compact=True
+                            )
+                        with Horizontal(classes="row"):
+                            # Absolute voltage target on the private VoltRails
+                            # path (mobile-only, NVAPI). Bounds + starting
+                            # position come from the volt-rail P0 walls in
+                            # _on_mobile_limits; disabled until they load.
+                            yield Label("Volt Limit (mV)")
+                            yield ShortcutInput(
+                                value="", id="mobile-volt-limit", compact=True
+                            )
+                    with Grid(id="mobile-actions"):
+                        yield Button(
+                            "Apply Mobile",
+                            id="mobile-apply",
+                            classes="red",
+                            compact=True,
+                        )
+                        yield Button(
+                            "Reset Mobile",
+                            id="mobile-reset",
                             classes="green",
                             compact=True,
                         )

--- a/tui/nvoc_tui/panes/vfcurve.py
+++ b/tui/nvoc_tui/panes/vfcurve.py
@@ -175,4 +175,19 @@ def compose_vfcurve(config: AppConfig, auto_refresh_label: Text) -> ComposeResul
                                 classes="green",
                                 compact=True,
                             )
+            # Curve selector: active curve (Select) + visibility checkboxes.
+            # Options/state are refreshed by the controller once curves are
+            # discovered; undiscovered curves stay disabled.
+            with Horizontal(id="vf-curve-selector"):
+                yield Label("Curve")
+                yield Select(
+                    options=[("GPC", "gpc")],
+                    value="gpc",
+                    id="vf-active-curve",
+                    allow_blank=False,
+                    compact=True,
+                )
+                yield Checkbox("GPC", value=True, id="vf-curve-gpc", compact=True)
+                yield Checkbox("XBAR", value=True, id="vf-curve-xbar", compact=True)
+                yield Checkbox("HOST", value=True, id="vf-curve-host", compact=True)
             yield PlotextPlot(id="vf-plot")

--- a/tui/nvoc_tui/parsing.py
+++ b/tui/nvoc_tui/parsing.py
@@ -18,7 +18,7 @@ import re
 from pathlib import Path
 from typing import Any, cast
 
-from .models import GpuDescriptor
+from .models import CurveData, GpuDescriptor
 
 
 GPU_LINE_RE = re.compile(r"^GPU\s+(\d+)\s*:\s*(.+)$")
@@ -442,4 +442,166 @@ def compute_vf_plot_bounds(
             (x_min - x_padding, x_max + x_padding),
             (y_min, y_max + y_padding),
         ),
+    )
+
+
+# ── Multi-curve helpers (port of the GUI VF-curve logic, minus editing) ──
+
+# Per-curve metadata: plot label, g(def) prior class for raw-converted
+# translation, and the ClockDomain bit for the direct-read live crosshair.
+CURVE_META: dict[str, dict[str, Any]] = {
+    "gpc": {"label": "GPC", "class": "graphics", "domain_bit": 0},
+    "xbar": {"label": "XBAR", "class": "fabric", "domain_bit": 1},
+    "host": {"label": "HOST", "class": "fabric", "domain_bit": 5},
+}
+
+
+def public_vfp_unsupported(gpc_err: str | None) -> bool:
+    """True when the open VFP interface explicitly rejected the query."""
+    if not gpc_err:
+        return False
+    low = gpc_err.lower()
+    return "not supported" in low or "no implementation" in low
+
+
+def build_vf_curves(
+    gpc_points: list[dict[str, Any]] | None,
+    gpc_err: str | None,
+    clk_data: dict[str, Any] | None,
+) -> dict[str, CurveData] | None:
+    """Classify public + private V/F reads into per-domain curves.
+
+    Port of the GUI ``_build_curves``: GPC prefers the open interface
+    (Fixed points flip it to private writes); XBAR/HOST come from the private
+    ClockClient V/F-POINTS ``vf_curve`` segments (pstate_bins / unknown
+    domains are skipped). Point-id ranges come straight from the segment
+    structure — never hardcoded. Returns ``None`` when no curve can be built.
+    """
+    curves: dict[str, CurveData] = {}
+
+    gpc_curve: CurveData | None = None
+    if gpc_points:
+        gpc_curve = CurveData("gpc")
+        gpc_curve.source = "public"
+        gpc_curve.voltages = [p["voltage_uv"] / 1000.0 for p in gpc_points]
+        gpc_curve.frequencies = [p["frequency_khz"] / 1000.0 for p in gpc_points]
+        gpc_curve.defaults = [
+            (p.get("default_frequency_khz") or p["frequency_khz"]) / 1000.0
+            for p in gpc_points
+        ]
+        gpc_curve.has_fixed = any(p.get("point_type") == "fixed" for p in gpc_points)
+        gpc_curve.seg_start = 0
+        gpc_curve.seg_end = len(gpc_points) - 1 if gpc_points else 0
+        # Public family present: traditional OC unless a point is Fixed.
+        gpc_curve.write_mode = "private" if gpc_curve.has_fixed else "public"
+    elif public_vfp_unsupported(gpc_err):
+        # Open family rejected — the private GPC segment (if any) is the
+        # only GPC source; located below from clk_data.
+        pass
+
+    private_gpc: CurveData | None = None
+    if clk_data and clk_data.get("segments"):
+        segs = clk_data["segments"]
+        pts = clk_data.get("points", [])
+        for seg in segs:
+            if seg.get("kind") != "vf_curve":
+                continue  # pstate_bins are not curves — never plotted
+            hint = seg.get("domain", "unknown")
+            bank = int(seg.get("bank", 0))
+            s = int(seg.get("start_index", 0))
+            e = int(seg.get("end_index", s))
+            seg_pts = [
+                p
+                for p in pts
+                if int(p.get("bank", 0)) == bank and s <= int(p.get("index", -1)) <= e
+            ]
+            if not seg_pts:
+                continue
+            if hint not in CURVE_META:
+                # Unknown clock domains (sysclk etc.) are never displayed —
+                # and must not be mistaken for the private GPC fallback.
+                continue
+            cd = CurveData(hint)
+            cd.source = "private"
+            cd.bank = bank
+            cd.seg_start = s
+            cd.seg_end = e
+            cd.voltages = [p["voltage_uV"] / 1000.0 for p in seg_pts]
+            cd.frequencies = [p["freq_current_mhz"] for p in seg_pts]
+            cd.defaults = [p["freq_default_mhz"] for p in seg_pts]
+            cd.write_mode = "private"
+            if cd.curve_id == "gpc":
+                private_gpc = cd
+            elif cd.curve_id in CURVE_META:
+                curves[cd.curve_id] = cd
+            # unknown domains are skipped (only gpc/xbar/host displayed)
+
+    # Resolve GPC source: public preferred, private fallback.
+    if gpc_curve is not None:
+        curves["gpc"] = gpc_curve
+    elif private_gpc is not None:
+        curves["gpc"] = private_gpc
+
+    return curves or None
+
+
+def reverse_lookup_voltage(
+    volts: list[float], freqs: list[float], target_freq: float
+) -> float | None:
+    """Voltage on the curve closest to ``target_freq`` (linear interpolation).
+
+    xbar/host curves are monotonic in frequency vs voltage (no pstate
+    off-curve excursion), so the reverse lookup is single-valued; targets
+    outside the range clamp to the nearer end. Port of the GUI helper.
+    """
+    n = len(freqs)
+    if n == 0:
+        return None
+    if n == 1:
+        return volts[0]
+    ascending = freqs[-1] >= freqs[0]
+    sfreqs = freqs
+    svolts = volts
+    if not ascending:
+        sfreqs = list(reversed(freqs))
+        svolts = list(reversed(volts))
+    if target_freq <= sfreqs[0]:
+        return svolts[0]
+    if target_freq >= sfreqs[-1]:
+        return svolts[-1]
+    for i in range(n - 1):
+        f0, f1 = sfreqs[i], sfreqs[i + 1]
+        if f0 <= target_freq <= f1:
+            v0, v1 = svolts[i], svolts[i + 1]
+            if f1 == f0:
+                return v0
+            t = (target_freq - f0) / (f1 - f0)
+            return v0 + (v1 - v0) * t
+    return svolts[-1]
+
+
+def compute_vf_plot_bounds_multi(
+    curves: list[CurveData],
+    *,
+    live_point: tuple[float, float] | None = None,
+    lock_point: tuple[float, float] | None = None,
+    working_point: tuple[float, float] | None = None,
+) -> tuple[tuple[float, float], tuple[float, float]] | None:
+    """Union bounds across every visible curve (same padding as single)."""
+    voltages: list[float] = []
+    freqs: list[float] = []
+    defaults: list[float] = []
+    for curve in curves:
+        voltages.extend(curve.voltages)
+        freqs.extend(curve.frequencies)
+        defaults.extend(curve.defaults)
+    if not voltages or not freqs or not defaults:
+        return None
+    return compute_vf_plot_bounds(
+        voltages,
+        freqs,
+        defaults,
+        live_point=live_point,
+        lock_point=lock_point,
+        working_point=working_point,
     )

--- a/tui/nvoc_tui/styles/overclock.tcss
+++ b/tui/nvoc_tui/styles/overclock.tcss
@@ -1,18 +1,19 @@
 #overclock-groups {
-    grid-size: 3 1;
-    grid-columns: 1fr 1fr 1fr;
+    grid-size: 4 1;
+    grid-columns: 1fr 1fr 1fr 1fr;
     grid-gutter: 0 1;
     height: auto;
 }
 
 .narrow #overclock-groups {
-    grid-size: 1 3;
+    grid-size: 1 4;
     grid-columns: 1fr;
 }
 
 #clock-controls,
 #pstate-controls,
 #power-controls,
+#mobile-controls,
 #fan-controls {
     grid-gutter: 0 1;
     height: auto;
@@ -20,7 +21,10 @@
     grid-columns: 1fr;
 }
 
-#clock-controls,
+#clock-controls {
+    grid-size: 1 3;
+}
+
 #pstate-controls {
     grid-size: 1 2;
 }
@@ -30,7 +34,15 @@
     grid-size: 1 4;
 }
 
-.wide #clock-controls,
+#mobile-controls {
+    grid-size: 1 5;
+}
+
+.wide #clock-controls {
+    grid-size: 2 2;
+    grid-columns: 1fr 1fr;
+}
+
 .wide #pstate-controls {
     grid-size: 2 1;
     grid-columns: 1fr 1fr;
@@ -42,9 +54,15 @@
     grid-columns: 1fr 1fr;
 }
 
+.wide #mobile-controls {
+    grid-size: 2 3;
+    grid-columns: 1fr 1fr;
+}
+
 #clock-actions,
 #pstate-actions,
 #power-actions,
+#mobile-actions,
 #fan-actions {
     grid-gutter: 0 1;
     height: auto;

--- a/tui/nvoc_tui/styles/vfcurve.tcss
+++ b/tui/nvoc_tui/styles/vfcurve.tcss
@@ -72,6 +72,20 @@
     grid-columns: auto auto auto auto auto auto;
 }
 
+#vf-curve-selector {
+    height: auto;
+    align-vertical: middle;
+    margin: 0 1;
+}
+
+#vf-curve-selector Label {
+    margin: 0 1;
+}
+
+#vf-active-curve {
+    width: 12;
+}
+
 #vf-plot {
     min-height: 20;
     height: 1fr;

--- a/tui/tests/test_controllers.py
+++ b/tui/tests/test_controllers.py
@@ -10,7 +10,7 @@ from nvoc_tui.controllers.dashboard import DashboardController
 from nvoc_tui.controllers.header import HeaderController
 from nvoc_tui.controllers.overclock import OverclockController
 from nvoc_tui.controllers.vfcurve import VFCurveController
-from nvoc_tui.models import AppConfig, GpuCache, GpuDescriptor
+from nvoc_tui.models import AppConfig, CurveData, GpuCache, GpuDescriptor
 
 
 class FakeApp:
@@ -66,6 +66,9 @@ class FakeApp:
     def call_from_thread(self, callback, *args) -> None:
         callback(*args)
 
+    def call_after_refresh(self, callback, *args) -> None:
+        callback(*args)
+
     def run_native_action(self, description: str, action) -> None:
         self.actions.append(description)
         output = action(self.native)
@@ -73,10 +76,27 @@ class FakeApp:
         if output:
             self.write_log(output)
 
+    def run_action_chain(self, commands) -> None:
+        for description, action in commands:
+            self.actions.append(description)
+            output = action(self.native)
+            self.action_outputs.append(output)
+            if output:
+                self.write_log(output)
+
     def run_query(
-        self, command_name: str, callback, *, log_output: bool = True
+        self,
+        command_name: str,
+        callback,
+        *,
+        log_output: bool = True,
+        allow_wake: bool = True,
     ) -> None:
-        self.query_calls.append((command_name, callback, log_output))
+        self.query_calls.append((
+            command_name,
+            callback,
+            {"log_output": log_output, "allow_wake": allow_wake},
+        ))
 
     def write_log(self, text: str) -> None:
         self.logs.append(text)
@@ -137,10 +157,12 @@ class FakeNative:
     def __init__(self) -> None:
         self.calls: list[tuple] = []
         self.raise_on_set_clock: Exception | None = None
+        self.raise_on_set_vfp_point_private: Exception | None = None
+        self.direct_freq_khz: int = 0
 
-    def query_domain_vfp_points(self, gpu, domain, infer_missing_default):
+    def query_public_vftable(self, gpu, domain, infer_missing_default):
         self.calls.append((
-            "query_domain_vfp_points",
+            "query_public_vftable",
             gpu,
             domain,
             infer_missing_default,
@@ -155,6 +177,50 @@ class FakeNative:
             }
         ]
 
+    def query_private_vftable(self, gpu):
+        self.calls.append(("query_private_vftable", gpu))
+        return None
+
+    def query_private_freq_domain_status(self, gpu, domain_bit):
+        self.calls.append(("query_private_freq_domain_status", gpu, domain_bit))
+        return {"domain_bit": domain_bit, "freq_khz": self.direct_freq_khz}
+
+    def set_vfp_point_private(self, gpu, bank, index, delta_khz, freq_mode):
+        self.calls.append((
+            "set_vfp_point_private",
+            gpu,
+            bank,
+            index,
+            delta_khz,
+            freq_mode,
+        ))
+        if self.raise_on_set_vfp_point_private is not None:
+            raise self.raise_on_set_vfp_point_private
+        return {"applied": True}
+
+    def set_vfp_range_per_point_private(self, gpu, bank, start, end, deltas):
+        self.calls.append((
+            "set_vfp_range_per_point_private",
+            gpu,
+            bank,
+            start,
+            end,
+            list(deltas),
+        ))
+        return {"applied": True}
+
+    def clk_vf_delta_for_target_mhz(self, def_mhz, delta_mhz, class_name):
+        # Mirrors the call semantics used by the GUI/TUI raw-converted path:
+        # the 2nd argument is the desired MHz offset (not an absolute
+        # target); the raw f-offset scales it 10×.
+        self.calls.append((
+            "clk_vf_delta_for_target_mhz",
+            def_mhz,
+            delta_mhz,
+            class_name,
+        ))
+        return {"delta": int(delta_mhz * 10)}
+
     def set_power_limit(self, gpu, backend, value):
         self.calls.append(("set_power_limit", gpu, backend, value))
 
@@ -163,6 +229,36 @@ class FakeNative:
 
     def set_voltage_boost(self, gpu, value):
         self.calls.append(("set_voltage_boost", gpu, value))
+
+    def set_legacy_voltage_delta(self, gpu, delta_uv, pstate):
+        self.calls.append(("set_legacy_voltage_delta", gpu, delta_uv, pstate))
+
+    def set_clk_domain_offset(self, gpu, domain_bit, offset_khz, flags, unknown):
+        self.calls.append((
+            "set_clk_domain_offset",
+            gpu,
+            domain_bit,
+            offset_khz,
+            flags,
+            unknown,
+        ))
+        return {"applied": True, "applied_kHz": offset_khz}
+
+    def set_volt_rail_target(self, gpu, rail_bit, target_mv, unknown):
+        self.calls.append(("set_volt_rail_target", gpu, rail_bit, target_mv, unknown))
+        return {"applied": True, "effective_wall_uV": int(target_mv * 1000)}
+
+    def set_ppab_status(self, gpu, enabled):
+        self.calls.append(("set_ppab_status", gpu, enabled))
+
+    def set_dnotifier(self, gpu, level):
+        self.calls.append(("set_dnotifier", gpu, level))
+
+    def set_tgp_watt(self, gpu, watts, policy_index):
+        self.calls.append(("set_tgp_watt", gpu, watts, policy_index))
+
+    def set_target_temp(self, gpu, celsius, policy_index):
+        self.calls.append(("set_target_temp", gpu, celsius, policy_index))
 
     def set_fan(self, gpu, backend, fan_id, policy, level):
         self.calls.append(("set_fan", gpu, backend, fan_id, policy, level))
@@ -203,10 +299,11 @@ def test_dashboard_tick_suppresses_status_json_output() -> None:
     DashboardController(app).tick()
 
     assert len(app.query_calls) == 1
-    command_name, callback, log_output = app.query_calls[0]
+    command_name, callback, kwargs = app.query_calls[0]
     assert command_name == "status"
     assert callback.__name__ == "on_status_loaded"
-    assert log_output is False
+    assert kwargs["log_output"] is False
+    assert kwargs["allow_wake"] is True  # first sample may wake the GPU
 
 
 def test_offline_error_classification_excludes_unsupported_features() -> None:
@@ -564,8 +661,7 @@ def test_vfcurve_refresh_keeps_points_in_memory(tmp_path: Path) -> None:
             "default_frequency_khz": 1750000,
         }
     ]
-    app.native_service.query_domain_vfp_points = lambda _gpu: points
-
+    app.native_service.query_public_vftable = lambda _gpu: points
     app.native_service.submit_query = lambda job: job()
     controller = VFCurveController(app)
     rendered: list[bool] = []
@@ -642,13 +738,54 @@ def test_vfcurve_lock_voltage_accepts_mv_value() -> None:
 
 def test_vfcurve_reset_vfp_reports_success() -> None:
     app = FakeApp()
+    controller = VFCurveController(app)
+    controller._curves = {
+        "gpc": CurveData(
+            "gpc",
+            write_mode="public",
+            seg_start=0,
+            seg_end=1,
+            frequencies=[1800.0, 1900.0],
+            defaults=[1785.0, 1890.0],
+        )
+    }
 
-    assert VFCurveController(app).handle_button("vf-reset") is True
+    assert controller.handle_button("vf-reset") is True
 
     assert app.actions == ["reset VFP deltas"]
-    assert app.action_outputs == ["Successfully reset VFP deltas."]
-    assert app.logs == ["Successfully reset VFP deltas."]
-    assert app.native.calls == [("reset_vfp_deltas", "0x0000", "all")]
+    assert app.action_outputs == [
+        "Successfully reset GPC curve to default (0-1, public)."
+    ]
+    assert app.logs == ["Successfully reset GPC curve to default (0-1, public)."]
+    assert app.native.calls == [("set_vfp_range_delta", "0x0000", 0, 1, 0)]
+
+
+def test_vfcurve_reset_private_curve_uses_mode0_clear() -> None:
+    app = FakeApp()
+    controller = VFCurveController(app)
+    controller._curves = {
+        "xbar": CurveData(
+            "xbar",
+            source="private",
+            write_mode="private",
+            bank=1,
+            seg_start=2,
+            seg_end=4,
+            frequencies=[1000.0, 1100.0, 1200.0],
+            defaults=[1000.0, 1100.0, 1200.0],
+        )
+    }
+    controller._active_curve = "xbar"
+
+    assert controller.handle_button("vf-reset") is True
+
+    assert app.actions == ["reset VFP deltas"]
+    assert app.native.calls == [
+        ("set_vfp_point_private", "0x0000", 1, 2, 0, True),
+        ("set_vfp_point_private", "0x0000", 1, 3, 0, True),
+        ("set_vfp_point_private", "0x0000", 1, 4, 0, True),
+    ]
+    assert "Successfully reset XBAR (private mode-0, 2-4)." in app.action_outputs
 
 
 def test_vfcurve_apply_adjustment_reports_success() -> None:
@@ -658,8 +795,17 @@ def test_vfcurve_apply_adjustment_reports_success() -> None:
         "#vf-range-end": SimpleNamespace(value="5"),
         "#vf-delta": SimpleNamespace(value="125"),
     }
+    controller = VFCurveController(app)
+    controller._curves = {
+        "gpc": CurveData(
+            "gpc",
+            write_mode="public",
+            frequencies=[1800.0] * 11,
+            defaults=[1785.0] * 11,
+        )
+    }
 
-    assert VFCurveController(app).handle_button("vf-apply-adj") is True
+    assert controller.handle_button("vf-apply-adj") is True
 
     assert app.actions == ["apply VFP range delta"]
     assert app.action_outputs == [
@@ -667,3 +813,413 @@ def test_vfcurve_apply_adjustment_reports_success() -> None:
     ]
     assert app.logs == ["Successfully applied 125 MHz VFP delta to points 5-10."]
     assert app.native.calls == [("set_vfp_range_delta", "0x0000", 5, 10, 125000)]
+
+
+def test_vfcurve_apply_private_mode0_then_raw_fallback() -> None:
+    app = FakeApp()
+    app.native.raise_on_set_vfp_point_private = RuntimeError("Argument range")
+    app.widgets = {
+        "#vf-range-start": SimpleNamespace(value="1"),
+        "#vf-range-end": SimpleNamespace(value="2"),
+        "#vf-delta": SimpleNamespace(value="100"),
+    }
+    controller = VFCurveController(app)
+    controller._curves = {
+        "xbar": CurveData(
+            "xbar",
+            source="private",
+            write_mode="private",
+            bank=1,
+            seg_start=5,
+            frequencies=[1000.0, 1100.0, 1200.0, 1300.0],
+            defaults=[1000.0, 1100.0, 1200.0, 1300.0],
+        )
+    }
+    controller._active_curve = "xbar"
+
+    assert controller.handle_button("vf-apply-adj") is True
+
+    # mode-0 attempted on the first point, rejected, then the whole range is
+    # re-applied via the raw-converted path.
+    assert app.native.calls[0] == (
+        "set_vfp_point_private",
+        "0x0000",
+        1,
+        6,
+        100000,
+        True,
+    )
+    assert ("clk_vf_delta_for_target_mhz", 1100, 100.0, "fabric") in app.native.calls
+    assert ("clk_vf_delta_for_target_mhz", 1200, 100.0, "fabric") in app.native.calls
+    range_call = app.native.calls[-1]
+    assert range_call[0] == "set_vfp_range_per_point_private"
+    assert range_call[1:5] == ("0x0000", 1, 6, 7)
+    assert range_call[5] == [1000, 1000]  # (100 MHz target) * 10 per FakeNative
+    assert (
+        "Successfully applied private raw-converted offsets to XBAR (2 pts)."
+        in app.action_outputs
+    )
+
+
+class _FakePlt:
+    def clear_figure(self) -> None:
+        pass
+
+    def clear_data(self) -> None:
+        pass
+
+    def clear_color(self) -> None:
+        pass
+
+    def plot(self, *args, **kwargs) -> None:
+        pass
+
+    def scatter(self, *args, **kwargs) -> None:
+        pass
+
+    def vline(self, *args, **kwargs) -> None:
+        pass
+
+    def hline(self, *args, **kwargs) -> None:
+        pass
+
+    def text(self, *args, **kwargs) -> None:
+        pass
+
+    def xlim(self, *args, **kwargs) -> None:
+        pass
+
+    def ylim(self, *args, **kwargs) -> None:
+        pass
+
+    def title(self, *args, **kwargs) -> None:
+        pass
+
+    def xlabel(self, *args, **kwargs) -> None:
+        pass
+
+    def ylabel(self, *args, **kwargs) -> None:
+        pass
+
+
+def _plot_widget() -> SimpleNamespace:
+    return SimpleNamespace(plt=_FakePlt(), refresh=lambda: None)
+
+
+def _selector_widgets() -> dict[str, SimpleNamespace]:
+    return {
+        "#vf-plot": _plot_widget(),
+        "#vf-active-curve": SimpleNamespace(
+            value="gpc", set_options=lambda options: None, disabled=False
+        ),
+        "#vf-curve-gpc": SimpleNamespace(value=True, disabled=False),
+        "#vf-curve-xbar": SimpleNamespace(value=True, disabled=False),
+        "#vf-curve-host": SimpleNamespace(value=True, disabled=False),
+    }
+
+
+def test_vfcurve_toggle_visibility_guards_last_visible_curve() -> None:
+    app = FakeApp()
+    app.widgets = _selector_widgets()
+    controller = VFCurveController(app)
+    controller._curves = {
+        "gpc": CurveData("gpc", frequencies=[1800.0], defaults=[1785.0]),
+        "xbar": CurveData("xbar", frequencies=[1200.0], defaults=[1200.0]),
+    }
+    controller._curve_visible = {"gpc": True, "xbar": True}
+    gpc_checkbox = app.widgets["#vf-curve-gpc"]
+    # Active falls back to xbar on hide → direct-read kick needs a queue.
+    app.native_service.submit_query = lambda job: None
+
+    # Hide GPC (active): allowed, active falls back to the other visible curve.
+    controller._toggle_curve_visible("gpc", gpc_checkbox)
+    assert controller._curve_visible == {"gpc": False, "xbar": True}
+    assert controller._active_curve == "xbar"
+
+    # Hide XBAR too (now the only visible curve): vetoed, checkbox snaps back.
+    xbar_checkbox = app.widgets["#vf-curve-xbar"]
+    controller._toggle_curve_visible("xbar", xbar_checkbox)
+    assert controller._curve_visible == {"gpc": False, "xbar": True}
+    assert xbar_checkbox.value is True
+
+
+def test_vfcurve_on_curve_loaded_builds_multi_curves() -> None:
+    app = FakeApp()
+    app.widgets = _selector_widgets()
+    controller = VFCurveController(app)
+    gpc_points = [
+        {
+            "index": 0,
+            "voltage_uv": 800000,
+            "frequency_khz": 1800000,
+            "default_frequency_khz": 1785000,
+        }
+    ]
+    clk_data = {
+        "segments": [
+            {
+                "kind": "vf_curve",
+                "domain": "xbar",
+                "bank": 1,
+                "start_index": 2,
+                "end_index": 3,
+            },
+            {
+                "kind": "pstate_bins",
+                "domain": "unknown",
+                "bank": 9,
+                "start_index": 0,
+                "end_index": 5,
+            },
+        ],
+        "points": [
+            {
+                "bank": 1,
+                "index": 2,
+                "voltage_uV": 700000,
+                "freq_current_mhz": 1200.0,
+                "freq_default_mhz": 1200.0,
+            },
+            {
+                "bank": 1,
+                "index": 3,
+                "voltage_uV": 750000,
+                "freq_current_mhz": 1300.0,
+                "freq_default_mhz": 1300.0,
+            },
+        ],
+    }
+
+    controller.on_curve_loaded(gpc_points, None, clk_data)
+
+    assert set(controller._curves) == {"gpc", "xbar"}
+    assert controller._curves["gpc"].write_mode == "public"
+    assert controller._curves["xbar"].bank == 1
+    assert controller._curves["xbar"].seg_start == 2
+    assert controller._curves["xbar"].seg_end == 3
+    assert app.cache.vf_curves is controller._curves
+    assert app.cache.curve_visible == {"gpc": True, "xbar": True}
+
+
+def test_vfcurve_direct_read_updates_live_point() -> None:
+    app = FakeApp()
+    app.widgets = _selector_widgets()
+    controller = VFCurveController(app)
+    controller._curves = {
+        "xbar": CurveData(
+            "xbar",
+            voltages=[700.0, 750.0, 800.0],
+            frequencies=[1200.0, 1300.0, 1400.0],
+            defaults=[1200.0, 1300.0, 1400.0],
+        )
+    }
+    controller._curve_visible = {"xbar": True}
+    controller._active_curve = "xbar"
+    scheduled: list[object] = []
+    app.native_service.submit_query = lambda job: scheduled.append(job)
+    app.native_service.query_private_freq_domain_status = (
+        app.native.query_private_freq_domain_status
+    )
+    app.native.direct_freq_khz = 1350000
+
+    controller._kick_direct_read("xbar")
+    assert controller._direct_read_inflight is True
+    assert len(scheduled) == 1
+
+    # 1350 MHz → halfway between the 1300/1400 points → 775 mV.
+    scheduled[0]()
+    assert controller._direct_read_inflight is False
+    assert app.cache.vf_live_point == (775.0, 1350.0)
+
+
+def _oc_app(**info: object) -> FakeApp:
+    app = FakeApp()
+    app.cache.info = dict(info)
+    app.widgets = {
+        "#oc-api": SimpleNamespace(value="nvapi"),
+        "#power-api": SimpleNamespace(value="nvapi"),
+        "#core-offset": SimpleNamespace(value="100"),
+        "#mem-offset": SimpleNamespace(value="200"),
+        "#xbar-offset": SimpleNamespace(value="60"),
+        "#power-limit": SimpleNamespace(value="110"),
+        "#thermal-limit": SimpleNamespace(value="88"),
+        "#voltage-boost": SimpleNamespace(value="25"),
+        "#mobile-ppab": SimpleNamespace(value="on"),
+        "#mobile-dnotifier": SimpleNamespace(value=3),
+        "#mobile-tgp": SimpleNamespace(value="100"),
+        "#mobile-target-temp": SimpleNamespace(value="85"),
+        "#mobile-volt-limit": SimpleNamespace(value="1050"),
+    }
+    return app
+
+
+def test_overclock_apply_oc_includes_xbar_when_supported() -> None:
+    app = _oc_app(xbar_supported=True)
+
+    assert OverclockController(app).handle_button("oc-apply") is True
+
+    assert app.actions == ["apply overclock"]
+    calls = app.native.calls
+    assert calls == [
+        ("set_clock_offset", "0x0000", "nvapi", "core", 100, "P0"),
+        ("set_clock_offset", "0x0000", "nvapi", "memory", 200, "P0"),
+        ("set_clk_domain_offset", "0x0000", 1, 60000, None, None),
+    ]
+    assert "Successfully applied nvapi overclock." in app.action_outputs[0]
+    assert "Successfully applied Xbar offset +60 MHz" in app.action_outputs[0]
+
+
+def test_overclock_apply_oc_skips_xbar_when_unsupported() -> None:
+    app = _oc_app(xbar_supported=False)
+
+    OverclockController(app).handle_button("oc-apply")
+
+    assert not any(c[0] == "set_clk_domain_offset" for c in app.native.calls)
+
+
+def test_overclock_apply_oc_skips_xbar_under_nvml_backend() -> None:
+    app = _oc_app(xbar_supported=True)
+    app.widgets["#oc-api"] = SimpleNamespace(value="nvml")
+
+    OverclockController(app).handle_button("oc-apply")
+
+    assert not any(c[0] == "set_clk_domain_offset" for c in app.native.calls)
+
+
+def test_overclock_xbar_supported_arch_heuristic() -> None:
+    app = _oc_app(codename="AD107-B", gpu_architecture="Unknown:400:7:161")
+    controller = OverclockController(app)
+    assert controller.xbar_supported() is True
+
+    app2 = _oc_app(gpu_name="NVIDIA GeForce GTX 1080")
+    assert OverclockController(app2).xbar_supported() is False
+
+    app3 = _oc_app(gpu_name="NVIDIA GeForce RTX 4060 Laptop GPU")
+    assert OverclockController(app3).xbar_supported() is True
+
+
+def test_overclock_reset_oc_chain_resets_xbar_when_supported() -> None:
+    app = _oc_app(xbar_supported=True)
+
+    assert OverclockController(app).handle_button("oc-reset") is True
+
+    assert app.actions == [
+        "reset core offset",
+        "reset memory offset",
+        "reset xbar offset",
+    ]
+    assert ("set_clk_domain_offset", "0x0000", 1, 0, None, None) in app.native.calls
+    assert "Successfully applied Xbar offset +0 MHz" in "\n".join(app.logs)
+
+
+def test_overclock_reset_oc_chain_skips_xbar_when_unsupported() -> None:
+    app = _oc_app(xbar_supported=False)
+
+    OverclockController(app).handle_button("oc-reset")
+
+    assert app.actions == ["reset core offset", "reset memory offset"]
+    assert not any(c[0] == "set_clk_domain_offset" for c in app.native.calls)
+
+
+def test_overclock_apply_limits_routes_legacy_overvolt() -> None:
+    app = _oc_app(is_legacy_voltage=True)
+
+    assert OverclockController(app).handle_button("limits-apply") is True
+
+    assert app.native.calls == [
+        ("set_power_limit", "0x0000", "nvapi", 110),
+        ("set_thermal_limit", "0x0000", 88),
+        ("set_legacy_voltage_delta", "0x0000", 25000, "P0"),
+    ]
+
+
+def test_overclock_is_legacy_voltage_heuristic() -> None:
+    app = _oc_app(gpu_name="NVIDIA GeForce GTX 970")
+    assert OverclockController(app).is_legacy_voltage() is True
+
+    app2 = _oc_app(gpu_name="NVIDIA GeForce RTX 4060 Laptop GPU")
+    assert OverclockController(app2).is_legacy_voltage() is False
+
+    app3 = _oc_app(codename="GM204")
+    assert OverclockController(app3).is_legacy_voltage() is True
+
+
+def test_overclock_mobile_apply_includes_volt_limit() -> None:
+    app = _oc_app(is_mobile=True)
+    controller = OverclockController(app)
+    controller._volt_limit_supported = True
+    controller._volt_limit_range = (300.0, 1100.0)
+    controller._volt_rail_bit = 0
+
+    assert controller.handle_button("mobile-apply") is True
+
+    assert ("set_volt_rail_target", "0x0000", 0, 1050.0, None) in app.native.calls
+    assert "Successfully applied Volt Limit 1050 mV" in app.action_outputs[0]
+
+
+def test_overclock_mobile_apply_clamps_volt_limit_to_walls() -> None:
+    app = _oc_app(is_mobile=True)
+    app.widgets["#mobile-volt-limit"] = SimpleNamespace(value="1500")
+    controller = OverclockController(app)
+    controller._volt_limit_supported = True
+    controller._volt_limit_range = (300.0, 1100.0)
+
+    controller.handle_button("mobile-apply")
+
+    assert ("set_volt_rail_target", "0x0000", 0, 1100.0, None) in app.native.calls
+
+
+def test_overclock_mobile_apply_skips_volt_limit_when_unavailable() -> None:
+    app = _oc_app(is_mobile=True)
+    controller = OverclockController(app)
+
+    controller.handle_button("mobile-apply")
+
+    assert not any(c[0] == "set_volt_rail_target" for c in app.native.calls)
+
+
+def test_overclock_volt_limit_bounds_from_p0_walls() -> None:
+    bounds = OverclockController._volt_limit_bounds_from_p0({
+        "vbios_wall_uV": 1_085_000,
+        "vrm_max_wall_uV": 1_100_000,
+        "effective_wall_uV": 1_060_000,
+    })
+    # min(VBIOS, VRM) = 1085 mV snapped down to the 2.5 mV grid; position
+    # 1060 mV is already on-grid.
+    assert bounds == (300.0, 1085.0, 1060.0)
+
+    # No walls reported → 1200 mV fallback; no effective wall → sit at max.
+    assert OverclockController._volt_limit_bounds_from_p0({}) == (
+        300.0,
+        1200.0,
+        1200.0,
+    )
+
+
+def test_overclock_resolve_volt_rail_bit() -> None:
+    assert (
+        OverclockController._resolve_volt_rail_bit({
+            "rail_descriptors": [{"rail_bit": 2}],
+        })
+        == 2
+    )
+    assert OverclockController._resolve_volt_rail_bit({"rail_mask": "0x5"}) == 0
+    assert OverclockController._resolve_volt_rail_bit({"rail_mask": "0x8"}) == 3
+    assert OverclockController._resolve_volt_rail_bit({}) == 0
+
+
+def test_overclock_format_volt_rail_result_messages() -> None:
+    assert (
+        OverclockController._format_volt_rail_result(
+            1050.0, {"applied": True, "effective_wall_uV": 1_045_000}
+        )
+        == "Successfully applied Volt Limit 1050 mV (effective wall 1045 mV)."
+    )
+    assert (
+        OverclockController._format_volt_rail_result(1050.0, {"supported": False})
+        == "Volt-rail target not supported by this driver."
+    )
+    assert (
+        OverclockController._format_volt_rail_result(1050.0, {"applied": True})
+        == "Successfully applied Volt Limit 1050 mV."
+    )

--- a/tui/tests/test_metrics_format.py
+++ b/tui/tests/test_metrics_format.py
@@ -30,7 +30,6 @@ def test_format_metric_lines_full() -> None:
         "pcie_max_link_gen": 4,
         "pcie_tx_mibps": 1234.5,
         "pcie_rx_mibps": 7.8,
-        "pcie_replay_counter": 2,
         "perf": {"unknown": 0, "limits": 32},
     }
 
@@ -45,42 +44,73 @@ def test_format_metric_lines_full() -> None:
     assert "LOAD: GPU 100% | MC 0% | VEN 12% | BUS 2%" in text
     assert "VRAM: 2.0 / 8.0 GB" in text
     assert "FAN: 1234 RPM @ 45%" in text
-    assert "PCIE: Gen4/4 x16 ↑1.2 GiB/s ↓7.8 MiB/s ⚠replay 2" in text
+    assert "PCIE: Gen4/4 x16" in text
+    # PCIe generation prepended as "Gen<cur>/<max>".
+    # Bidirectional bandwidth appended after lane count, nvitop-style (↑Tx ↓Rx).
+    # 1234.5 MiB/s -> 1.2 GiB/s; 7.8 -> 7.8 MiB/s.
+    assert "↑1.2 GiB/s" in text
+    assert "↓7.8 MiB/s" in text
     # limits = 32 = UNKNOWN_32 bit -> decoded reason name, not raw hex.
     assert "PERF LIMIT: Unknown32" in text
     assert "ARCH: Ada" in text
 
 
-def test_format_metric_lines_thermal_trio() -> None:
-    status = {
-        "temperature_c": 55,
-        "temp_hotspot": 63.5,
-        "temp_memory": 58,
-    }
+def test_format_metric_lines_pwr_with_power_limit() -> None:
+    """PWR line appends the enforced power limit (live TGP cap) as `draw W / limit W`
+    when the backend reports it — mirroring nvidia-smi's `1W / 30W` form."""
+    status_with_limit = {"power_w": 1.653, "power_limit_w": 30}
+    text = "\n".join(_format_metric_lines(status_with_limit, "Ada"))
+    assert "PWR: 1.653 W / 30 W" in text
 
-    text = "\n".join(_format_metric_lines(status, "---"))
-
-    # All three present — core always shown, hotspot/memory appended in order.
-    assert "TEMP: CORE 55 C | HOTSPOT 64 C | MEM 58 C" in text
-
-
-def test_format_metric_lines_core_only_when_no_extra_temps() -> None:
-    text = "\n".join(_format_metric_lines({"temperature_c": 47}, "---"))
-
-    assert "TEMP: CORE 47 C" in text
-    assert "HOT" not in text
-    assert "MEM 47 C" not in text
+    # Without a limit the line keeps the plain `draw W` form.
+    status_no_limit = {"power_w": 132}
+    text = "\n".join(_format_metric_lines(status_no_limit, "Ada"))
+    assert "PWR: 132 W" in text
+    assert "/" not in text
 
 
-def test_format_metric_lines_effective_clocks() -> None:
-    status = {"eff_gpu_clock_mhz": 1897.5, "eff_mem_clock_mhz": 7500}
+def test_format_metric_lines_pcie_bandwidth_absent() -> None:
+    """No bandwidth keys -> PCIE line keeps just the lane count."""
+    status = {"pcie_lanes": 8}
     text = "\n".join(_format_metric_lines(status, "Ada"))
-    assert "ECLK: GPU 1898 | MEM 7500 MHz" in text
+    assert "PCIE: x8" in text
+    assert "↑" not in text
+    assert "↓" not in text
 
 
-def test_format_metric_lines_effective_clocks_are_optional() -> None:
-    text = "\n".join(_format_metric_lines({"gpu_clock_mhz": 1800}, "Ada"))
-    assert "ECLK: ---" in text
+def test_format_metric_lines_pcie_bandwidth_only_lanes_missing() -> None:
+    """Bandwidth present but no lane count -> shows bandwidth alone."""
+    status = {"pcie_tx_mibps": 0.5, "pcie_rx_mibps": 0.3}
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "↑0.5 MiB/s" in text
+    assert "↓0.3 MiB/s" in text
+
+
+def test_format_metric_lines_fabric_clocks() -> None:
+    """FCLK line surfaces internal fabric clocks (Xbar/crossbar, Sys, Hub, ...)
+    from the GetAllClocks V2 all_clocks_mhz breakdown."""
+    status = {
+        "all_clocks_mhz": {
+            "Gpc": 2100.0,
+            "Xbar": 1800.0,  # the "crossbar clock" GPU-Z shows
+            "Sys": 900.0,
+            "Hub": 600.0,
+            "M": 7500.0,  # memory — not in the fabric list
+            "Hotclk": 0.0,  # zero -> omitted
+        }
+    }
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "FCLK: XBAR 1800 | SYS 900 | HUB 600 | GPC 2100 MHz" in text
+    # Memory and zero clocks must NOT appear on the FCLK line.
+    assert "M 7500" not in text
+    assert "HOTCLK 0" not in text
+
+
+def test_format_metric_lines_fabric_clocks_absent() -> None:
+    """No all_clocks_mhz -> FCLK line shows dashes."""
+    status = {}
+    text = "\n".join(_format_metric_lines(status, "Ada"))
+    assert "FCLK: ---" in text
 
 
 def test_format_metric_lines_perf_decodes_multiple_reasons() -> None:
@@ -97,24 +127,68 @@ def test_format_metric_lines_perf_zero_is_none() -> None:
     assert "PERF LIMIT: none" in text
 
 
-def test_format_metric_lines_pcie_telemetry_is_optional() -> None:
-    text = "\n".join(_format_metric_lines({"pcie_lanes": 8}, "Ada"))
-    assert "PCIE: x8" in text
-    assert "Gen" not in text
-    assert "↑" not in text
-    assert "replay" not in text
-
-
-def test_format_metric_lines_pcie_telemetry_without_lanes() -> None:
+def test_format_metric_lines_thermal_trio() -> None:
     status = {
-        "pcie_max_link_gen": 5,
-        "pcie_tx_mibps": 0.5,
-        "pcie_rx_mibps": 0.3,
-        "pcie_replay_counter": 0,
+        "temperature_c": 55,
+        "temp_hotspot": 63.5,
+        "temp_memory": 58,
     }
-    text = "\n".join(_format_metric_lines(status, "Ada"))
-    assert "PCIE: Gen?/5 ↑0.5 MiB/s ↓0.3 MiB/s" in text
-    assert "replay" not in text
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    # All three present — core always shown, hotspot/memory appended in order.
+    assert "TEMP: CORE 55 C | HOTSPOT 64 C | MEM 58 C" in text
+
+
+def test_format_metric_lines_effective_clocks() -> None:
+    status = {
+        "gpu_clock_mhz": 1800,
+        "mem_clock_mhz": 7500,
+        "eff_gpu_clock_mhz": 1897.5,
+        "eff_mem_clock_mhz": 7500,
+    }
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    assert "ECLK: GPU 1898 | MEM 7500 MHz" in text
+
+
+def test_format_metric_lines_effective_clocks_absent() -> None:
+    text = "\n".join(_format_metric_lines({"gpu_clock_mhz": 1800}, "---"))
+
+    assert "ECLK: ---" in text
+
+
+def test_format_metric_lines_core_only_when_no_extra_temps() -> None:
+    text = "\n".join(_format_metric_lines({"temperature_c": 47}, "---"))
+
+    assert "TEMP: CORE 47 C" in text
+    assert "HOT" not in text
+    assert "MEM 47 C" not in text
+
+
+def test_format_metric_lines_pairs_live_with_policy_thresholds() -> None:
+    # target_temp_c (policy 2 = target-temperature wall) pairs with the core
+    # reading; max_temp_c (policy 1 = max operating temp) pairs with hot spot.
+    status = {
+        "temperature_c": 46,
+        "target_temp_c": 87,
+        "temp_hotspot": 53,
+        "max_temp_c": 105,
+    }
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    assert "TEMP: CORE 46 / 87 C | HOTSPOT 53 / 105 C" in text
+
+
+def test_format_metric_lines_thresholds_optional() -> None:
+    # Only the target wall present, no max temp: core pairs, hot spot stays bare.
+    status = {"temperature_c": 46, "target_temp_c": 87, "temp_hotspot": 53}
+
+    text = "\n".join(_format_metric_lines(status, "---"))
+
+    assert "TEMP: CORE 46 / 87 C | HOTSPOT 53 C" in text
 
 
 def test_format_metric_lines_missing_fields_render_dashes() -> None:

--- a/tui/tests/test_parsing.py
+++ b/tui/tests/test_parsing.py
@@ -14,6 +14,7 @@
 from pathlib import Path
 
 from nvoc_tui.parsing import (
+    build_vf_curves,
     compute_vf_plot_bounds,
     find_curve_point_for_voltage,
     load_vf_curve,
@@ -25,6 +26,8 @@ from nvoc_tui.parsing import (
     parse_json_output,
     parse_status_output,
     vf_curve_points_to_series,
+    public_vfp_unsupported,
+    reverse_lookup_voltage,
 )
 
 
@@ -158,6 +161,14 @@ def test_normalize_status_json_output() -> None:
               "channel_type": 0
             },
             37
+          ],
+          [
+            {
+              "target": "Gpu",
+              "channel_num": 2,
+              "channel_type": 255
+            },
+            48.25
           ]
         ]
       }
@@ -305,3 +316,177 @@ def test_compute_vf_plot_bounds_includes_live_and_working_points() -> None:
     assert x_max > 875.0
     assert y_min == 0.0
     assert y_max > 2100.0
+
+
+def test_public_vfp_unsupported_substring_match() -> None:
+    assert public_vfp_unsupported(None) is False
+    assert public_vfp_unsupported("pynvoc VFP query failed: boom") is False
+    assert public_vfp_unsupported("Rusty VFP error: Not Supported") is True
+    assert public_vfp_unsupported("driver said no implementation") is True
+
+
+def test_build_vf_curves_public_only() -> None:
+    gpc_points = [
+        {
+            "index": 0,
+            "voltage_uv": 800000,
+            "frequency_khz": 1800000,
+            "default_frequency_khz": 1785000,
+            "point_type": "prog",
+        }
+    ]
+
+    curves = build_vf_curves(gpc_points, None, None)
+
+    assert set(curves) == {"gpc"}
+    assert curves["gpc"].source == "public"
+    assert curves["gpc"].write_mode == "public"
+    assert curves["gpc"].has_fixed is False
+    assert curves["gpc"].voltages == [800.0]
+    assert curves["gpc"].frequencies == [1800.0]
+    assert curves["gpc"].defaults == [1785.0]
+
+
+def test_build_vf_curves_fixed_point_forces_private_write() -> None:
+    gpc_points = [
+        {
+            "index": 0,
+            "voltage_uv": 800000,
+            "frequency_khz": 1800000,
+            "default_frequency_khz": 1785000,
+            "point_type": "fixed",
+        }
+    ]
+
+    curves = build_vf_curves(gpc_points, None, None)
+
+    assert curves["gpc"].has_fixed is True
+    assert curves["gpc"].write_mode == "private"
+
+
+def test_build_vf_curves_private_segments_and_skips() -> None:
+    clk_data = {
+        "segments": [
+            {
+                "kind": "vf_curve",
+                "domain": "gpc",
+                "bank": 0,
+                "start_index": 0,
+                "end_index": 1,
+            },
+            {
+                "kind": "vf_curve",
+                "domain": "xbar",
+                "bank": 1,
+                "start_index": 2,
+                "end_index": 3,
+            },
+            {
+                "kind": "vf_curve",
+                "domain": "host",
+                "bank": 2,
+                "start_index": 6,
+                "end_index": 7,
+            },
+            # pstate_bins and unknown domains are never curves.
+            {
+                "kind": "pstate_bins",
+                "domain": "gpc",
+                "bank": 3,
+                "start_index": 0,
+                "end_index": 9,
+            },
+            {
+                "kind": "vf_curve",
+                "domain": "sysclk",
+                "bank": 4,
+                "start_index": 0,
+                "end_index": 2,
+            },
+        ],
+        "points": [
+            {
+                "bank": 0,
+                "index": 0,
+                "voltage_uV": 700000,
+                "freq_current_mhz": 1000.0,
+                "freq_default_mhz": 1000.0,
+            },
+            {
+                "bank": 0,
+                "index": 1,
+                "voltage_uV": 750000,
+                "freq_current_mhz": 1100.0,
+                "freq_default_mhz": 1100.0,
+            },
+            {
+                "bank": 1,
+                "index": 2,
+                "voltage_uV": 700000,
+                "freq_current_mhz": 1200.0,
+                "freq_default_mhz": 1200.0,
+            },
+            {
+                "bank": 1,
+                "index": 3,
+                "voltage_uV": 750000,
+                "freq_current_mhz": 1300.0,
+                "freq_default_mhz": 1300.0,
+            },
+            {
+                "bank": 2,
+                "index": 6,
+                "voltage_uV": 600000,
+                "freq_current_mhz": 900.0,
+                "freq_default_mhz": 900.0,
+            },
+            {
+                "bank": 2,
+                "index": 7,
+                "voltage_uV": 650000,
+                "freq_current_mhz": 950.0,
+                "freq_default_mhz": 950.0,
+            },
+            {
+                "bank": 4,
+                "index": 0,
+                "voltage_uV": 500000,
+                "freq_current_mhz": 800.0,
+                "freq_default_mhz": 800.0,
+            },
+        ],
+    }
+
+    curves = build_vf_curves(None, "driver said Not Supported", clk_data)
+
+    # Public read unsupported → private GPC segment is the GPC source.
+    assert set(curves) == {"gpc", "xbar", "host"}
+    assert curves["gpc"].source == "private"
+    assert curves["gpc"].bank == 0
+    assert (curves["gpc"].seg_start, curves["gpc"].seg_end) == (0, 1)
+    assert curves["xbar"].bank == 1
+    assert (curves["xbar"].seg_start, curves["xbar"].seg_end) == (2, 3)
+    assert curves["host"].voltages == [600.0, 650.0]
+    for curve in curves.values():
+        assert curve.write_mode == "private"
+
+
+def test_build_vf_curves_none_when_no_source() -> None:
+    assert build_vf_curves(None, "boom", None) is None
+    assert build_vf_curves([], None, {"segments": [], "points": []}) is None
+
+
+def test_reverse_lookup_voltage_interpolates_and_clamps() -> None:
+    volts = [700.0, 750.0, 800.0]
+    freqs = [1200.0, 1300.0, 1400.0]
+
+    assert reverse_lookup_voltage(volts, freqs, 1350.0) == 775.0
+    assert reverse_lookup_voltage(volts, freqs, 1100.0) == 700.0
+    assert reverse_lookup_voltage(volts, freqs, 1500.0) == 800.0
+    # Descending order still resolves.
+    assert (
+        reverse_lookup_voltage(list(reversed(volts)), list(reversed(freqs)), 1250.0)
+        == 725.0
+    )
+    assert reverse_lookup_voltage([], [], 1000.0) is None
+    assert reverse_lookup_voltage([700.0], [1200.0], 900.0) == 700.0


### PR DESCRIPTION
Restores the physicsdolphin-authored TUI monitoring, thermal/power controls, VF-curve handling, and associated tests removed by 046b74b18e19aa9a48ac15b2e5fb21f5e7cc37e4.

Validation on a stack with the core/CLI and pynvoc recoveries:
- uv sync --locked
- uv run pytest (95 passed)

Related: #267; depends on #313 and #314.