### PR TITLE
fix(optimizer,stressor): restore physicsdolphin GPU scanning and fill paths

### DIFF
--- a/auto-optimizer/Cargo.toml
+++ b/auto-optimizer/Cargo.toml
@@ -10,7 +10,13 @@ keywords = ["nvidia", "gtx", "gpu", "nvapi", "overclock"]
 readme = "README.md"
 license = "Apache-2.0"
 
-include = ["/src/**", "/README*", "/LICENSE*"]
+include = [
+    "/src/**",
+    "/test/windows_gpu_event_query.ps1",
+    "/test/windows_oc_pnp_recover.ps1",
+    "/README*",
+    "/LICENSE*",
+]
 
 [features]
 default = ["stressor-bundled"]

--- a/auto-optimizer/src/arg_help.rs
+++ b/auto-optimizer/src/arg_help.rs
@@ -99,19 +99,12 @@ fn optimize_command() -> Command {
 
     #[cfg(all(feature = "stressor-external", not(feature = "stressor-bundled")))]
     {
-        cmd = cmd
-            .arg(
-                Arg::new("test_exe")
-                    .long("test-exe")
-                    .value_name("PATH")
-                    .default_value("cli-stressor-cuda-rs"),
-            )
-            .arg(
-                Arg::new("minload_exe")
-                    .long("minload-exe")
-                    .value_name("PATH")
-                    .default_value("cli-stressor-cuda-rs"),
-            );
+        cmd = cmd.arg(
+            Arg::new("test_exe")
+                .long("test-exe")
+                .value_name("PATH")
+                .default_value("cli-stressor-cuda-rs"),
+        );
     }
 
     #[cfg(all(feature = "stressor-bundled", feature = "stressor-external"))]
@@ -126,12 +119,6 @@ fn optimize_command() -> Command {
             .arg(
                 Arg::new("test_exe")
                     .long("test-exe")
-                    .value_name("PATH")
-                    .default_value("cli-stressor-cuda-rs"),
-            )
-            .arg(
-                Arg::new("minload_exe")
-                    .long("minload-exe")
                     .value_name("PATH")
                     .default_value("cli-stressor-cuda-rs"),
             );
@@ -344,24 +331,15 @@ fn vfp_autoscan_command(legacy: bool) -> Command {
 
     #[cfg(all(feature = "stressor-external", not(feature = "stressor-bundled")))]
     {
-        cmd = cmd
-            .arg(
-                Arg::new("test_exe")
-                    .value_name("TEST_EXE")
-                    .short('w')
-                    .long("test-exe")
-                    .num_args(1)
-                    .default_value("cli-stressor-cuda-rs")
-                    .help("External cli-stressor-cuda-rs executable path"),
-            )
-            .arg(
-                Arg::new("minload_exe")
-                    .long("minload-exe")
-                    .value_name("PATH")
-                    .num_args(1)
-                    .default_value("cli-stressor-cuda-rs")
-                    .help("External cli-stressor-cuda-rs executable used for min-load"),
-            );
+        cmd = cmd.arg(
+            Arg::new("test_exe")
+                .value_name("TEST_EXE")
+                .short('w')
+                .long("test-exe")
+                .num_args(1)
+                .default_value("cli-stressor-cuda-rs")
+                .help("External cli-stressor-cuda-rs executable path"),
+        );
     }
 
     #[cfg(all(feature = "stressor-bundled", feature = "stressor-external"))]
@@ -383,14 +361,6 @@ fn vfp_autoscan_command(legacy: bool) -> Command {
                     .num_args(1)
                     .default_value("cli-stressor-cuda-rs")
                     .help("External cli-stressor-cuda-rs executable path"),
-            )
-            .arg(
-                Arg::new("minload_exe")
-                    .long("minload-exe")
-                    .value_name("PATH")
-                    .num_args(1)
-                    .default_value("cli-stressor-cuda-rs")
-                    .help("External cli-stressor-cuda-rs executable used for min-load"),
             );
     }
 

--- a/auto-optimizer/src/autoscan_config.rs
+++ b/auto-optimizer/src/autoscan_config.rs
@@ -7,8 +7,8 @@
 //! legacy 路径携带 gpuboostv3 专属字段。
 
 use super::platform::{
-    default_minload_exe_path, default_test_exe_path, default_vfp_csv_path,
-    default_vfp_init_csv_path, default_vfp_log_path, default_vfp_temp_csv_path,
+    default_test_exe_path, default_vfp_csv_path, default_vfp_init_csv_path, default_vfp_log_path,
+    default_vfp_temp_csv_path,
 };
 use clap::ArgMatches;
 use nvoc_core::ClockDomain;
@@ -153,8 +153,6 @@ impl StressorConfig {
 pub struct AutoscanCommonConfig {
     /// 压力测试可执行文件路径
     pub test_exe: String,
-    /// Min-load Vulkan 可执行文件路径（唤醒 Optimus 笔记本上的 GPU）
-    pub minload_exe: String,
     /// 扫描日志文件路径
     pub log: String,
     /// 单轮超时循环次数
@@ -194,7 +192,6 @@ impl AutoscanCommonConfig {
         };
         AutoscanCommonConfig {
             test_exe: selected_executable("test_exe", default_test_exe_path()),
-            minload_exe: selected_executable("minload_exe", default_minload_exe_path()),
             log: matches
                 .get_one::<String>("log")
                 .cloned()
@@ -302,7 +299,6 @@ mod tests {
         let cfg = GpuBoostAutoscanConfig::from_autoscan_matches(&matches).unwrap();
 
         assert_eq!(cfg.common.test_exe, default_test_exe_path());
-        assert_eq!(cfg.common.minload_exe, default_minload_exe_path());
         assert_eq!(cfg.common.log, default_vfp_log_path());
         assert_eq!(cfg.common.timeout_loops, 30);
         assert_eq!(cfg.common.recovery_method, None);
@@ -323,7 +319,6 @@ mod tests {
         let cfg = LegacyAutoscanConfig::from_legacy_matches(&matches).unwrap();
 
         assert_eq!(cfg.common.test_exe, default_test_exe_path());
-        assert_eq!(cfg.common.minload_exe, default_minload_exe_path());
         assert_eq!(cfg.common.log, default_vfp_log_path());
         assert_eq!(cfg.common.timeout_loops, 30);
         assert_eq!(cfg.common.recovery_method, None);
@@ -345,7 +340,6 @@ mod tests {
         let cfg = GpuBoostAutoscanConfig::from_autoscan_matches(&matches).unwrap();
 
         assert_eq!(cfg.common.test_exe, "cli-stressor-cuda-rs");
-        assert_eq!(cfg.common.minload_exe, "cli-stressor-cuda-rs");
     }
 
     #[test]

--- a/auto-optimizer/src/cleanup.rs
+++ b/auto-optimizer/src/cleanup.rs
@@ -1,8 +1,8 @@
 use nvml_wrapper::enums::device::FanControlPolicy;
 use nvoc_core::{
     ClockDomain, CoolerPolicy, CoolerTarget, Error, GpuTarget, QueryFanInfo, ResetCoolerLevels,
-    ResetFanSpeed, ResetVfpDeltas, ResetVfpFrequencyLock, ResetVfpLock, SetCoolerLevels,
-    SetFanSpeed, VfpResetDomain, run,
+    ResetFanSpeed, ResetPublicVftableGpcLock, ResetPublicVftableOffset, ResetVfpFrequencyLock,
+    SetCoolerLevels, SetFanSpeed, VfpResetDomain, run,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -92,7 +92,7 @@ fn reset_vfp(gpu: &GpuTarget<'_>) {
         "reset VFP deltas",
         run(
             gpu,
-            ResetVfpDeltas {
+            ResetPublicVftableOffset {
                 domain: VfpResetDomain::All,
             },
         ),
@@ -100,7 +100,11 @@ fn reset_vfp(gpu: &GpuTarget<'_>) {
 }
 
 fn reset_locks(gpu: &GpuTarget<'_>) {
-    ignore_cleanup_error(gpu, "reset VFP voltage lock", run(gpu, ResetVfpLock));
+    ignore_cleanup_error(
+        gpu,
+        "reset VFP voltage lock",
+        run(gpu, ResetPublicVftableGpcLock),
+    );
     ignore_cleanup_error(
         gpu,
         "reset graphics VFP frequency lock",

--- a/auto-optimizer/src/main.rs
+++ b/auto-optimizer/src/main.rs
@@ -21,7 +21,7 @@ mod stressor_process;
 use anyhow::Result;
 use cleanup::{AutoscanExit, cleanup_autoscan_exit};
 use nvoc_core::{
-    BackendSet, ConvertEnum, GpuSelector, GpuTarget, ResetVfpDeltas, VfpResetDomain,
+    BackendSet, ConvertEnum, GpuSelector, GpuTarget, ResetPublicVftableOffset, VfpResetDomain,
     discover_targets, run, select_targets, sync_memory_pstate_as_p0,
 };
 use oc_profile_function::{export_vfp_from_log, fix_result, handle_vfp_export, handle_vfp_import};
@@ -170,7 +170,7 @@ fn main_result() -> Result<i32, Box<dyn std::error::Error>> {
                 .transpose()?
                 .unwrap_or(VfpResetDomain::All);
             for gpu in &nvapi_selected {
-                run(gpu, ResetVfpDeltas { domain })?;
+                run(gpu, ResetPublicVftableOffset { domain })?;
             }
         }
         Some(("export-vfp", matches)) => {

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -18,7 +18,7 @@ use nvoc_core::{
 use nvoc_core::{Error, QueryGpuStatus, set_nvapi_pstate_clock_offsets};
 use nvoc_core::{
     GpuOperation, GpuType, QueryGpuInfo, SetNvapiPowerLimits, SetNvapiSensorLimits,
-    SetPstateBaseVoltage, SetVfpPointDelta, SetVoltageBoost, fetch_gpu_type,
+    SetPstateBaseVoltage, SetPublicVftablePointOffset, SetVoltageBoost, fetch_gpu_type,
     legacy_p0_core_max_voltage_delta, query_domain_vf_points_indexed, query_domain_vfp_indices,
     run, set_nvapi_cooler_settings, set_nvapi_domain_vfp_deltas, sync_memory_pstate_as_p0,
 };
@@ -608,7 +608,7 @@ pub fn handle_vfp_import(gpu: &GpuTarget<'_>, matches: &clap::ArgMatches) -> Res
 
     if domain == ClockDomain::Graphics {
         for (point, delta) in deltas {
-            run_output(gpu, SetVfpPointDelta { point, delta })?;
+            run_output(gpu, SetPublicVftablePointOffset { point, delta })?;
         }
     } else {
         set_domain_vfp_deltas_raw(gpu, domain, &deltas)?;

--- a/auto-optimizer/src/oc_profile_function.rs
+++ b/auto-optimizer/src/oc_profile_function.rs
@@ -1039,9 +1039,11 @@ pub fn apply_autoscan_profile(
     cooler_level: u32,
 ) -> Result<(), Error> {
     let info = run_output(gpu, QueryGpuInfo)?;
-    let gpu_name = &info.name;
+    let gpu_type = fetch_gpu_type(&info).unwrap_or(GpuType::Unknown);
 
-    if gpu_name.contains("Laptop") || gpu_name.contains("Device") {
+    // 移动端判定走 gpu_type（原为 name.contains("Laptop"/"Device") 的自发
+    // 启发式）；Unknown 一并按移动端保守跳过，对应旧 "Device" 检查的意图。
+    if gpu_type.is_mobile() || gpu_type.is_unknown() {
         println!("TDP/Temp/VDDQ control not available on MOBILE chips! Skipping...");
         return Ok(());
     }
@@ -1049,7 +1051,6 @@ pub fn apply_autoscan_profile(
     // 根据 GPU 世代选择电压设置方式
     // 900 系（Maxwell，GM 代号）及更早 → 使用 set_pstate_base_voltage（P0 baseVoltages delta）
     // 10 系（Pascal，GP1 代号）及以后  → 使用 set_voltage_boost（VoltRails boost）
-    let gpu_type = fetch_gpu_type(&info).unwrap_or(GpuType::Unknown);
 
     if gpu_type.is_legacy_voltage() {
         // 900 系及更早：通过 SetPstates20 写 P0 baseVoltage delta（最大允许値，即尽量升压）

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -705,6 +705,7 @@ pub fn autoscan_legacy(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> Resul
             is_50_series: _, // legacy 路径不区分架构世代
             testing_step: _,
             freq_step_exp_core,
+            ..
         } = gpu_type.as_ref().map(|t| t.oc_params()).unwrap_or_default();
         // GC6 原生唤醒门槛（与 core 预唤醒钩子同源）；识别失败 -> 保守唤醒
         let needs_gc6_wake = gpu_type

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -10,7 +10,7 @@ use self::phases::{
     CommonPhaseArgs, GpuBoostPhaseArgs, LegacyPhaseArgs, MemOcPhaseArgs, run_gpuboostv3_long_phase,
     run_gpuboostv3_short_phase, run_legacy_long_phase, run_legacy_short_phase, run_mem_oc_phase,
 };
-use self::runtime::{MinLoadPulse, retry_operation_with_backoff, run_output};
+use self::runtime::{native_wake, retry_operation_with_backoff, run_output};
 #[cfg(debug_assertions)]
 use super::manual_override::ManualOverride;
 use super::oc_profile_function::{
@@ -54,7 +54,6 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
     }
 
     let test_exe = common.test_exe.as_str();
-    let minload_exe = common.minload_exe.as_str();
     let log_filename = common.log.as_str();
     let mut l = ScanLogWriter::open_append(log_filename)?;
     #[cfg(debug_assertions)]
@@ -103,23 +102,14 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
 
         None => {
             println!("Voltage scan initialized because values were missing in the log.");
-            // 探测前先读取首个 GPU 的世代，判断是否需要 MinLoadPulse 唤醒。
-            let wakeup_load_needed = gpus
-                .first()
-                .and_then(|g| run_output(g, QueryGpuInfo).ok())
-                .and_then(|info| fetch_gpu_type(&info).ok())
-                .map(|t| t.oc_params().wakeup_load_needed)
-                .unwrap_or(false);
             // New logs need a read-only voltage range probe before any per-point
-            // VFP writes are attempted.
+            // VFP writes are attempted. GPUnotpowered 会在 retry 内部触发原生唤醒。
             let voltage_limits = retry_operation_with_backoff(
+                gpus,
                 || handle_test_voltage_limits(gpus, matches, print_scan_separator),
                 "ProbeVoltageLimits",
                 8,
                 1,
-                minload_exe,
-                cuda_device,
-                wakeup_load_needed,
             )?;
             let lvp = voltage_limits
                 .iter()
@@ -196,16 +186,16 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
                 delta: KilohertzDelta(45000),
             },
         )?;
-        // 仅在需要唤醒的世代（30/50 系笔记本）执行 MinLoadPulse
-        let wakeup_load_needed = gpu_type
+        // GC6 原生唤醒门槛：与 core 预唤醒钩子同源（GpuType::needs_gc6_wake，
+        // 全移动端 + Unknown）。旧 wakeup_load_needed 世代表只标 30/50 系，
+        // 恰好漏掉 40 系笔记本 —— 而 RTX 4060 Laptop 正是 610 激进 GCOFF 实测机型。
+        let needs_gc6_wake = gpu_type
             .as_ref()
-            .map(|t| t.oc_params().wakeup_load_needed)
-            .unwrap_or(false);
-        let _pulse = if wakeup_load_needed {
-            Some(MinLoadPulse::wake(minload_exe, cuda_device))
-        } else {
-            None
-        };
+            .map(|t| t.needs_gc6_wake())
+            .unwrap_or(true); // 识别失败 -> 保守唤醒
+        if needs_gc6_wake {
+            native_wake(gpu);
+        }
         match handle_lock_vfp(gpus, matches, upper_voltage_point, false) {
             Ok(_) => println!("Voltage locked successfully."),
             Err(e) => eprintln!("Error: Failed to lock voltage - {:?}", e),
@@ -234,13 +224,11 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
 
         // Retry QueryGpuStatus with backoff to handle transient GPU power state issues
         let status = retry_operation_with_backoff(
+            std::slice::from_ref(gpu),
             || run_output(gpu, QueryGpuStatus),
             "QueryGpuStatus (initial VFP load)",
             8, // attempts
             1, // base_wait_secs
-            minload_exe,
-            cuda_device,
-            wakeup_load_needed,
         )?;
         let points = status.vfp.ok_or(Error::VfpUnsupported)?.graphics;
 
@@ -397,14 +385,13 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
                     coefficient: fluctuation_coefficient,
                 },
                 test_exe,
-                minload_exe,
                 delimiter: delimiter.as_str(),
                 test_duration,
                 endurance_coefficient,
                 progress: Some(scan_progress.as_ref()),
                 cuda_device,
                 stressor_extra_args,
-                wakeup_load_needed,
+                needs_gc6_wake,
                 stressor_profile,
                 stressor_config,
                 #[cfg(debug_assertions)]
@@ -453,11 +440,10 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
                 .ok_or(Error::Str("invalid point index"))?
                 .default_frequency;
 
-            let _pulse = if wakeup_load_needed {
-                Some(MinLoadPulse::wake(minload_exe, cuda_device))
-            } else {
-                None
-            };
+            // 每个电压点锁定前原生唤醒（读为主的窗口，core 钩子只兜底写操作）
+            if needs_gc6_wake {
+                native_wake(gpu);
+            }
             match handle_lock_vfp(gpus, matches, point, true) {
                 Ok(_) => {
                     flat_curve_flag = false;
@@ -589,13 +575,11 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
 
             // Retry QueryGpuStatus with backoff for memory OC readout
             let status = retry_operation_with_backoff(
+                std::slice::from_ref(gpu),
                 || run_output(gpu, QueryGpuStatus),
                 "QueryGpuStatus (memory OC readout)",
                 5, // attempts
                 1, // base_wait_secs
-                minload_exe,
-                cuda_device,
-                wakeup_load_needed,
             )?;
             let readout_f = status.clone().clocks;
             let mut clocks = Vec::new();
@@ -640,14 +624,13 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
                         coefficient: fluctuation_coefficient,
                     },
                     test_exe,
-                    minload_exe,
                     delimiter: delimiter.as_str(),
                     test_duration,
                     endurance_coefficient,
                     progress: Some(scan_progress.as_ref()),
                     cuda_device,
                     stressor_extra_args,
-                    wakeup_load_needed,
+                    needs_gc6_wake,
                     stressor_profile,
                     stressor_config,
                     #[cfg(debug_assertions)]
@@ -698,7 +681,6 @@ pub fn autoscan_legacy(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> Resul
     let stressor_profile = common.stressor.profile.as_str();
     let stressor_config = common.stressor.config.as_deref();
     let test_exe = common.test_exe.as_str();
-    let minload_exe = common.minload_exe.as_str();
     let log_filename = common.log.as_str();
     let mut l = ScanLogWriter::open_append(log_filename)?;
     #[cfg(debug_assertions)]
@@ -721,10 +703,14 @@ pub fn autoscan_legacy(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> Resul
             safe_elasticity_per_cycle,
             fluctuation_coefficient,
             is_50_series: _, // legacy 路径不区分架构世代
-            wakeup_load_needed,
             testing_step: _,
             freq_step_exp_core,
         } = gpu_type.as_ref().map(|t| t.oc_params()).unwrap_or_default();
+        // GC6 原生唤醒门槛（与 core 预唤醒钩子同源）；识别失败 -> 保守唤醒
+        let needs_gc6_wake = gpu_type
+            .as_ref()
+            .map(|t| t.needs_gc6_wake())
+            .unwrap_or(true);
 
         let core_oc_safe_limit_ref = core_oc_safe_limit;
 
@@ -810,14 +796,13 @@ pub fn autoscan_legacy(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> Resul
                     coefficient: fluctuation_coefficient,
                 },
                 test_exe,
-                minload_exe,
                 delimiter: delimiter.as_str(),
                 test_duration,
                 endurance_coefficient,
                 progress: None,
                 cuda_device,
                 stressor_extra_args,
-                wakeup_load_needed,
+                needs_gc6_wake,
                 stressor_profile,
                 stressor_config,
                 #[cfg(debug_assertions)]

--- a/auto-optimizer/src/oc_scanner.rs
+++ b/auto-optimizer/src/oc_scanner.rs
@@ -25,8 +25,8 @@ use super::scan_support::{handle_lock_vfp, handle_test_voltage_limits, print_sca
 use clap::ArgMatches;
 use nvoc_core::{
     ClockDomain, Error, GpuOcParams, GpuTarget, KilohertzDelta, PState, QueryGpuInfo,
-    QueryGpuStatus, QueryVfpPointVoltage, SetVfpPointDelta, VfPoint, VfPointType, fetch_gpu_type,
-    set_nvapi_pstate_clock_offsets,
+    QueryGpuStatus, QueryVfpPointVoltage, SetPublicVftablePointOffset, VfPoint, VfPointType,
+    fetch_gpu_type, set_nvapi_pstate_clock_offsets,
 };
 use std::sync::Arc;
 
@@ -181,7 +181,7 @@ pub fn autoscan_gpuboostv3(gpus: &Vec<GpuTarget<'_>>, matches: &ArgMatches) -> R
 
         run_output(
             gpu,
-            SetVfpPointDelta {
+            SetPublicVftablePointOffset {
                 point: upper_voltage_point,
                 delta: KilohertzDelta(45000),
             },

--- a/auto-optimizer/src/oc_scanner/phases.rs
+++ b/auto-optimizer/src/oc_scanner/phases.rs
@@ -10,7 +10,7 @@ use clap::ArgMatches;
 use nvoc_core::sync_memory_pstate_as_p0;
 use nvoc_core::{
     ClockDomain, Error, GpuTarget, KilohertzDelta, Microvolts, NvapiLockedVoltageTarget, PState,
-    QueryVfpPointVoltage, ResetVfpDeltas, SetVfpVoltageLock, VfpResetDomain,
+    QueryVfpPointVoltage, ResetPublicVftableOffset, SetGpcVoltLock, VfpResetDomain,
     set_nvapi_pstate_clock_offsets, set_nvapi_vfp_curve_delta,
 };
 use std::io;
@@ -198,7 +198,7 @@ fn set_vfp_and_recheck(
         if let Ok(locked_v) = run_output(gpu, QueryVfpPointVoltage { point }) {
             let _ = run_output(
                 gpu,
-                SetVfpVoltageLock {
+                SetGpcVoltLock {
                     voltage_target: NvapiLockedVoltageTarget::Voltage(locked_v),
                     feedback: false,
                 },
@@ -540,7 +540,7 @@ pub(super) fn run_gpuboostv3_short_phase(
         if test_flag != 0 {
             run_output(
                 gpu,
-                ResetVfpDeltas {
+                ResetPublicVftableOffset {
                     domain: VfpResetDomain::Core,
                 },
             )?;
@@ -664,7 +664,7 @@ pub(super) fn run_gpuboostv3_long_phase(
         if long_duration_flag != 0 {
             run_output(
                 gpu,
-                ResetVfpDeltas {
+                ResetPublicVftableOffset {
                     domain: VfpResetDomain::Core,
                 },
             )?;

--- a/auto-optimizer/src/oc_scanner/phases.rs
+++ b/auto-optimizer/src/oc_scanner/phases.rs
@@ -1,5 +1,5 @@
 use super::pressure::{PressureTestConfig, run_pressure_test};
-use super::runtime::{MinLoadPulse, run_output};
+use super::runtime::{native_wake, run_output};
 #[cfg(debug_assertions)]
 use crate::manual_override::ManualOverride;
 use crate::progressbar::ScanProgress;
@@ -24,14 +24,16 @@ pub(super) struct CommonPhaseArgs<'a> {
     pub(super) minimum_delta_core_freq_step: i32,
     pub(super) fluctuation: FluctuationStrategy,
     pub(super) test_exe: &'a str,
-    pub(super) minload_exe: &'a str,
     pub(super) delimiter: &'a str,
     pub(super) test_duration: u64,
     pub(super) endurance_coefficient: u64,
     pub(super) progress: Option<&'a ScanProgress>,
     pub(super) cuda_device: Option<u32>,
     pub(super) stressor_extra_args: &'a [String],
-    pub(super) wakeup_load_needed: bool,
+    /// 是否需要 GC6 原生唤醒（GpuType::needs_gc6_wake：全移动端 + Unknown）。
+    /// 在电压锁定等"读操作为主"的窗口前显式调用 native_wake；NVAPI 写操作
+    /// 由 core::operation::run 预唤醒钩子自动兜底。
+    pub(super) needs_gc6_wake: bool,
     pub(super) stressor_profile: &'a str,
     pub(super) stressor_config: Option<&'a str>,
     #[cfg(debug_assertions)]
@@ -102,7 +104,6 @@ impl<'a> CommonPhaseArgs<'a> {
             minimum_delta_core_freq_step: self.minimum_delta_core_freq_step,
             fluctuation: self.fluctuation.clone(),
             test_exe: self.test_exe,
-            minload_exe: self.minload_exe,
             test_code: spec.test_code,
             timeout_loops: spec.timeout_loops,
             is_legacy_global_offset: spec.is_legacy_global_offset,
@@ -110,7 +111,6 @@ impl<'a> CommonPhaseArgs<'a> {
             progress: self.progress,
             cuda_device: self.cuda_device,
             stressor_extra_args: self.stressor_extra_args,
-            wakeup_load_needed: self.wakeup_load_needed,
             stressor_profile: self.stressor_profile,
             stressor_config: self.stressor_config,
             #[cfg(debug_assertions)]
@@ -176,16 +176,14 @@ fn set_vfp_and_recheck(
     init_core_oc_value: i32,
     minimum_delta_core_freq_step: i32,
     max_attempts: i32,
-    minload_exe: &str,
-    cuda_device: Option<u32>,
-    wakeup_load_needed: bool,
+    needs_gc6_wake: bool,
 ) -> Result<(), Error> {
     for attempt in 1..=max_attempts {
-        let _pulse = if wakeup_load_needed {
-            Some(MinLoadPulse::wake(minload_exe, cuda_device))
-        } else {
-            None
-        };
+        // 每轮尝试前原生唤醒：等待退避（最长 64s）期间 GPU 可能已重新 GCOFF，
+        // 后续的 V/F recheck 是读操作、不走 core 写预唤醒钩子。
+        if needs_gc6_wake {
+            native_wake(gpu);
+        }
 
         set_nvapi_vfp_curve_delta(
             gpu,
@@ -489,9 +487,7 @@ pub(super) fn run_gpuboostv3_short_phase(
             controller.f_current,
             args.common.minimum_delta_core_freq_step,
             10,
-            args.common.minload_exe,
-            args.common.cuda_device,
-            args.common.wakeup_load_needed,
+            args.common.needs_gc6_wake,
         )?;
 
         controller.test_progress_num += 1;
@@ -619,9 +615,7 @@ pub(super) fn run_gpuboostv3_long_phase(
             controller.f_current,
             args.common.minimum_delta_core_freq_step,
             5,
-            args.common.minload_exe,
-            args.common.cuda_device,
-            args.common.wakeup_load_needed,
+            args.common.needs_gc6_wake,
         )?;
 
         *test_code += 1;
@@ -735,14 +729,10 @@ pub(super) fn run_mem_oc_phase(
     let mut mem_test_code: usize = 0;
 
     loop {
-        let _pulse = if args.common.wakeup_load_needed {
-            Some(MinLoadPulse::wake(
-                args.common.minload_exe,
-                args.common.cuda_device,
-            ))
-        } else {
-            None
-        };
+        // 显存 OC 循环内，锁定电压（读为主的窗口）前原生唤醒
+        if args.common.needs_gc6_wake {
+            native_wake(gpu);
+        }
         match handle_lock_vfp(gpus, args.common.matches, args.point, false) {
             Ok(_) => println!("Voltage locked successfully."),
             Err(e) => eprintln!("Error: Failed to lock voltage - {:?}", e),

--- a/auto-optimizer/src/oc_scanner/pressure.rs
+++ b/auto-optimizer/src/oc_scanner/pressure.rs
@@ -11,15 +11,15 @@ use crate::stressor_process::{bundled_command, external_command, is_bundled, res
 use clap::ArgMatches;
 use nvoc_core::{
     ClockDomain, GpuTarget, KilohertzDelta, NvapiLockedVoltageTarget, PState, QueryGpuStatus,
-    QueryVfpPointVoltage, ResetVfpDeltas, SetVfpPointDelta, SetVfpVoltageLock, VfpResetDomain,
-    set_nvapi_pstate_clock_offsets,
+    QueryVfpPointVoltage, ResetPublicVftableOffset, SetGpcVoltLock, SetPublicVftablePointOffset,
+    VfpResetDomain, set_nvapi_pstate_clock_offsets,
 };
-use std::process::{Child, Command, Stdio};
-use std::thread::JoinHandle;
 #[cfg(windows)]
 use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
 #[cfg(windows)]
 use std::sync::OnceLock;
+use std::thread::JoinHandle;
 use std::thread::sleep;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -58,7 +58,7 @@ fn set_vfp_range_warn(gpu: &GpuTarget<'_>, range: std::ops::RangeInclusive<usize
     for offset in range {
         match run_output(
             gpu,
-            SetVfpPointDelta {
+            SetPublicVftablePointOffset {
                 point: offset,
                 delta: KilohertzDelta(delta_khz),
             },
@@ -525,13 +525,13 @@ pub(super) fn run_pressure_test(
                     || {
                         run_output(
                             gpu,
-                            ResetVfpDeltas {
+                            ResetPublicVftableOffset {
                                 domain: VfpResetDomain::Core,
                             },
                         )
                         .map(|_| ())
                     },
-                    "ResetVfpDeltas",
+                    "ResetPublicVftableOffset",
                     5,
                     5,
                 );
@@ -666,7 +666,7 @@ pub(super) fn run_pressure_test(
                                     // ensure voltage lock is applied as before
                                     run_output(
                                         gpu,
-                                        SetVfpVoltageLock {
+                                        SetGpcVoltLock {
                                             voltage_target: NvapiLockedVoltageTarget::Voltage(v),
                                             feedback: false,
                                         },
@@ -764,13 +764,13 @@ pub(super) fn run_pressure_test(
                             || {
                                 run_output(
                                     gpu,
-                                    ResetVfpDeltas {
+                                    ResetPublicVftableOffset {
                                         domain: VfpResetDomain::All,
                                     },
                                 )
                                 .map(|_| ())
                             },
-                            "ResetVfpDeltas (timeout recovery)",
+                            "ResetPublicVftableOffset (timeout recovery)",
                             5,
                             5,
                         );

--- a/auto-optimizer/src/oc_scanner/pressure.rs
+++ b/auto-optimizer/src/oc_scanner/pressure.rs
@@ -29,7 +29,6 @@ pub(super) struct PressureTestConfig<'a> {
     pub(super) minimum_delta_core_freq_step: i32,
     pub(super) fluctuation: FluctuationStrategy,
     pub(super) test_exe: &'a str,
-    pub(super) minload_exe: &'a str,
     pub(super) test_code: String,
     pub(super) timeout_loops: u64,
     pub(super) is_legacy_global_offset: bool,
@@ -39,8 +38,6 @@ pub(super) struct PressureTestConfig<'a> {
     pub(super) cuda_device: Option<u32>,
     /// Extra arguments appended verbatim to the stressor command.
     pub(super) stressor_extra_args: &'a [String],
-    /// 是否需要在掉电时以 MinLoadPulse 唤醒 GPU（仅 30/50 系笔记本端默认开启）。
-    pub(super) wakeup_load_needed: bool,
     pub(super) stressor_profile: &'a str,
     pub(super) stressor_config: Option<&'a str>,
     #[cfg(debug_assertions)]
@@ -435,6 +432,7 @@ pub(super) fn run_pressure_test(
                 let mut fluctuation_h_l_flag = false;
                 let mut thrm_or_pwr_limit_number = 0;
                 let _ = retry_operation_with_backoff(
+                    std::slice::from_ref(gpu),
                     || {
                         run_output(
                             gpu,
@@ -447,9 +445,6 @@ pub(super) fn run_pressure_test(
                     "ResetVfpDeltas",
                     5,
                     5,
-                    cfg.minload_exe,
-                    cfg.cuda_device,
-                    cfg.wakeup_load_needed,
                 );
                 test_initialization(gpu, cfg);
 
@@ -676,6 +671,7 @@ pub(super) fn run_pressure_test(
                         );
                         force_kill_process(&mut process, "in-test timeout");
                         let _ = retry_operation_with_backoff(
+                            std::slice::from_ref(gpu),
                             || {
                                 run_output(
                                     gpu,
@@ -688,9 +684,6 @@ pub(super) fn run_pressure_test(
                             "ResetVfpDeltas (timeout recovery)",
                             5,
                             5,
-                            cfg.minload_exe,
-                            cfg.cuda_device,
-                            cfg.wakeup_load_needed,
                         );
                         break;
                     }
@@ -823,13 +816,11 @@ pub(super) fn run_pressure_test(
                         exit_code
                     );
                     let _ = retry_operation_with_backoff(
+                        std::slice::from_ref(gpu),
                         || apply_autoscan_profile(gpu, matches, 80),
                         "apply_autoscan_profile",
                         5,
                         5,
-                        cfg.minload_exe,
-                        cfg.cuda_device,
-                        cfg.wakeup_load_needed,
                     );
                 }
 

--- a/auto-optimizer/src/oc_scanner/pressure.rs
+++ b/auto-optimizer/src/oc_scanner/pressure.rs
@@ -16,6 +16,10 @@ use nvoc_core::{
 };
 use std::process::{Child, Command, Stdio};
 use std::thread::JoinHandle;
+#[cfg(windows)]
+use std::path::PathBuf;
+#[cfg(windows)]
+use std::sync::OnceLock;
 use std::thread::sleep;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -229,6 +233,81 @@ fn force_kill_process(process: &mut Child, reason: &str) {
     }
 }
 
+// ─────────────── Windows PowerShell 子进程辅助 ───────────────
+//
+// 两个 PowerShell 脚本（事件查询 / PnP 恢复）通过 include_str! 嵌入二进制，
+// 首次调用时落盘到 %TEMP% 再以绝对路径 -File 调用：
+//  1. 消除旧 "./test/*.ps1" 相对路径对工作目录的依赖（从 GUI / 其他 cwd 拉起
+//     时 PowerShell 报"路径不存在"，且该错误文本是 GBK 编码，被
+//     from_utf8_lossy 解成乱码）；
+//  2. 发布的二进制不再需要携带 test/ 目录。
+// 文件名带 PID 后缀避免并发进程互踩；残留文件交给系统 TEMP 清理。
+
+#[cfg(windows)]
+static PNP_RECOVER_SCRIPT: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// 把嵌入的 .ps1 写到 %TEMP%（每进程一次）。失败返回 None，由调用方降级。
+#[cfg(windows)]
+fn materialize_embedded_script(
+    cache: &'static OnceLock<Option<PathBuf>>,
+    script_stem: &str,
+    body: &'static str,
+) -> Option<PathBuf> {
+    cache
+        .get_or_init(|| {
+            let dir = std::env::temp_dir().join("nvoc-auto-optimizer-scripts");
+            std::fs::create_dir_all(&dir).ok()?;
+            let path = dir.join(format!("{script_stem}-{}.ps1", std::process::id()));
+            std::fs::write(&path, body).ok()?;
+            Some(path)
+        })
+        .clone()
+}
+
+/// 解码 PowerShell 子进程的输出字节。
+///
+/// PowerShell 5.1 重定向输出默认用 OEM 代码页（中文系统 = GBK/CP936），
+/// 直接 `from_utf8_lossy` 会把中文错误文本（如"-File 参数无法匹配实际参数，
+/// 因为路径不存在"）变成 U+FFFD 乱码。这里先试严格 UTF-8（脚本内已把
+/// [Console]::OutputEncoding 设为 UTF8，正常路径输出都是 UTF-8），失败则
+/// 回退用 Win32 `MultiByteToWideChar(CP_OEMCP)` 按 OEM 码页解码 —— 覆盖
+/// 脚本执行前 PowerShell 自身的报错（参数绑定/启动失败等仍是 GBK）。
+#[cfg(windows)]
+fn decode_console_output(bytes: &[u8]) -> String {
+    if let Ok(text) = std::str::from_utf8(bytes) {
+        return text.to_string();
+    }
+
+    type Dword = u32;
+    const CP_OEMCP: Dword = 1;
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn MultiByteToWideChar(
+            code_page: Dword,
+            dw_flags: u32,
+            lp_multi_byte_str: *const u8,
+            cb_multi_byte: i32,
+            lp_wide_char_str: *mut u16,
+            cch_wide_char: i32,
+        ) -> i32;
+    }
+
+    // SAFETY: 输入指针/长度指向有效缓冲；先探测所需长度再写入同长缓冲。
+    unsafe {
+        let len = bytes.len() as i32;
+        let needed = MultiByteToWideChar(CP_OEMCP, 0, bytes.as_ptr(), len, std::ptr::null_mut(), 0);
+        if needed > 0 {
+            let mut buf = vec![0u16; needed as usize];
+            let written =
+                MultiByteToWideChar(CP_OEMCP, 0, bytes.as_ptr(), len, buf.as_mut_ptr(), needed);
+            if written > 0 {
+                return String::from_utf16_lossy(&buf[..written as usize]);
+            }
+        }
+    }
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
 #[cfg(not(windows))]
 fn count_linux_gpu_xid_events_by_time(
     start: SystemTime,
@@ -295,7 +374,17 @@ fn count_linux_gpu_xid_events_by_time(
 fn pnp_recover_gpu(gpu: &GpuTarget<'_>) -> bool {
     let pci_bus = gpu.id.pci_bus();
 
-    let script_path = "./test/windows_oc_pnp_recover.ps1";
+    let script_path = match materialize_embedded_script(
+        &PNP_RECOVER_SCRIPT,
+        "windows_oc_pnp_recover",
+        include_str!("../../test/windows_oc_pnp_recover.ps1"),
+    ) {
+        Some(path) => path,
+        None => {
+            eprintln!("pnp_recover: failed to stage embedded recovery script to TEMP");
+            return false;
+        }
+    };
     eprintln!(
         "pnp_recover: Triggering PnP disable/enable cycle for GPU at PCI bus {} (GpuId: {})...",
         pci_bus, gpu.id.0
@@ -308,7 +397,7 @@ fn pnp_recover_gpu(gpu: &GpuTarget<'_>) -> bool {
             "-ExecutionPolicy",
             "Bypass",
             "-File",
-            script_path,
+            script_path.to_str().unwrap_or_default(),
             "-TargetPciBus",
             &pci_bus.to_string(),
         ])
@@ -318,14 +407,14 @@ fn pnp_recover_gpu(gpu: &GpuTarget<'_>) -> bool {
         Ok(out) => {
             if out.status.success() {
                 eprintln!("pnp_recover: PnP cycle completed successfully.");
-                eprintln!("stdout: {}", String::from_utf8_lossy(&out.stdout).trim());
+                eprintln!("stdout: {}", decode_console_output(&out.stdout).trim());
                 // Wait for GPU to re-appear in NVML
                 sleep(Duration::from_secs(10));
                 true
             } else {
                 eprintln!(
                     "pnp_recover: PnP cycle failed: {}",
-                    String::from_utf8_lossy(&out.stderr)
+                    decode_console_output(&out.stderr)
                 );
                 false
             }
@@ -842,6 +931,43 @@ pub(super) fn run_pressure_test(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(windows)]
+    fn console_output_decodes_gbk_without_replacement_chars() {
+        // "路径不存在" 的 GBK (CP936) 编码 —— PowerShell 在中文系统上以 OEM
+        // 码页输出错误文本，旧实现 from_utf8_lossy 会把它变成 U+FFFD 乱码。
+        let gbk_bytes = [0xC2, 0xB7, 0xBE, 0xB6, 0xB2, 0xBB, 0xB4, 0xE6, 0xD4, 0xDA];
+        let decoded = decode_console_output(&gbk_bytes);
+        assert!(!decoded.is_empty());
+        assert!(
+            !decoded.contains('\u{FFFD}'),
+            "OEM 回退解码不应产生 U+FFFD，实际: {decoded:?}"
+        );
+        // UTF-8 输入必须原样通过
+        assert_eq!(decode_console_output("ok".as_bytes()), "ok");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn embedded_script_materializes_to_absolute_temp_path() {
+        let path = materialize_embedded_script(
+            &PNP_RECOVER_SCRIPT,
+            "windows_oc_pnp_recover",
+            include_str!("../../test/windows_oc_pnp_recover.ps1"),
+        )
+        .expect("staging embedded script must succeed");
+        assert!(path.is_absolute(), "staged path must be absolute: {path:?}");
+        assert!(path.exists(), "staged script must exist: {path:?}");
+        // OnceLock 缓存：第二次调用返回同一路径
+        let again = materialize_embedded_script(
+            &PNP_RECOVER_SCRIPT,
+            "windows_oc_pnp_recover",
+            include_str!("../../test/windows_oc_pnp_recover.ps1"),
+        )
+        .expect("second staging must succeed");
+        assert_eq!(path, again);
+    }
 
     #[test]
     fn vfp_curve_range_saturates_low_points() {

--- a/auto-optimizer/src/oc_scanner/runtime.rs
+++ b/auto-optimizer/src/oc_scanner/runtime.rs
@@ -1,8 +1,4 @@
-use crate::stressor_process::{bundled_command, external_command, is_bundled};
 use nvoc_core::{Error, GpuOperation, GpuTarget, run as nvoc_run};
-#[cfg(windows)]
-use std::process::Command;
-use std::process::{Child, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -10,69 +6,32 @@ pub(super) fn run_output<O: GpuOperation>(gpu: &GpuTarget<'_>, op: O) -> Result<
     nvoc_run(gpu, op).map(|report| report.output)
 }
 
-/// Spawns a minimal Vulkan load process to wake a power-gated GPU on Optimus
-/// laptops, then kills the process when dropped.
-pub(super) struct MinLoadPulse(Option<Child>);
-
-impl MinLoadPulse {
-    pub(super) fn wake(test_exe: &str, cuda_device: Option<u32>) -> Self {
-        let mut cmd = if is_bundled(test_exe) {
-            match bundled_command(Some("minload"), None, 15.0, cuda_device, &[]) {
-                Ok(command) => command,
-                Err(e) => {
-                    eprintln!("MinLoadPulse: failed to prepare bundled worker: {e}");
-                    return Self(None);
-                }
-            }
-        } else {
-            external_command(test_exe, Some("minload"), None, 15.0, cuda_device, &[])
-        };
-        cmd.stdout(Stdio::null());
-        cmd.stderr(Stdio::null());
-        match cmd.spawn() {
-            Ok(child) => {
-                eprintln!("MinLoadPulse: spawned PID {} to wake GPU.", child.id(),);
-                sleep(Duration::from_secs(3));
-                Self(Some(child))
-            }
-            Err(e) => {
-                eprintln!("MinLoadPulse: failed to spawn: {}", e);
-                Self(None)
-            }
-        }
-    }
-}
-
-impl Drop for MinLoadPulse {
-    fn drop(&mut self) {
-        if let Some(mut child) = self.0.take() {
-            let pid = child.id();
-            #[cfg(windows)]
-            {
-                let _ = Command::new("taskkill")
-                    .args(["/F", "/T", "/PID", &pid.to_string()])
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status();
-            }
-            let _ = child.kill();
-            let _ = child.wait();
-            eprintln!("MinLoadPulse: killed PID {}.", pid);
-        }
+/// 原生唤醒：对 GC6/GCOFF 掉电的 dGPU 调用 force_gc6_exit（NVAPI 0x55590CB2），
+/// 一次性拉回 D0。取代旧的 MinLoadPulse 方案（spawn Vulkan minload 子进程 +
+/// 固定 3s sleep + taskkill）—— 无子进程、毫秒级完成、无残留进程风险。
+///
+/// 唤醒非持久（空闲约 5-20s 后会重新 GCOFF），因此只对紧随其后的操作序列
+/// 有效；NVAPI 写操作另由 core::operation::run 的预唤醒钩子按
+/// GpuType::needs_gc6_wake() 自动兜底，读操作序列则需在本侧显式调用。
+/// 桌面端（无 GC6）驱动返回 NoImplementation(-104) 等，按 best-effort 忽略。
+pub(super) fn native_wake(gpu: &GpuTarget<'_>) {
+    match gpu.force_wake() {
+        Ok(()) => eprintln!("NativeWake: force_gc6_exit ok."),
+        Err(e) => eprintln!("NativeWake: force_gc6_exit failed (continuing): {:?}", e),
     }
 }
 
 // Retry a generic operation with exponential backoff on any NVAPI error.
-// When GPUnotpowered is detected, automatically spawns a minimal Vulkan load
-// via minload_exe to wake the GPU before retrying.
+// When GPUnotpowered is detected, natively wake every GPU in `gpus` via
+// force_gc6_exit before retrying (see native_wake). The error itself proves
+// the GPU is power-gated, so no generation gate is needed here — desktop
+// GPUs never return GPUnotpowered.
 pub(super) fn retry_operation_with_backoff<T, F>(
+    gpus: &[GpuTarget<'_>],
     mut op: F,
     label: &str,
     attempts: usize,
     base_wait_secs: u64,
-    minload_exe: &str,
-    cuda_device: Option<u32>,
-    wakeup_load_needed: bool,
 ) -> Result<T, Error>
 where
     F: FnMut() -> Result<T, Error>,
@@ -99,12 +58,14 @@ where
                 let s_lower = format!("{:?}", &e).to_lowercase();
                 last_err = Some(e);
 
-                if s_lower.contains("gpunotpowered") && wakeup_load_needed {
+                if s_lower.contains("gpunotpowered") {
                     eprintln!(
-                        "{}: GPUnotpowered detected, launching min-load pulse...",
+                        "{}: GPUnotpowered detected, natively waking via force_gc6_exit...",
                         label
                     );
-                    let _pulse = MinLoadPulse::wake(minload_exe, cuda_device);
+                    for gpu in gpus {
+                        native_wake(gpu);
+                    }
                     match op() {
                         Ok(v) => {
                             eprintln!("{} succeeded on GPU wake retry.", label);

--- a/auto-optimizer/src/optimize.rs
+++ b/auto-optimizer/src/optimize.rs
@@ -4,8 +4,8 @@ use crate::oc_scanner::{autoscan_gpuboostv3, autoscan_legacy};
 use clap::ArgMatches;
 use nvoc_cli_common::color::stylize_warning;
 use nvoc_core::{
-    Error, GpuTarget, QueryGpuInfo, ResetPstateClockOffsets, ResetVfpDeltas, ResetVfpLock,
-    VfpResetDomain, run,
+    Error, GpuTarget, QueryGpuInfo, ResetPstateGlobalFreqOffset, ResetPublicVftableGpcLock,
+    ResetPublicVftableOffset, VfpResetDomain, run,
 };
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, IsTerminal, Write};
@@ -157,7 +157,7 @@ fn reset_pstate_offsets(gpu: &GpuTarget<'_>) -> Result<(), Error> {
                 .map(move |(&domain, _)| (pstate, domain))
         })
         .collect();
-    run(gpu, ResetPstateClockOffsets { offsets })?;
+    run(gpu, ResetPstateGlobalFreqOffset { offsets })?;
     Ok(())
 }
 
@@ -213,11 +213,11 @@ pub fn run_optimize(targets: &[GpuTarget<'_>], matches: &ArgMatches) -> Result<(
     reset_pstate_offsets(gpu)?;
     run(
         gpu,
-        ResetVfpDeltas {
+        ResetPublicVftableOffset {
             domain: VfpResetDomain::All,
         },
     )?;
-    run(gpu, ResetVfpLock)?;
+    run(gpu, ResetPublicVftableGpcLock)?;
 
     if !init.exists() {
         let mut args = command_prefix(gpu);

--- a/auto-optimizer/src/optimize.rs
+++ b/auto-optimizer/src/optimize.rs
@@ -254,13 +254,7 @@ pub fn run_optimize(targets: &[GpuTarget<'_>], matches: &ArgMatches) -> Result<(
             .ok()
             .flatten()
             .ok_or_else(|| error("external stressor backend requires --test-exe"))?;
-        let minload_exe = matches
-            .try_get_one::<String>("minload_exe")
-            .ok()
-            .flatten()
-            .ok_or_else(|| error("external stressor backend requires --minload-exe"))?;
         scan_args.extend(["--test-exe".into(), test_exe.clone()]);
-        scan_args.extend(["--minload-exe".into(), minload_exe.clone()]);
         if matches
             .try_get_one::<String>("stressor_backend")
             .ok()

--- a/auto-optimizer/src/platform.rs
+++ b/auto-optimizer/src/platform.rs
@@ -29,21 +29,6 @@ pub const fn default_test_exe_path() -> &'static str {
     }
 }
 
-pub const fn default_minload_exe_path() -> &'static str {
-    #[cfg(feature = "stressor-bundled")]
-    {
-        crate::stressor_process::BUNDLED_SENTINEL
-    }
-    #[cfg(all(not(feature = "stressor-bundled"), feature = "stressor-external"))]
-    {
-        "cli-stressor-cuda-rs"
-    }
-    #[cfg(not(any(feature = "stressor-bundled", feature = "stressor-external")))]
-    {
-        ""
-    }
-}
-
 #[cfg(all(not(windows), not(target_os = "linux")))]
 pub fn panic_windows_only(feature: &str) -> ! {
     panic!("{feature} is only supported on Windows in this repository")
@@ -126,7 +111,7 @@ pub fn is_elevated() -> bool {
 
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
-    use super::{default_minload_exe_path, default_test_exe_path};
+    use super::default_test_exe_path;
 
     #[test]
     #[cfg(target_os = "linux")]
@@ -137,15 +122,10 @@ mod tests {
                 default_test_exe_path(),
                 crate::stressor_process::BUNDLED_SENTINEL
             );
-            assert_eq!(
-                default_minload_exe_path(),
-                crate::stressor_process::BUNDLED_SENTINEL
-            );
         }
         #[cfg(all(not(feature = "stressor-bundled"), feature = "stressor-external"))]
         {
             assert_eq!(default_test_exe_path(), "cli-stressor-cuda-rs");
-            assert_eq!(default_minload_exe_path(), "cli-stressor-cuda-rs");
         }
     }
 }

--- a/auto-optimizer/src/scan_support.rs
+++ b/auto-optimizer/src/scan_support.rs
@@ -2,8 +2,8 @@ use clap::ArgMatches;
 use nvoc_cli_common::color::stylize;
 use nvoc_core::{
     CheckVoltageFrequency, ClockDomain, ConvertEnum, Error, GpuOperation, GpuTarget, Kilohertz,
-    Microvolts, ProbeVoltageLimits, QueryTdpTempLimits, QueryVfpPointVoltage, SetVfpFrequencyLock,
-    SetVfpVoltageLock, TdpTempLimits, VfpLockRequest, run,
+    Microvolts, ProbeVoltageLimits, QueryTdpTempLimits, QueryVfpPointVoltage, SetGpcVoltLock,
+    SetVfpFrequencyLock, TdpTempLimits, VfpLockRequest, run,
 };
 use std::str::FromStr;
 use time::{OffsetDateTime, format_description::parse_borrowed};
@@ -56,14 +56,14 @@ fn apply_vfp_lock(
     match request {
         VfpLockRequest::VoltagePoint(point) => run_output(
             gpu,
-            SetVfpVoltageLock {
+            SetGpcVoltLock {
                 voltage_target: nvoc_core::NvapiLockedVoltageTarget::Point(point),
                 feedback,
             },
         ),
         VfpLockRequest::Voltage(voltage) => run_output(
             gpu,
-            SetVfpVoltageLock {
+            SetGpcVoltLock {
                 voltage_target: nvoc_core::NvapiLockedVoltageTarget::Voltage(voltage),
                 feedback,
             },

--- a/auto-optimizer/src/stressor_process.rs
+++ b/auto-optimizer/src/stressor_process.rs
@@ -1,4 +1,4 @@
-use nvoc_core::{Error, GpuTarget, QueryGpuInfo, run};
+use nvoc_core::{Error, GpuTarget, GpuType, QueryGpuInfo, fetch_gpu_type, run};
 use std::process::Command;
 
 #[cfg(feature = "stressor-bundled")]
@@ -113,29 +113,24 @@ pub fn resolve_profile(gpu: &GpuTarget<'_>, requested: &str) -> Result<String, E
 
     let info = run(gpu, QueryGpuInfo)?.output;
     let vram_kib = u64::from(info.physical_frame_buffer.0);
-    profile_for_gpu(&info.name, vram_kib)
+    // Generation verdict from core gpu_type.rs (name + codename) — the old
+    // name-tokenizing heuristic ("GeForce" + "RTX 40xx/50xx") duplicated
+    // gpu_type knowledge and could not see past the marketing name.
+    let gpu_type = fetch_gpu_type(&info).unwrap_or(GpuType::Unknown);
+    profile_for_gpu(&gpu_type, vram_kib)
 }
 
-fn profile_for_gpu(gpu_name: &str, vram_kib: u64) -> Result<String, Error> {
-    if is_geforce_rtx_40_or_50_series(gpu_name) {
+fn profile_for_gpu(gpu_type: &GpuType, vram_kib: u64) -> Result<String, Error> {
+    if matches!(
+        gpu_type,
+        GpuType::Mobile40Series
+            | GpuType::Desktop40Series
+            | GpuType::Mobile50Series
+            | GpuType::Desktop50Series
+    ) {
         return Ok("40-50".to_string());
     }
     profile_for_vram_kib(vram_kib)
-}
-
-fn is_geforce_rtx_40_or_50_series(gpu_name: &str) -> bool {
-    let words: Vec<_> = gpu_name.split_whitespace().collect();
-    words
-        .iter()
-        .any(|word| word.eq_ignore_ascii_case("GeForce"))
-        && words
-            .windows(2)
-            .any(|pair| pair[0].eq_ignore_ascii_case("RTX") && is_40_or_50_model(pair[1]))
-}
-
-fn is_40_or_50_model(model: &str) -> bool {
-    let digits: String = model.chars().take_while(char::is_ascii_digit).collect();
-    digits.len() == 4 && (digits.starts_with("40") || digits.starts_with("50"))
 }
 
 fn profile_for_vram_kib(vram_kib: u64) -> Result<String, Error> {
@@ -235,25 +230,28 @@ mod tests {
     }
 
     #[test]
-    fn automatic_profile_selects_geforce_40_50_series_by_model() {
+    fn automatic_profile_selects_40_50_series_by_generation() {
+        // The name→GpuType mapping itself is covered by core's
+        // gpu_type_detection test; this checks the profile choice per type.
         assert_eq!(
-            profile_for_gpu("NVIDIA GeForce RTX 4090", 24 * 1024 * 1024).unwrap(),
+            profile_for_gpu(&GpuType::Desktop40Series, 24 * 1024 * 1024).unwrap(),
             "40-50"
         );
         assert_eq!(
-            profile_for_gpu("NVIDIA GeForce RTX 5070 Ti", 12 * 1024 * 1024).unwrap(),
+            profile_for_gpu(&GpuType::Desktop50Series, 12 * 1024 * 1024).unwrap(),
             "40-50"
         );
         assert_eq!(
-            profile_for_gpu("NVIDIA GeForce RTX 4090 Laptop GPU", 8 * 1024 * 1024).unwrap(),
+            profile_for_gpu(&GpuType::Mobile40Series, 8 * 1024 * 1024).unwrap(),
             "40-50"
         );
         assert_eq!(
-            profile_for_gpu("NVIDIA GeForce RTX 3090", 24 * 1024 * 1024).unwrap(),
+            profile_for_gpu(&GpuType::Desktop30Series, 24 * 1024 * 1024).unwrap(),
             "standard"
         );
+        // Workstation Ada is Lovelace but not a GeForce 40/50 card → VRAM path.
         assert_eq!(
-            profile_for_gpu("NVIDIA RTX 4000 Ada Generation", 20 * 1024 * 1024).unwrap(),
+            profile_for_gpu(&GpuType::WorkstationLovelace, 20 * 1024 * 1024).unwrap(),
             "standard"
         );
     }

--- a/auto-optimizer/src/stressor_process.rs
+++ b/auto-optimizer/src/stressor_process.rs
@@ -52,6 +52,14 @@ fn add_stressor_args(
     if let Some(device) = cuda_device {
         command.args(["--gpu-index", &device.to_string()]);
     }
+    // Device-side buffer generation by default: it removes the host RNG +
+    // H2D gap between bursts, giving more wall-clock to actual stress. The
+    // stressor itself falls back to host generation if the NVRTC fill
+    // kernels fail to build, and an explicit `--gpu-generate` in extra_args
+    // (caller-controlled) suppresses the duplicate flag.
+    if !extra_args.iter().any(|a| a == "--gpu-generate") {
+        command.arg("--gpu-generate");
+    }
     command.args(extra_args);
 }
 
@@ -192,9 +200,27 @@ mod tests {
                 "25",
                 "--gpu-index",
                 "2",
+                "--gpu-generate",
                 "--disable-fp8"
             ]
         );
+    }
+
+    #[test]
+    fn explicit_gpu_generate_flag_is_not_duplicated() {
+        let command = external_command(
+            "cli-stressor-cuda-rs",
+            None,
+            None,
+            10.0,
+            None,
+            &["--gpu-generate".into()],
+        );
+        let count = command
+            .get_args()
+            .filter(|a| *a == "--gpu-generate")
+            .count();
+        assert_eq!(count, 1);
     }
 
     #[test]

--- a/auto-optimizer/test/windows_oc_pnp_recover.ps1
+++ b/auto-optimizer/test/windows_oc_pnp_recover.ps1
@@ -2,6 +2,11 @@ param(
     [int]$TargetPciBus = -1
 )
 
+# 强制重定向下输出为 UTF-8（默认是 OEM 码页 = 中文系统 GBK，设备名含中文
+# 会被 Rust 侧的 UTF-8 解码打碎）。脚本执行前 PowerShell 自身的报错仍可能是
+# GBK，由调用侧 decode_console_output 的 OEM 回退兜底。
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
 function Toggle-DeviceStateByHardwareID {
     param (
         [string]$HardwareID

--- a/cli-stressor-cuda-rs/README.md
+++ b/cli-stressor-cuda-rs/README.md
@@ -121,7 +121,7 @@ cargo run -p cli-stressor-cuda-rs --features cuda -- \
   --kernel-types gemm,intalu
 ```
 
-若使用内置 `minload` profile 或启用 Vulkan 图形压力，请同时启用 `vulkan` feature：
+若启用 Vulkan 图形压力，请同时启用 `vulkan` feature：
 
 ```bash
 cargo build --release -p cli-stressor-cuda-rs --features cuda,vulkan
@@ -318,7 +318,7 @@ cargo run -p cli-stressor-cuda-rs --features cuda -- \
   --kernel-types gemm,intalu
 ```
 
-When using the built-in `minload` profile or Vulkan graphics stress, build with both features:
+When enabling Vulkan graphics stress, build with both features:
 
 ```bash
 cargo build --release -p cli-stressor-cuda-rs --features cuda,vulkan

--- a/cli-stressor-cuda-rs/profiles/minload.toml
+++ b/cli-stressor-cuda-rs/profiles/minload.toml
@@ -1,8 +1,0 @@
-vulkan_only = true
-enable_vulkan_stress = true
-vulkan_image_width = 64
-vulkan_image_height = 64
-vulkan_image_depth = 64
-vulkan_image_count = 1
-vulkan_image_msaa = 1
-duration = 15

--- a/cli-stressor-cuda-rs/src/cuda_backend.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend.rs
@@ -9,6 +9,7 @@
 //! - [`gemm`]: cuBLAS GEMM stress path (FP precisions).
 //! - [`mem_ops`]: memcpy / memset / sgeam (transpose & elementwise) / reduction.
 //! - [`atomic`]: atomic-operation stress kernel (custom NVRTC).
+//! - [`gpu_fill`]: opt-in device-side stress-buffer generation (NVRTC).
 //! - [`kernels`]: shared NVRTC module-loading helpers.
 //! - [`device`]: device enumeration and selection (UUID / PCI / sorted index).
 
@@ -16,6 +17,7 @@ mod atomic;
 mod backend;
 mod device;
 mod gemm;
+mod gpu_fill;
 mod int_alu;
 mod kernels;
 mod lanes;

--- a/cli-stressor-cuda-rs/src/cuda_backend/atomic.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/atomic.rs
@@ -73,15 +73,22 @@ impl CudaBackend {
                 );
             }
         } else {
-            // One parallel non-crypto fill shared by all lanes; nothing in the
-            // atomic path depends on per-lane input differences.
-            let mut host = vec![0f32; n as usize];
-            fill_random_f32(&mut host, seed);
+            // Page-locked (write-combined) staging so H2D runs at full DMA
+            // bandwidth instead of the driver's pageable staging path; the
+            // fill is write-only, so WC memory's slow reads never trigger.
+            // One fill shared by all lanes; nothing in the atomic path
+            // depends on per-lane input differences.
+            let mut pinned = unsafe { self._ctx.alloc_pinned::<f32>(n as usize) }
+                .map_err(|err| BackendError::Other(err.to_string()))?;
+            fill_random_f32(
+                pinned.as_mut_slice().map_err(|err| BackendError::Other(err.to_string()))?,
+                seed,
+            );
             for lane in 0..lane_count {
                 let stream = self.stream_for_lane(lane);
                 xs.push(
                     stream
-                        .clone_htod(&host)
+                        .clone_htod(&pinned)
                         .map_err(|err| BackendError::Other(err.to_string()))?,
                 );
                 outs.push(

--- a/cli-stressor-cuda-rs/src/cuda_backend/atomic.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/atomic.rs
@@ -3,13 +3,10 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use rand::rngs::StdRng;
-use rand::{RngExt, SeedableRng};
-
 use cudarc::driver::{CudaContext, CudaFunction, CudaModule, LaunchConfig, PushKernelArg};
 use cudarc::nvrtc::compile_ptx;
 
-use cli_stressor_cuda_rs::{BackendError, StreamMode};
+use cli_stressor_cuda_rs::{BackendError, StreamMode, fill_random_f32};
 
 use super::backend::CudaBackend;
 use super::kernels::load_kernel;
@@ -46,22 +43,53 @@ impl CudaBackend {
             .ok_or_else(|| BackendError::Other("atomic kernel unavailable".to_string()))?;
         let n = (size * size) as u32;
         let lane_count = Self::lane_count(stream_mode);
-        let mut rng = StdRng::seed_from_u64(seed);
         let mut xs = Vec::with_capacity(lane_count);
         let mut outs = Vec::with_capacity(lane_count);
-        for lane in 0..lane_count {
-            let stream = self.stream_for_lane(lane);
-            let host: Vec<f32> = (0..n).map(|_| rng.random::<f32>()).collect();
-            xs.push(
-                stream
-                    .clone_htod(&host)
-                    .map_err(|err| BackendError::Other(err.to_string()))?,
-            );
-            outs.push(
-                stream
-                    .alloc_zeros::<u32>(1)
-                    .map_err(|err| BackendError::Other(err.to_string()))?,
-            );
+        if self.gpu_generate_enabled() {
+            let kernels = self
+                .gpu_fill
+                .as_ref()
+                .ok_or_else(|| BackendError::Other("gpu fill kernels unavailable".into()))?;
+            let total = n as u64;
+            for lane in 0..lane_count {
+                let stream = self.stream_for_lane(lane);
+                let x = stream
+                    .alloc_zeros::<f32>(n as usize)
+                    .map_err(|err| BackendError::Other(err.to_string()))?;
+                unsafe {
+                    stream
+                        .launch_builder(&kernels.f32_fn)
+                        .arg(&x)
+                        .arg(&total)
+                        .arg(&(seed.wrapping_add(lane as u64)))
+                        .launch(LaunchConfig::for_num_elems(n.max(1)))
+                        .map_err(|err| BackendError::Other(err.to_string()))?;
+                }
+                xs.push(x);
+                outs.push(
+                    stream
+                        .alloc_zeros::<u32>(1)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+            }
+        } else {
+            // One parallel non-crypto fill shared by all lanes; nothing in the
+            // atomic path depends on per-lane input differences.
+            let mut host = vec![0f32; n as usize];
+            fill_random_f32(&mut host, seed);
+            for lane in 0..lane_count {
+                let stream = self.stream_for_lane(lane);
+                xs.push(
+                    stream
+                        .clone_htod(&host)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+                outs.push(
+                    stream
+                        .alloc_zeros::<u32>(1)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+            }
         }
         let cfg = LaunchConfig::for_num_elems(n.max(1));
 

--- a/cli-stressor-cuda-rs/src/cuda_backend/atomic.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/atomic.rs
@@ -81,7 +81,9 @@ impl CudaBackend {
             let mut pinned = unsafe { self._ctx.alloc_pinned::<f32>(n as usize) }
                 .map_err(|err| BackendError::Other(err.to_string()))?;
             fill_random_f32(
-                pinned.as_mut_slice().map_err(|err| BackendError::Other(err.to_string()))?,
+                pinned
+                    .as_mut_slice()
+                    .map_err(|err| BackendError::Other(err.to_string()))?,
                 seed,
             );
             for lane in 0..lane_count {

--- a/cli-stressor-cuda-rs/src/cuda_backend/backend.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/backend.rs
@@ -39,6 +39,9 @@ pub struct CudaBackend {
     pub(super) atomic_fn: Option<CudaFunction>,
     pub(super) _intalu_module: Option<Arc<CudaModule>>,
     pub(super) intalu_fn: Option<CudaFunction>,
+    /// Opt-in device-side stress-buffer generation (`--gpu-generate`).
+    pub(super) gpu_generate: bool,
+    pub(super) gpu_fill: Option<super::gpu_fill::GpuFillKernels>,
     pub(super) info: DeviceInfo,
 }
 
@@ -140,6 +143,8 @@ impl CudaBackend {
             atomic_fn,
             _intalu_module: intalu_module,
             intalu_fn,
+            gpu_generate: false,
+            gpu_fill: None,
             info,
         })
     }

--- a/cli-stressor-cuda-rs/src/cuda_backend/gpu_fill.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/gpu_fill.rs
@@ -1,0 +1,102 @@
+//! Device-side stress-buffer generation (opt-in via `--gpu-generate`).
+//!
+//! Instead of generating random data on the host and copying it H2D, a tiny
+//! NVRTC kernel fills the device buffer directly with the same SplitMix64
+//! stream the host helpers produce (`lib.rs::splitmix64`). This removes the
+//! host RNG + PCIe upload from the critical path between bursts, giving more
+//! wall-clock to actual stress work. Content differs from the host path
+//! (kernel-local index arithmetic), which is fine: no validation path reads
+//! stress buffers.
+
+use std::sync::Arc;
+
+use cudarc::driver::{CudaContext, CudaFunction, CudaModule};
+
+use cudarc::nvrtc::compile_ptx;
+
+use cli_stressor_cuda_rs::BackendError;
+
+use super::backend::CudaBackend;
+
+const GPU_FILL_SRC: &str = r#"
+extern "C" __device__ unsigned long long splitmix64(unsigned long long* state) {
+    *state += 0x9E3779B97F4A7C15ULL;
+    unsigned long long z = *state;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+extern "C" __global__ void fill_random_bytes(unsigned char* buf, unsigned long long n, unsigned long long seed) {
+    unsigned long long stride = (unsigned long long)gridDim.x * blockDim.x;
+    for (unsigned long long idx = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x; idx < n; idx += stride) {
+        unsigned long long state = seed + idx * 0x9E3779B97F4A7C15ULL;
+        buf[idx] = (unsigned char)(splitmix64(&state) >> 32);
+    }
+}
+
+extern "C" __global__ void fill_random_f32(float* buf, unsigned long long n, unsigned long long seed) {
+    unsigned long long stride = (unsigned long long)gridDim.x * blockDim.x;
+    for (unsigned long long idx = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x; idx < n; idx += stride) {
+        unsigned long long state = seed + idx * 0x9E3779B97F4A7C15ULL;
+        unsigned long long x = splitmix64(&state);
+        buf[idx] = (float)((x >> 40) & 0xFFFFFFULL) * (1.0f / 16777216.0f);
+    }
+}
+
+extern "C" __global__ void fill_random_i32(int* buf, unsigned long long n, unsigned long long seed) {
+    unsigned long long stride = (unsigned long long)gridDim.x * blockDim.x;
+    for (unsigned long long idx = (unsigned long long)blockIdx.x * blockDim.x + threadIdx.x; idx < n; idx += stride) {
+        unsigned long long state = seed + idx * 0x9E3779B97F4A7C15ULL;
+        buf[idx] = (int)(splitmix64(&state) >> 32);
+    }
+}
+"#;
+
+pub(super) struct GpuFillKernels {
+    pub(super) _module: Arc<CudaModule>,
+    pub(super) bytes_fn: CudaFunction,
+    pub(super) f32_fn: CudaFunction,
+    pub(super) i32_fn: CudaFunction,
+}
+
+pub(super) fn build_gpu_fill_kernels(ctx: &Arc<CudaContext>) -> Result<GpuFillKernels, BackendError> {
+    let ptx = compile_ptx(GPU_FILL_SRC).map_err(|err| BackendError::Other(err.to_string()))?;
+    let module = ctx
+        .load_module(ptx)
+        .map_err(|err| BackendError::Other(err.to_string()))?;
+    let bytes_fn = module
+        .load_function("fill_random_bytes")
+        .map_err(|err| BackendError::Other(err.to_string()))?;
+    let f32_fn = module
+        .load_function("fill_random_f32")
+        .map_err(|err| BackendError::Other(err.to_string()))?;
+    let i32_fn = module
+        .load_function("fill_random_i32")
+        .map_err(|err| BackendError::Other(err.to_string()))?;
+    Ok(GpuFillKernels {
+        _module: module,
+        bytes_fn,
+        f32_fn,
+        i32_fn,
+    })
+}
+
+impl CudaBackend {
+    /// Opt in to device-side stress-buffer generation. Builds the NVRTC fill
+    /// kernels eagerly so per-burst paths stay allocation-free.
+    pub fn enable_gpu_generate(&mut self) -> Result<(), BackendError> {
+        if self.gpu_fill.is_some() {
+            self.gpu_generate = true;
+            return Ok(());
+        }
+        let kernels = build_gpu_fill_kernels(&self._ctx)?;
+        self.gpu_fill = Some(kernels);
+        self.gpu_generate = true;
+        Ok(())
+    }
+
+    pub(super) fn gpu_generate_enabled(&self) -> bool {
+        self.gpu_generate
+    }
+}

--- a/cli-stressor-cuda-rs/src/cuda_backend/gpu_fill.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/gpu_fill.rs
@@ -60,7 +60,9 @@ pub(super) struct GpuFillKernels {
     pub(super) i32_fn: CudaFunction,
 }
 
-pub(super) fn build_gpu_fill_kernels(ctx: &Arc<CudaContext>) -> Result<GpuFillKernels, BackendError> {
+pub(super) fn build_gpu_fill_kernels(
+    ctx: &Arc<CudaContext>,
+) -> Result<GpuFillKernels, BackendError> {
     let ptx = compile_ptx(GPU_FILL_SRC).map_err(|err| BackendError::Other(err.to_string()))?;
     let module = ctx
         .load_module(ptx)

--- a/cli-stressor-cuda-rs/src/cuda_backend/int_alu.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/int_alu.rs
@@ -152,14 +152,20 @@ impl CudaBackend {
                 );
             }
         } else {
-            // One parallel non-crypto fill shared by all lanes.
-            let mut host = vec![0i32; n as usize];
-            fill_random_i32(&mut host, seed);
+            // Page-locked (write-combined) staging for full-bandwidth H2D;
+            // write-only fill, so WC's slow reads never trigger. One fill
+            // shared by all lanes.
+            let mut pinned = unsafe { self._ctx.alloc_pinned::<i32>(n as usize) }
+                .map_err(|err| BackendError::Other(err.to_string()))?;
+            fill_random_i32(
+                pinned.as_mut_slice().map_err(|err| BackendError::Other(err.to_string()))?,
+                seed,
+            );
             for lane in 0..lane_count {
                 let stream = self.stream_for_lane(lane);
                 xs.push(
                     stream
-                        .clone_htod(&host)
+                        .clone_htod(&pinned)
                         .map_err(|err| BackendError::Other(err.to_string()))?,
                 );
                 outs.push(

--- a/cli-stressor-cuda-rs/src/cuda_backend/int_alu.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/int_alu.rs
@@ -17,13 +17,12 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use rand::rngs::StdRng;
-use rand::{RngExt, SeedableRng};
-
 use cudarc::driver::{CudaContext, CudaFunction, CudaModule, LaunchConfig, PushKernelArg};
 use cudarc::nvrtc::{CompileOptions, compile_ptx_with_opts};
 
-use cli_stressor_cuda_rs::{BackendError, DeviceInfo, PrecisionKind, PrecisionSpec, StreamMode};
+use cli_stressor_cuda_rs::{
+    BackendError, DeviceInfo, PrecisionKind, PrecisionSpec, StreamMode, fill_random_i32,
+};
 
 use super::backend::CudaBackend;
 use super::kernels::load_kernel;
@@ -109,7 +108,6 @@ impl CudaBackend {
             .ok_or_else(|| BackendError::Other("INT ALU kernel unavailable".to_string()))?;
         let n = (size * size) as u32;
         let lane_count = Self::lane_count(stream_mode);
-        let mut rng = StdRng::seed_from_u64(seed);
         let mode: u32 = match spec.kind {
             PrecisionKind::INT8 => 8,
             PrecisionKind::INT16 => 16,
@@ -124,21 +122,52 @@ impl CudaBackend {
 
         let mut xs = Vec::with_capacity(lane_count);
         let mut outs = Vec::with_capacity(lane_count);
-        for lane in 0..lane_count {
-            let stream = self.stream_for_lane(lane);
-            // Seed with i32 data regardless of mode; the kernel narrows
-            // internally for the 8/16-bit stress variants.
-            let host: Vec<i32> = (0..n).map(|_| rng.random::<u32>() as i32).collect();
-            xs.push(
-                stream
-                    .clone_htod(&host)
-                    .map_err(|err| BackendError::Other(err.to_string()))?,
-            );
-            outs.push(
-                stream
+        if self.gpu_generate_enabled() {
+            let kernels = self
+                .gpu_fill
+                .as_ref()
+                .ok_or_else(|| BackendError::Other("gpu fill kernels unavailable".into()))?;
+            let total = n as u64;
+            for lane in 0..lane_count {
+                let stream = self.stream_for_lane(lane);
+                // i32 data regardless of mode; the kernel narrows internally
+                // for the 8/16-bit stress variants.
+                let x = stream
                     .alloc_zeros::<i32>(n as usize)
-                    .map_err(|err| BackendError::Other(err.to_string()))?,
-            );
+                    .map_err(|err| BackendError::Other(err.to_string()))?;
+                unsafe {
+                    stream
+                        .launch_builder(&kernels.i32_fn)
+                        .arg(&x)
+                        .arg(&total)
+                        .arg(&(seed.wrapping_add(lane as u64)))
+                        .launch(LaunchConfig::for_num_elems(n.max(1)))
+                        .map_err(|err| BackendError::Other(err.to_string()))?;
+                }
+                xs.push(x);
+                outs.push(
+                    stream
+                        .alloc_zeros::<i32>(n as usize)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+            }
+        } else {
+            // One parallel non-crypto fill shared by all lanes.
+            let mut host = vec![0i32; n as usize];
+            fill_random_i32(&mut host, seed);
+            for lane in 0..lane_count {
+                let stream = self.stream_for_lane(lane);
+                xs.push(
+                    stream
+                        .clone_htod(&host)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+                outs.push(
+                    stream
+                        .alloc_zeros::<i32>(n as usize)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+            }
         }
         let cfg = LaunchConfig::for_num_elems(n.max(1));
 

--- a/cli-stressor-cuda-rs/src/cuda_backend/int_alu.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/int_alu.rs
@@ -158,7 +158,9 @@ impl CudaBackend {
             let mut pinned = unsafe { self._ctx.alloc_pinned::<i32>(n as usize) }
                 .map_err(|err| BackendError::Other(err.to_string()))?;
             fill_random_i32(
-                pinned.as_mut_slice().map_err(|err| BackendError::Other(err.to_string()))?,
+                pinned
+                    .as_mut_slice()
+                    .map_err(|err| BackendError::Other(err.to_string()))?,
                 seed,
             );
             for lane in 0..lane_count {

--- a/cli-stressor-cuda-rs/src/cuda_backend/mem_ops.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/mem_ops.rs
@@ -9,8 +9,8 @@ use cudarc::cublas::{Asum, AsumConfig, sys as cublas_sys};
 use cudarc::driver::{DevicePtr, DevicePtrMut, PushKernelArg};
 
 use cli_stressor_cuda_rs::{
-    BackendError, PrecisionKind, PrecisionSpec, StreamMode, make_random_host_matrix,
-    tiled_random_bytes,
+    BackendError, PrecisionKind, PrecisionSpec, RNG_TILE_BYTES, StreamMode, fill_random_bytes,
+    make_random_host_matrix,
 };
 
 use super::backend::CudaBackend;
@@ -70,18 +70,30 @@ impl CudaBackend {
                 );
             }
         } else {
-            // Host path: one random tile repeated at DRAM speed, shared by
-            // all lanes (memcpy does not read the source, per-lane uniqueness
-            // buys nothing and costs wall-clock between bursts).
-            let mut host = vec![0u8; bytes];
-            tiled_random_bytes(&mut host, seed);
+            // Host path, tile + device-side repeat: only RNG_TILE_BYTES cross
+            // PCIe (pageable staging cost scales with bytes); the bulk fill
+            // runs D2D on the copy engine at VRAM bandwidth. The tile is
+            // shared by all lanes — memcpy never inspects the source.
+            let tile_len = RNG_TILE_BYTES.min(bytes);
+            let mut tile = vec![0u8; tile_len];
+            fill_random_bytes(&mut tile, seed);
             for lane in 0..lane_count {
                 let stream = self.stream_for_lane(lane);
-                srcs.push(
+                let tile_dev = stream
+                    .clone_htod(&tile)
+                    .map_err(|err| BackendError::Other(err.to_string()))?;
+                let mut src = stream
+                    .alloc_zeros::<u8>(bytes)
+                    .map_err(|err| BackendError::Other(err.to_string()))?;
+                let mut offset = 0;
+                while offset < bytes {
+                    let len = tile_len.min(bytes - offset);
                     stream
-                        .clone_htod(&host)
-                        .map_err(|err| BackendError::Other(err.to_string()))?,
-                );
+                        .memcpy_dtod(&tile_dev.slice(0..len), &mut src.slice_mut(offset..offset + len))
+                        .map_err(|err| BackendError::Other(err.to_string()))?;
+                    offset += len;
+                }
+                srcs.push(src);
                 dsts.push(
                     stream
                         .alloc_zeros::<u8>(bytes)

--- a/cli-stressor-cuda-rs/src/cuda_backend/mem_ops.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/mem_ops.rs
@@ -89,7 +89,10 @@ impl CudaBackend {
                 while offset < bytes {
                     let len = tile_len.min(bytes - offset);
                     stream
-                        .memcpy_dtod(&tile_dev.slice(0..len), &mut src.slice_mut(offset..offset + len))
+                        .memcpy_dtod(
+                            &tile_dev.slice(0..len),
+                            &mut src.slice_mut(offset..offset + len),
+                        )
                         .map_err(|err| BackendError::Other(err.to_string()))?;
                     offset += len;
                 }

--- a/cli-stressor-cuda-rs/src/cuda_backend/mem_ops.rs
+++ b/cli-stressor-cuda-rs/src/cuda_backend/mem_ops.rs
@@ -6,10 +6,11 @@ use rand::{RngExt, SeedableRng};
 use std::time::Instant;
 
 use cudarc::cublas::{Asum, AsumConfig, sys as cublas_sys};
-use cudarc::driver::{DevicePtr, DevicePtrMut};
+use cudarc::driver::{DevicePtr, DevicePtrMut, PushKernelArg};
 
 use cli_stressor_cuda_rs::{
     BackendError, PrecisionKind, PrecisionSpec, StreamMode, make_random_host_matrix,
+    tiled_random_bytes,
 };
 
 use super::backend::CudaBackend;
@@ -34,23 +35,59 @@ impl CudaBackend {
             PrecisionKind::INT32 => 4usize,
         };
         let bytes = size * size * elem_size;
-        let mut rng = StdRng::seed_from_u64(seed);
         let lane_count = Self::lane_count(stream_mode);
         let mut srcs = Vec::with_capacity(lane_count);
         let mut dsts = Vec::with_capacity(lane_count);
-        for lane in 0..lane_count {
-            let stream = self.stream_for_lane(lane);
-            let host: Vec<u8> = (0..bytes).map(|_| rng.random::<u8>()).collect();
-            srcs.push(
-                stream
-                    .clone_htod(&host)
-                    .map_err(|err| BackendError::Other(err.to_string()))?,
-            );
-            dsts.push(
-                stream
+        if self.gpu_generate_enabled() {
+            // Device-side generation: no host RNG, no H2D copy. Content is
+            // kernel-generated splitmix data; memcpy never inspects it.
+            let kernels = self
+                .gpu_fill
+                .as_ref()
+                .ok_or_else(|| BackendError::Other("gpu fill kernels unavailable".into()))?;
+            let n = bytes as u64;
+            for lane in 0..lane_count {
+                let stream = self.stream_for_lane(lane);
+                let src = stream
                     .alloc_zeros::<u8>(bytes)
-                    .map_err(|err| BackendError::Other(err.to_string()))?,
-            );
+                    .map_err(|err| BackendError::Other(err.to_string()))?;
+                unsafe {
+                    stream
+                        .launch_builder(&kernels.bytes_fn)
+                        .arg(&src)
+                        .arg(&n)
+                        .arg(&(seed.wrapping_add(lane as u64)))
+                        .launch(cudarc::driver::LaunchConfig::for_num_elems(
+                            bytes.min(u32::MAX as usize) as u32,
+                        ))
+                        .map_err(|err| BackendError::Other(err.to_string()))?;
+                }
+                srcs.push(src);
+                dsts.push(
+                    stream
+                        .alloc_zeros::<u8>(bytes)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+            }
+        } else {
+            // Host path: one random tile repeated at DRAM speed, shared by
+            // all lanes (memcpy does not read the source, per-lane uniqueness
+            // buys nothing and costs wall-clock between bursts).
+            let mut host = vec![0u8; bytes];
+            tiled_random_bytes(&mut host, seed);
+            for lane in 0..lane_count {
+                let stream = self.stream_for_lane(lane);
+                srcs.push(
+                    stream
+                        .clone_htod(&host)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+                dsts.push(
+                    stream
+                        .alloc_zeros::<u8>(bytes)
+                        .map_err(|err| BackendError::Other(err.to_string()))?,
+                );
+            }
         }
         for _ in 0..warmup_iters {
             for lane in 0..lane_count {

--- a/cli-stressor-cuda-rs/src/lib.rs
+++ b/cli-stressor-cuda-rs/src/lib.rs
@@ -738,7 +738,10 @@ fn rng_pool() -> &'static rayon::ThreadPool {
             .unwrap_or_else(|_| {
                 // A 1-thread pool cannot fail to build; parallelism is a
                 // perf knob, not a correctness requirement.
-                rayon::ThreadPoolBuilder::new().num_threads(1).build().unwrap()
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(1)
+                    .build()
+                    .unwrap()
             })
     })
 }
@@ -787,19 +790,21 @@ mod rng_perf_tests {
 /// for a given seed (same seed => same bytes regardless of thread count).
 pub fn fill_random_bytes(buf: &mut [u8], seed: u64) {
     rng_pool().install(|| {
-        buf.par_chunks_mut(RNG_CHUNK).enumerate().for_each(|(ci, c)| {
-            let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
-            let mut words = c.chunks_exact_mut(8);
-            for w in &mut words {
-                let x = splitmix64(&mut state).to_le_bytes();
-                w.copy_from_slice(&x);
-            }
-            let rem = words.into_remainder();
-            if !rem.is_empty() {
-                let x = splitmix64(&mut state).to_le_bytes();
-                rem.copy_from_slice(&x[..rem.len()]);
-            }
-        });
+        buf.par_chunks_mut(RNG_CHUNK)
+            .enumerate()
+            .for_each(|(ci, c)| {
+                let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                let mut words = c.chunks_exact_mut(8);
+                for w in &mut words {
+                    let x = splitmix64(&mut state).to_le_bytes();
+                    w.copy_from_slice(&x);
+                }
+                let rem = words.into_remainder();
+                if !rem.is_empty() {
+                    let x = splitmix64(&mut state).to_le_bytes();
+                    rem.copy_from_slice(&x[..rem.len()]);
+                }
+            });
     });
 }
 
@@ -807,25 +812,29 @@ pub fn fill_random_bytes(buf: &mut [u8], seed: u64) {
 /// chunk-deterministic for a given seed.
 pub fn fill_random_f32(buf: &mut [f32], seed: u64) {
     rng_pool().install(|| {
-        buf.par_chunks_mut(RNG_CHUNK).enumerate().for_each(|(ci, c)| {
-            let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
-            for v in c.iter_mut() {
-                let x = splitmix64(&mut state);
-                *v = ((x >> 40) as f32) * (1.0f32 / 16_777_216.0f32);
-            }
-        });
+        buf.par_chunks_mut(RNG_CHUNK)
+            .enumerate()
+            .for_each(|(ci, c)| {
+                let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                for v in c.iter_mut() {
+                    let x = splitmix64(&mut state);
+                    *v = ((x >> 40) as f32) * (1.0f32 / 16_777_216.0f32);
+                }
+            });
     });
 }
 
 /// Parallel-fill an i32 buffer with random bits, chunk-deterministic.
 pub fn fill_random_i32(buf: &mut [i32], seed: u64) {
     rng_pool().install(|| {
-        buf.par_chunks_mut(RNG_CHUNK).enumerate().for_each(|(ci, c)| {
-            let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
-            for v in c.iter_mut() {
-                *v = (splitmix64(&mut state) >> 32) as i32;
-            }
-        });
+        buf.par_chunks_mut(RNG_CHUNK)
+            .enumerate()
+            .for_each(|(ci, c)| {
+                let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                for v in c.iter_mut() {
+                    *v = (splitmix64(&mut state) >> 32) as i32;
+                }
+            });
     });
 }
 

--- a/cli-stressor-cuda-rs/src/lib.rs
+++ b/cli-stressor-cuda-rs/src/lib.rs
@@ -12,6 +12,7 @@ use rand_distr::StandardNormal;
 use rayon::prelude::*;
 use std::mem::MaybeUninit;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
@@ -716,6 +717,116 @@ pub fn per_element_allclose(diff: &[f32], reference: &[f32], atol: f32, rtol: f3
         .all(|(d, r)| *d <= atol + rtol * r.abs())
 }
 
+/// Number of CPU threads used for host-side stress-buffer generation.
+///
+/// Sized to the target machine's CPU count (`available_parallelism`), with a
+/// conservative fallback of 8 when detection fails. Never hardcoded: the
+/// stressor must scale from laptop parts to multi-socket workstations.
+pub fn rng_thread_count() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8)
+}
+
+fn rng_pool() -> &'static rayon::ThreadPool {
+    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(rng_thread_count())
+            .thread_name(|i| format!("stress-rng-{i}"))
+            .build()
+            .unwrap_or_else(|_| {
+                // A 1-thread pool cannot fail to build; parallelism is a
+                // perf knob, not a correctness requirement.
+                rayon::ThreadPoolBuilder::new().num_threads(1).build().unwrap()
+            })
+    })
+}
+
+/// SplitMix64: fast non-crypto PRNG for stress input data. Stress buffers
+/// never feed validation (which uses its own small `StdRng` matrices), so
+/// crypto quality is unnecessary; throughput is (this runs between bursts
+/// and steals wall-clock from actual stress time).
+#[inline(always)]
+pub fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+const RNG_CHUNK: usize = 1 << 16;
+
+/// Parallel-fill a byte buffer with splitmix64 output, chunk-deterministic
+/// for a given seed (same seed => same bytes regardless of thread count).
+pub fn fill_random_bytes(buf: &mut [u8], seed: u64) {
+    rng_pool().install(|| {
+        buf.par_chunks_mut(RNG_CHUNK).enumerate().for_each(|(ci, c)| {
+            let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+            let mut words = c.chunks_exact_mut(8);
+            for w in &mut words {
+                let x = splitmix64(&mut state).to_le_bytes();
+                w.copy_from_slice(&x);
+            }
+            let rem = words.into_remainder();
+            if !rem.is_empty() {
+                let x = splitmix64(&mut state).to_le_bytes();
+                rem.copy_from_slice(&x[..rem.len()]);
+            }
+        });
+    });
+}
+
+/// Parallel-fill an f32 buffer with uniform [0,1) values (24-bit mantissa),
+/// chunk-deterministic for a given seed.
+pub fn fill_random_f32(buf: &mut [f32], seed: u64) {
+    rng_pool().install(|| {
+        buf.par_chunks_mut(RNG_CHUNK).enumerate().for_each(|(ci, c)| {
+            let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+            for v in c.iter_mut() {
+                let x = splitmix64(&mut state);
+                *v = ((x >> 40) as f32) * (1.0f32 / 16_777_216.0f32);
+            }
+        });
+    });
+}
+
+/// Parallel-fill an i32 buffer with random bits, chunk-deterministic.
+pub fn fill_random_i32(buf: &mut [i32], seed: u64) {
+    rng_pool().install(|| {
+        buf.par_chunks_mut(RNG_CHUNK).enumerate().for_each(|(ci, c)| {
+            let mut state = seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+            for v in c.iter_mut() {
+                *v = (splitmix64(&mut state) >> 32) as i32;
+            }
+        });
+    });
+}
+
+/// Size of the random tile generated per buffer before tiling-repeat.
+const RNG_TILE_BYTES: usize = 4 << 20;
+
+/// Cheapest full-random fill for paths that do not care about content
+/// uniqueness (memcpy never reads its source): generate one random tile,
+/// then repeat it via `copy_within` at DRAM speed. Result is fully
+/// deterministic for a given seed.
+pub fn tiled_random_bytes(buf: &mut [u8], seed: u64) {
+    if buf.len() <= RNG_TILE_BYTES {
+        fill_random_bytes(buf, seed);
+        return;
+    }
+    let tile_len = RNG_TILE_BYTES;
+    let (tile, _rest) = buf.split_at_mut(tile_len);
+    fill_random_bytes(tile, seed);
+    let mut filled = tile_len;
+    while filled < buf.len() {
+        let copy_len = filled.min(buf.len() - filled);
+        buf.copy_within(0..copy_len, filled);
+        filled += copy_len;
+    }
+}
+
 pub fn make_random_host_matrix(size: usize, seed: u64) -> HostMatrix {
     let n = size * size;
     let mut data = Vec::<MaybeUninit<f32>>::with_capacity(n);
@@ -731,16 +842,18 @@ pub fn make_random_host_matrix(size: usize, seed: u64) -> HostMatrix {
     // validation path, which compares GPU vs CPU over the same matrix, are
     // unaffected) while saturating all CPU cores.
     const CHUNK: usize = 1 << 16;
-    data.par_chunks_mut(CHUNK)
-        .enumerate()
-        .for_each(|(ci, slice)| {
-            let mut rng = StdRng::seed_from_u64(
-                seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)),
-            );
-            for v in slice.iter_mut() {
-                v.write(rng.sample(StandardNormal));
-            }
-        });
+    rng_pool().install(|| {
+        data.par_chunks_mut(CHUNK)
+            .enumerate()
+            .for_each(|(ci, slice)| {
+                let mut rng = StdRng::seed_from_u64(
+                    seed.wrapping_add((ci as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)),
+                );
+                for v in slice.iter_mut() {
+                    v.write(rng.sample(StandardNormal));
+                }
+            });
+    });
     let len = data.len();
     let capacity = data.capacity();
     let ptr = data.as_mut_ptr().cast::<f32>();

--- a/cli-stressor-cuda-rs/src/lib.rs
+++ b/cli-stressor-cuda-rs/src/lib.rs
@@ -830,7 +830,7 @@ pub fn fill_random_i32(buf: &mut [i32], seed: u64) {
 }
 
 /// Size of the random tile generated per buffer before tiling-repeat.
-const RNG_TILE_BYTES: usize = 4 << 20;
+pub const RNG_TILE_BYTES: usize = 4 << 20;
 
 /// Cheapest full-random fill for paths that do not care about content
 /// uniqueness (memcpy never reads its source): generate one random tile,

--- a/cli-stressor-cuda-rs/src/lib.rs
+++ b/cli-stressor-cuda-rs/src/lib.rs
@@ -758,6 +758,31 @@ pub fn splitmix64(state: &mut u64) -> u64 {
 
 const RNG_CHUNK: usize = 1 << 16;
 
+#[cfg(test)]
+mod rng_perf_tests {
+    use super::*;
+
+    /// Not a pass/fail test: run manually with
+    /// `cargo test --release -- --ignored tiled_fill_throughput --nocapture`
+    /// to check host generation throughput on the target machine.
+    #[test]
+    #[ignore]
+    fn tiled_fill_throughput() {
+        let gib = 2usize << 30;
+        let mut buf = vec![0u8; gib];
+        let t = std::time::Instant::now();
+        tiled_random_bytes(&mut buf, 42);
+        let elapsed = t.elapsed().as_secs_f64();
+        println!(
+            "tiled fill: {:.2} GiB in {:.3} s = {:.2} GB/s (threads={})",
+            gib as f64 / (1 << 30) as f64,
+            elapsed,
+            gib as f64 / elapsed / 1e9,
+            rng_thread_count()
+        );
+    }
+}
+
 /// Parallel-fill a byte buffer with splitmix64 output, chunk-deterministic
 /// for a given seed (same seed => same bytes regardless of thread count).
 pub fn fill_random_bytes(buf: &mut [u8], seed: u64) {
@@ -809,22 +834,22 @@ const RNG_TILE_BYTES: usize = 4 << 20;
 
 /// Cheapest full-random fill for paths that do not care about content
 /// uniqueness (memcpy never reads its source): generate one random tile,
-/// then repeat it via `copy_within` at DRAM speed. Result is fully
-/// deterministic for a given seed.
+/// then repeat it in parallel at tile granularity. The repeat must be
+/// parallel, not a single `copy_within` walk: the backing allocation is
+/// lazily committed, so first-touch page faults on a fresh multi-GiB
+/// buffer are kernel-serialized per thread (~1 GB/s single-core).
 pub fn tiled_random_bytes(buf: &mut [u8], seed: u64) {
     if buf.len() <= RNG_TILE_BYTES {
         fill_random_bytes(buf, seed);
         return;
     }
-    let tile_len = RNG_TILE_BYTES;
-    let (tile, _rest) = buf.split_at_mut(tile_len);
+    let (tile, rest) = buf.split_at_mut(RNG_TILE_BYTES);
     fill_random_bytes(tile, seed);
-    let mut filled = tile_len;
-    while filled < buf.len() {
-        let copy_len = filled.min(buf.len() - filled);
-        buf.copy_within(0..copy_len, filled);
-        filled += copy_len;
-    }
+    rng_pool().install(|| {
+        rest.par_chunks_mut(RNG_TILE_BYTES).for_each(|chunk| {
+            chunk.copy_from_slice(&tile[..chunk.len()]);
+        });
+    });
 }
 
 pub fn make_random_host_matrix(size: usize, seed: u64) -> HostMatrix {

--- a/cli-stressor-cuda-rs/src/main.rs
+++ b/cli-stressor-cuda-rs/src/main.rs
@@ -119,7 +119,7 @@ struct Args {
 
     #[arg(
         long,
-        value_parser = ["standard", "low-vram", "40-50", "minload", "dynamic-export"],
+        value_parser = ["standard", "low-vram", "40-50", "dynamic-export"],
         conflicts_with = "config",
         help = "Use an embedded NVOC stress profile"
     )]
@@ -388,7 +388,6 @@ fn load_builtin_profile(name: &str) -> Result<FileConfig, String> {
         "standard" => include_str!("../profiles/standard.toml"),
         "low-vram" => include_str!("../profiles/low-vram.toml"),
         "40-50" => include_str!("../profiles/40-50.toml"),
-        "minload" => include_str!("../profiles/minload.toml"),
         "dynamic-export" => include_str!("../profiles/dynamic-export.toml"),
         other => return Err(format!("unknown embedded profile: {other}")),
     };

--- a/cli-stressor-cuda-rs/src/main.rs
+++ b/cli-stressor-cuda-rs/src/main.rs
@@ -204,6 +204,12 @@ struct Args {
     #[arg(long, default_value_t = false)]
     vulkan_only: bool,
 
+    /// Generate stress buffers on the GPU (NVRTC fill kernels) instead of
+    /// host-side parallel RNG + H2D copy; cuts the non-compute gap between
+    /// bursts (default off)
+    #[arg(long, default_value_t = false)]
+    gpu_generate: bool,
+
     /// Vulkan image width for 3D render stress
     #[arg(long, default_value_t = 8192)]
     vulkan_image_width: u32,
@@ -279,6 +285,9 @@ struct FileConfig {
     #[serde(alias = "vulkan-only")]
     vulkan_only: Option<bool>,
     kernel_params: Option<HashMap<String, FileKernelParam>>,
+    /// Generate stress buffers on the GPU via NVRTC fill kernels (default
+    /// off; host generation remains the conservative path).
+    gpu_generate: Option<bool>,
     gpu_index: Option<u32>,
     pci_bus: Option<String>,
     gpu_uuid: Option<String>,
@@ -512,6 +521,7 @@ fn parse_args_with_cli_sources() -> (Args, std::collections::HashSet<&'static st
         "kernel_types",
         "kernel_mixture",
         "kernel_params",
+        "gpu_generate",
         "enable_vulkan_stress",
         "vulkan_only",
         "stream_mode",
@@ -611,6 +621,9 @@ fn apply_file_config_to_args(
     }
     if let (true, Some(v)) = (!cli_set.contains("stream_mode"), &parsed.stream_mode) {
         args.stream_mode = v.clone();
+    }
+    if let (true, Some(v)) = (!cli_set.contains("gpu_generate"), parsed.gpu_generate) {
+        args.gpu_generate = v;
     }
     if let (true, Some(v)) = (!cli_set.contains("disable_fp8"), parsed.disable_fp8) {
         args.disable_fp8 = v;
@@ -1098,6 +1111,20 @@ pub fn run_from_args() {
             std::process::exit(1);
         }
     };
+    if args.gpu_generate {
+        if let Err(err) = backend.enable_gpu_generate() {
+            eprintln!(
+                "{}",
+                stylize(
+                    &format!(
+                        "GPU buffer generation unavailable ({}); falling back to host generation",
+                        err
+                    ),
+                    true
+                )
+            );
+        }
+    }
 
     #[cfg(feature = "vulkan")]
     let cuda_device_identity = match backend.device_identity() {
@@ -1428,6 +1455,12 @@ pub fn run_from_args() {
         "{}",
         stylize_config(&format!("  Validation size: {}", args.validate_size))
     );
+    if args.gpu_generate {
+        println!(
+            "{}",
+            stylize_config("  Buffer generation: GPU (NVRTC fill kernels)")
+        );
+    }
 
     let minor_mixture_display = if kernel_param_overrides
         .iter()

--- a/cli-stressor-cuda-rs/src/main.rs
+++ b/cli-stressor-cuda-rs/src/main.rs
@@ -1111,19 +1111,19 @@ pub fn run_from_args() {
             std::process::exit(1);
         }
     };
-    if args.gpu_generate {
-        if let Err(err) = backend.enable_gpu_generate() {
-            eprintln!(
-                "{}",
-                stylize(
-                    &format!(
-                        "GPU buffer generation unavailable ({}); falling back to host generation",
-                        err
-                    ),
-                    true
-                )
-            );
-        }
+    if args.gpu_generate
+        && let Err(err) = backend.enable_gpu_generate()
+    {
+        eprintln!(
+            "{}",
+            stylize(
+                &format!(
+                    "GPU buffer generation unavailable ({}); falling back to host generation",
+                    err
+                ),
+                true
+            )
+        );
     }
 
     #[cfg(feature = "vulkan")]


### PR DESCRIPTION
Restores physicsdolphin-authored auto-optimizer GC6 wake/profile behavior, Windows PnP script staging, and CUDA stressor GPU-generation/parallel fill paths removed by the umbrella cleanup. The branch also keeps the current native Windows event backend and only restores the still-used PnP helper.

The CLI terminology follow-up is limited to optimizer call sites; public CLI/core naming is in #313.

Validation on a stack with #313:
- cargo fmt --all -- --check
- cargo build --workspace --exclude cli-stressor-cuda-rs
- cargo test --package nvoc-auto-optimizer --all-targets --all-features (61 passed)
- cargo test --package cli-stressor-cuda-rs --all-targets --no-default-features (18 passed, 1 ignored)
- cargo clippy --workspace --exclude cli-stressor-cuda-rs --all-targets -- -D warnings

Related: #267; depends on #313.